### PR TITLE
[WIP] Add map interactivity for wizards at location

### DIFF
--- a/components/Map.tsx
+++ b/components/Map.tsx
@@ -7,7 +7,8 @@ import {
   TileLayer,
   ImageOverlay,
   Marker,
-  Popup
+  Popup,
+  useMapEvents
 } from "react-leaflet";
 
 import "leaflet/dist/leaflet.css";
@@ -31,6 +32,201 @@ const MapStyles = styled.div`
   }
 `;
 
+const locationJson = require('../data/locationMapping.json');
+const ipfs_base_url = 'https://ipfs.io/ipfs/QmbtiPZfgUzHd79T1aPcL9yZnhGFmzwar7h4vmfV6rV8Kq/';
+
+interface mapLocation {
+    location: string,
+    lat: number,
+    lon: number,
+    wizards: any
+};
+
+const list : mapLocation[] = [
+    {
+        location: "Wood",
+        lat: 1.5616648585079145, 
+        lon: 0.42945312500000006,
+        wizards: []
+    },
+    {
+        location: "Wild",
+        lat: 3.5494014838450294, 
+        lon: 1.8017578125000002,
+        wizards: []
+    },
+    {
+        location: "Quantum Shadow",
+        lat: -1.4375416705457718, 
+        lon: 7.032265625000001,
+        wizards: []
+    },
+    {
+        location: "Sands",
+        lat: -7.287296870330252, 
+        lon: 5.443296432495117,
+        wizards: []
+    },
+    {
+        location: "Oasis",
+        lat: -7.047486501133198, 
+        lon: 8.695249557495119,
+        wizards: []
+    },
+    {
+        location: "Valley",
+        lat: -2.620516682046257, 
+        lon: 8.814897537231447,
+        wizards: []
+    },
+    {
+        location: "Platonic Shadow",
+        lat: -4.09552408566189, 
+        lon: 8.409605026245119,
+        wizards: []
+    },
+    {
+        location: "Marsh",
+        lat: 1.1344967836973138, 
+        lon: 3.9809131622314458,
+        wizards: []
+    },
+    {
+        location: "Obelisk",
+        lat: -4.659742538615002, 
+        lon: 6.419878005981446,
+        wizards: []
+    },
+    {
+        location: "Citadel",
+        lat: -2.049704377901014, 
+        lon: -6.456098556518556,
+        wizards: []
+    },
+    {
+        location: "Mist",
+        lat: 1.481873260162654, 
+        lon: 8.519468307495119,
+        wizards: []
+    },
+    {
+        location: "Salt",
+        lat: 2.689546311929564, 
+        lon: -7.366762161254884,
+        wizards: []
+    },
+    {
+        location: "Surf",
+        lat: -6.371002854929476, 
+        lon: -2.818422317504883,
+        wizards: []
+    },
+    {
+        location: "Brine",
+        lat: -4.358478500880833, 
+        lon: -8.685121536254885,
+        wizards: []
+    },
+    {
+        location: "Riviera",
+        lat: -4.599439409670915, 
+        lon: 0.01605033874511719,
+        wizards: []
+    },
+    {
+        location: "Fey",
+        lat: 4.032768401966701, 
+        lon: 4.539413452148438,
+        wizards: []
+    },
+    {
+        location: "Veil",
+        lat: 6.417660165363671, 
+        lon: 3.528671264648438,
+        wizards: []
+    },
+    {
+        location: "Toadstools",
+        lat: 3.967011000868007, 
+        lon: 6.802597045898438,
+        wizards: []
+    },
+    {
+        location: "Wold",
+        lat: 3.6162185687724855, 
+        lon: -1.3492584228515625,
+        wizards: []
+    },
+    {
+        location: "Thorn",
+        lat: 0.8060952321492764, 
+        lon: 6.516952514648438,
+        wizards: []
+    },
+    {
+        location: "Cuckoo Land",
+        lat: 7.36323297225163, 
+        lon: 6.630506515502931,
+        wizards: []
+    },
+    {
+        location: "Psychic Leap",
+        lat: 6.556242027192075, 
+        lon: 7.597303390502931,
+        wizards: []
+    },
+    {
+        location: "Carnival",
+        lat: 2.3731405225423527, 
+        lon: 3.2247447967529297,
+        wizards: []
+    },
+    {
+        location: "Sacred Pillars",
+        lat: 7.101659219298023, 
+        lon: -2.0926380157470708,
+        wizards: []
+    },
+    {
+        location: "Lake",
+        lat: 5.047940217465466, 
+        lon: -0.6204700469970704,
+        wizards: []
+    },
+    {
+        location: "Bastion",
+        lat: 5.551149422965898, 
+        lon: 2.32386589050293,
+        wizards: []
+    },
+    {
+        location: "Realm",
+        lat: 6.905380920555986, 
+        lon: -0.07115364074707033,
+        wizards: []
+    },
+    {
+        location: "Keep",
+        lat: -2.1520416519568775, 
+        lon: -3.5208606719970708,
+        wizards: []
+    },
+    {
+        location: "Capital",
+        lat: 0.48416515144996225, 
+        lon: -6.97056770324707,
+        wizards: []
+    },
+    {
+        location: "Isle",
+        lat: -5.439484310404568, 
+        lon: -4.580698013305665,
+        wizards: []
+    },
+];
+
+list.forEach(element => element.wizards = locationJson[element.location]);
+
 const Map = () => (
   <MapStyles>
     <MapContainer
@@ -41,6 +237,16 @@ const Map = () => (
       attributionControl={false}
     >
       <ImageOverlay bounds={bounds} url="/static/img/map/map.png" />
+
+    {list.map((item, index) => 
+    <Marker key={index} position={[item.lat, item.lon]} title={`${item.location}`} >
+      <Popup maxHeight={200} maxWidth={200}>
+        {item.wizards.map((wizard: any, index: any) =>
+            <img src={ipfs_base_url + wizard.id + '.png'} height={100} width={100} />
+        )}
+      </Popup>
+    </Marker>
+    )}
     </MapContainer>
   </MapStyles>
 );

--- a/data/locationMapping.json
+++ b/data/locationMapping.json
@@ -1,0 +1,30126 @@
+{
+    "": [{
+        "id": "7",
+        "name": "Rogue Mage Andy"
+    }, {
+        "id": "8",
+        "name": "Bunny Wizard Bernardo"
+    }, {
+        "id": "9",
+        "name": "Prismatic Magi Braindraind"
+    }, {
+        "id": "10",
+        "name": "Edge Arcanist Artchick"
+    }, {
+        "id": "11",
+        "name": "Crow Master Claire Sliver"
+    }, {
+        "id": "12",
+        "name": "The Wizard Empress"
+    }, {
+        "id": "13",
+        "name": "3D Wizz DeeZe"
+    }, {
+        "id": "14",
+        "name": "Cat Wizard El Crypto Ball"
+    }, {
+        "id": "15",
+        "name": "Arcanist EyesTeethFlesh"
+    }, {
+        "id": "17",
+        "name": "Master Ape Gfunk"
+    }, {
+        "id": "18",
+        "name": "Cartomancer Fiskantes"
+    }, {
+        "id": "20",
+        "name": "Punk Rock Arcanist Joey"
+    }, {
+        "id": "21",
+        "name": "Loop Master Loopify"
+    }, {
+        "id": "22",
+        "name": "Necromancer ManuelDaMoon"
+    }, {
+        "id": "25",
+        "name": "Necromancer Nikita"
+    }, {
+        "id": "26",
+        "name": "Fortune Master Oxelrod"
+    }, {
+        "id": "27",
+        "name": "Great Old One 0xmon"
+    }, {
+        "id": "28",
+        "name": "The Great and Magical UserGnome"
+    }, {
+        "id": "29",
+        "name": "Necromancer LeggoMyGreggo"
+    }, {
+        "id": "30",
+        "name": "Great Old One Andolini"
+    }, {
+        "id": "72",
+        "name": "Supa Wizz 9272"
+    }, {
+        "id": "76",
+        "name": "Wise Sam"
+    }, {
+        "id": "77",
+        "name": "Bob the Bearded"
+    }, {
+        "id": "79",
+        "name": "Catherine The Great"
+    }, {
+        "id": "101",
+        "name": "Archmagus Milton"
+    }, {
+        "id": "118",
+        "name": "Bard Eliphas"
+    }, {
+        "id": "180",
+        "name": "Geomancer Hagar"
+    }, {
+        "id": "244",
+        "name": "Ice Mage Robert"
+    }, {
+        "id": "260",
+        "name": "Ghost Eater Eden"
+    }, {
+        "id": "297",
+        "name": "Arcanist Scorch"
+    }, {
+        "id": "305",
+        "name": "The Red Witch"
+    }, {
+        "id": "324",
+        "name": "Arcanist Gunthor"
+    }, {
+        "id": "365",
+        "name": "Cronus"
+    }, {
+        "id": "385",
+        "name": "Archmagus Ofaris"
+    }, {
+        "id": "540",
+        "name": "Merlin"
+    }, {
+        "id": "595",
+        "name": "Ice Mage Ofaris"
+    }, {
+        "id": "603",
+        "name": "Alchemist Patch"
+    }, {
+        "id": "666",
+        "name": "Old Scratch"
+    }, {
+        "id": "722",
+        "name": "Cosmic Mage Willow"
+    }, {
+        "id": "728",
+        "name": "Battle Mage Baird"
+    }, {
+        "id": "777",
+        "name": "Sacred Key Master"
+    }, {
+        "id": "840",
+        "name": "Pyromancer Lamia"
+    }, {
+        "id": "851",
+        "name": "Geomancer Behemoth"
+    }, {
+        "id": "909",
+        "name": "Arch-Magician Ofaris"
+    }, {
+        "id": "962",
+        "name": "Adept Cromwell"
+    }, {
+        "id": "984",
+        "name": "Ice Mage Drusilla"
+    }, {
+        "id": "1000",
+        "name": "Sharkey"
+    }, {
+        "id": "1016",
+        "name": "Aeromancer Allistair"
+    }, {
+        "id": "1121",
+        "name": "Oracle Corvin"
+    }, {
+        "id": "1164",
+        "name": "Adept Artis"
+    }, {
+        "id": "1234",
+        "name": "The Color Master"
+    }, {
+        "id": "1392",
+        "name": "Archmagus Nikolas"
+    }, {
+        "id": "1444",
+        "name": "Solomon"
+    }, {
+        "id": "1454",
+        "name": "Sage Digby"
+    }, {
+        "id": "1512",
+        "name": "Alchemist Charlord"
+    }, {
+        "id": "1552",
+        "name": "Sorcerer Alatar"
+    }, {
+        "id": "1587",
+        "name": "Mephistopheles"
+    }, {
+        "id": "1697",
+        "name": "Illusionist Peppy"
+    }, {
+        "id": "1829",
+        "name": "Conjurer Flynn"
+    }, {
+        "id": "1846",
+        "name": "Thaumaturge Milo"
+    }, {
+        "id": "1875",
+        "name": "Aleister Crowley"
+    }, {
+        "id": "1883",
+        "name": "Archmagus Cairon"
+    }, {
+        "id": "1940",
+        "name": "Enchanter Circe"
+    }, {
+        "id": "1964",
+        "name": "Pyromancer Duzzle"
+    }, {
+        "id": "1986",
+        "name": "The Goblin King"
+    }, {
+        "id": "2000",
+        "name": "The Grey Pilgrim"
+    }, {
+        "id": "2008",
+        "name": "Sorcerer Apollo"
+    }, {
+        "id": "2038",
+        "name": "Alchemist Hongo"
+    }, {
+        "id": "2047",
+        "name": "Ghost Eater Edge"
+    }, {
+        "id": "2051",
+        "name": "Sage Carly"
+    }, {
+        "id": "2056",
+        "name": "Ghost Eater Black Goat"
+    }, {
+        "id": "2074",
+        "name": "Archmagus Udor"
+    }, {
+        "id": "2083",
+        "name": "Sorcerer Aleister"
+    }, {
+        "id": "2137",
+        "name": "Augurer Ravana"
+    }, {
+        "id": "2146",
+        "name": "Fortune Teller Purple Boy"
+    }, {
+        "id": "2183",
+        "name": "Summoner Alvaro"
+    }, {
+        "id": "2188",
+        "name": "Sorcerer Kazud"
+    }, {
+        "id": "2203",
+        "name": "Enchanter Aleister"
+    }, {
+        "id": "2213",
+        "name": "Battlemage Lux"
+    }, {
+        "id": "2240",
+        "name": "Hedge Wizard Rumpleskin"
+    }, {
+        "id": "2295",
+        "name": "Alchemist Zelda"
+    }, {
+        "id": "2414",
+        "name": "Artificer Lumos"
+    }, {
+        "id": "2463",
+        "name": "Sage Jahid"
+    }, {
+        "id": "2469",
+        "name": "Ghost Eater Ixar"
+    }, {
+        "id": "2512",
+        "name": "Enchanter Corky"
+    }, {
+        "id": "2572",
+        "name": "Artificer Quddus"
+    }, {
+        "id": "2602",
+        "name": "Ice Mage Talon"
+    }, {
+        "id": "2624",
+        "name": "Summoner Oxnard"
+    }, {
+        "id": "2661",
+        "name": "Udor"
+    }, {
+        "id": "2678",
+        "name": "Battle Mage Homer"
+    }, {
+        "id": "2689",
+        "name": "Archmagus Solomon"
+    }, {
+        "id": "2743",
+        "name": "Magus Jameel"
+    }, {
+        "id": "2760",
+        "name": "Illusionist Uvlius"
+    }, {
+        "id": "2793",
+        "name": "Katherine"
+    }, {
+        "id": "2804",
+        "name": "Alchemist Baird"
+    }, {
+        "id": "2877",
+        "name": "Shaman Milo"
+    }, {
+        "id": "2892",
+        "name": "Sorcerer Udor"
+    }, {
+        "id": "2893",
+        "name": "Hedge Wizard Florah"
+    }, {
+        "id": "2978",
+        "name": "Archmagus Jerret"
+    }, {
+        "id": "3000",
+        "name": "The Bird Tamer"
+    }, {
+        "id": "3069",
+        "name": "Archmagus"
+    }, {
+        "id": "3090",
+        "name": "Azahl"
+    }, {
+        "id": "3156",
+        "name": "Sage Milo"
+    }, {
+        "id": "3175",
+        "name": "Zaros"
+    }, {
+        "id": "3257",
+        "name": "Electromancer Allistair"
+    }, {
+        "id": "3385",
+        "name": "Arcanist Bullock"
+    }, {
+        "id": "3386",
+        "name": "Hedge Wizard Elizabeth"
+    }, {
+        "id": "3408",
+        "name": "Alchemist Star Father"
+    }, {
+        "id": "3465",
+        "name": "Arch-Magician Jerret"
+    }, {
+        "id": "3549",
+        "name": "Shadow Mage Izible"
+    }, {
+        "id": "3655",
+        "name": "Pyromancer Soya"
+    }, {
+        "id": "3663",
+        "name": "Uvlius"
+    }, {
+        "id": "3707",
+        "name": "Sorcerer Eden"
+    }, {
+        "id": "3746",
+        "name": "Adept Ursula"
+    }, {
+        "id": "3835",
+        "name": "Ghost Eater Azahl"
+    }, {
+        "id": "3901",
+        "name": "Archmagus Oberon"
+    }, {
+        "id": "3955",
+        "name": "Alchemist Nadeem"
+    }, {
+        "id": "4000",
+        "name": "The Darkness Slayer"
+    }, {
+        "id": "4027",
+        "name": "Enchanter Aslan"
+    }, {
+        "id": "4130",
+        "name": "Clairvoyant Angus"
+    }, {
+        "id": "4180",
+        "name": "Pyromancer Peppy"
+    }, {
+        "id": "4184",
+        "name": "Sage Eden"
+    }, {
+        "id": "4229",
+        "name": "Illusionist Poppy"
+    }, {
+        "id": "4233",
+        "name": "Sage Kang"
+    }, {
+        "id": "4236",
+        "name": "Arch-Magician Baird"
+    }, {
+        "id": "4282",
+        "name": "Witch Velorina"
+    }, {
+        "id": "4305",
+        "name": "Witch Lenora"
+    }, {
+        "id": "4322",
+        "name": "Zelroth"
+    }, {
+        "id": "4392",
+        "name": "Druid Rainman"
+    }, {
+        "id": "4553",
+        "name": "Pyromancer Eden"
+    }, {
+        "id": "4572",
+        "name": "Fortune Teller Louis"
+    }, {
+        "id": "4605",
+        "name": "Summoner Giacomo"
+    }, {
+        "id": "4623",
+        "name": "Null Mage Eden"
+    }, {
+        "id": "4669",
+        "name": "Adept JackDaw"
+    }, {
+        "id": "4710",
+        "name": "Pyromancer Charlord"
+    }, {
+        "id": "4921",
+        "name": "Geomancer Hothor"
+    }, {
+        "id": "4964",
+        "name": "Voodoo Priest Victor"
+    }, {
+        "id": "5000",
+        "name": "The East Helper"
+    }, {
+        "id": "5017",
+        "name": "Alchemist Woomba"
+    }, {
+        "id": "5025",
+        "name": "Shaman Fugh"
+    }, {
+        "id": "5048",
+        "name": "Thaumaturge Crowley"
+    }, {
+        "id": "5089",
+        "name": "Battle Mage Durm"
+    }, {
+        "id": "5116",
+        "name": "Hedge Wizard Keziah"
+    }, {
+        "id": "5133",
+        "name": "Artificer Benito"
+    }, {
+        "id": "5142",
+        "name": "Ice Mage Twinkletoes"
+    }, {
+        "id": "5182",
+        "name": "Hex Mage Milo"
+    }, {
+        "id": "5247",
+        "name": "Hedge Wizard Cromwell"
+    }, {
+        "id": "5250",
+        "name": "Archmagus George"
+    }, {
+        "id": "5292",
+        "name": "Magus Basil"
+    }, {
+        "id": "5325",
+        "name": "Archmagus Milton"
+    }, {
+        "id": "5391",
+        "name": "Battle Mage Goliath"
+    }, {
+        "id": "5444",
+        "name": "Arcanist Axel"
+    }, {
+        "id": "5465",
+        "name": "Archmagus Apollo"
+    }, {
+        "id": "5498",
+        "name": "Druid Soya"
+    }, {
+        "id": "5502",
+        "name": "Adept Shigenjo"
+    }, {
+        "id": "5538",
+        "name": "Adept Aldus"
+    }, {
+        "id": "5555",
+        "name": "Arcanist Shoi-Ming"
+    }, {
+        "id": "5592",
+        "name": "Pyromancer Isaac"
+    }, {
+        "id": "5603",
+        "name": "Augurer Gwendolin"
+    }, {
+        "id": "5622",
+        "name": "Archmagus David"
+    }, {
+        "id": "5684",
+        "name": "Magus Eric"
+    }, {
+        "id": "5722",
+        "name": "Necromancer Voidoth"
+    }, {
+        "id": "5773",
+        "name": "Void Disciple Abaddon"
+    }, {
+        "id": "5919",
+        "name": "Fortune Teller Argus"
+    }, {
+        "id": "5969",
+        "name": "Artificer Velorina"
+    }, {
+        "id": "6018",
+        "name": "Archmagus Uvlius"
+    }, {
+        "id": "6035",
+        "name": "Wild Mage Yookoo"
+    }, {
+        "id": "6047",
+        "name": "Ghost Eater Voidoth"
+    }, {
+        "id": "6129",
+        "name": "Zubin"
+    }, {
+        "id": "6191",
+        "name": "Arcanist Magnus"
+    }, {
+        "id": "6193",
+        "name": "Sorcerer Jasper"
+    }, {
+        "id": "6206",
+        "name": "Hedge Wizard Azazel"
+    }, {
+        "id": "6315",
+        "name": "Druid Victoria"
+    }, {
+        "id": "6351",
+        "name": "Jeldor"
+    }, {
+        "id": "6397",
+        "name": "Archmagus Baird"
+    }, {
+        "id": "6443",
+        "name": "Cleric Jastor"
+    }, {
+        "id": "6469",
+        "name": "Pyromancer Koop"
+    }, {
+        "id": "6588",
+        "name": "Necromancer Orange Menace"
+    }, {
+        "id": "6607",
+        "name": "Battlemage Juniper"
+    }, {
+        "id": "6743",
+        "name": "Arch-Magician Artis"
+    }, {
+        "id": "6751",
+        "name": "Illusionist Samuel"
+    }, {
+        "id": "6828",
+        "name": "Adept Apollo"
+    }, {
+        "id": "6888",
+        "name": "Arch-Magician Aldus"
+    }, {
+        "id": "6935",
+        "name": "Alchemist Robert"
+    }, {
+        "id": "7028",
+        "name": "Necromancer Anton"
+    }, {
+        "id": "7044",
+        "name": "Adept Eronin"
+    }, {
+        "id": "7049",
+        "name": "Scryer Ixar"
+    }, {
+        "id": "7205",
+        "name": "Battle Mage Godfrey"
+    }, {
+        "id": "7264",
+        "name": "Arch-Magician Baird"
+    }, {
+        "id": "7317",
+        "name": "Druid Adium"
+    }, {
+        "id": "7322",
+        "name": "Nikolas"
+    }, {
+        "id": "7341",
+        "name": "Mystic Shivra"
+    }, {
+        "id": "7484",
+        "name": "Void Disciple Norix"
+    }, {
+        "id": "7593",
+        "name": "Aeromancer Asmodeus"
+    }, {
+        "id": "7676",
+        "name": "Witch Ursula"
+    }, {
+        "id": "7681",
+        "name": "Evoker Duzzle"
+    }, {
+        "id": "7713",
+        "name": "Ghost Eater Karasu"
+    }, {
+        "id": "7724",
+        "name": "Runecaster Aldus"
+    }, {
+        "id": "7726",
+        "name": "Pyromancer Zaros"
+    }, {
+        "id": "7899",
+        "name": "Cosmic Mage Calista"
+    }, {
+        "id": "7916",
+        "name": "Arch-Magician Amir"
+    }, {
+        "id": "7928",
+        "name": "Magus Dutorn"
+    }, {
+        "id": "7940",
+        "name": "Charmer Circe"
+    }, {
+        "id": "7945",
+        "name": "Magus Zorko"
+    }, {
+        "id": "7950",
+        "name": "Adept Robert"
+    }, {
+        "id": "7967",
+        "name": "Mystic Angus"
+    }, {
+        "id": "8034",
+        "name": "Hedge Wizard Ramiz"
+    }, {
+        "id": "8233",
+        "name": "Sorcerer Isaac"
+    }, {
+        "id": "8261",
+        "name": "Cosmic Mage Brutus"
+    }, {
+        "id": "8374",
+        "name": "Necromancer Tundror"
+    }, {
+        "id": "8395",
+        "name": "Arcanist Eden"
+    }, {
+        "id": "8447",
+        "name": "Artificer Alice"
+    }, {
+        "id": "8481",
+        "name": "Conjurer Milo"
+    }, {
+        "id": "8492",
+        "name": "Sorcerer Ozohr"
+    }, {
+        "id": "8500",
+        "name": "Alchemist Lumos"
+    }, {
+        "id": "8558",
+        "name": "Necromancer Nick"
+    }, {
+        "id": "8566",
+        "name": "Charmer Beyna"
+    }, {
+        "id": "8569",
+        "name": "Archmagus Basil"
+    }, {
+        "id": "8636",
+        "name": "Ice Mage Maia"
+    }, {
+        "id": "8650",
+        "name": "Druid Allistair"
+    }, {
+        "id": "8737",
+        "name": "Void Disciple Liliana"
+    }, {
+        "id": "8759",
+        "name": "Runecaster Zelroth"
+    }, {
+        "id": "8769",
+        "name": "Arch-Magician Jig"
+    }, {
+        "id": "8836",
+        "name": "Cleric Celah"
+    }, {
+        "id": "8880",
+        "name": "Pyromancer Pepo"
+    }, {
+        "id": "8888",
+        "name": "Headless Wizard"
+    }, {
+        "id": "8974",
+        "name": "Void Disciple Anton"
+    }, {
+        "id": "8977",
+        "name": "Sage Azahl"
+    }, {
+        "id": "8996",
+        "name": "Magus Soya"
+    }, {
+        "id": "8999",
+        "name": "Witch Delilah"
+    }, {
+        "id": "9121",
+        "name": "Archmagus Aleister"
+    }, {
+        "id": "9137",
+        "name": "Archmagus Zane"
+    }, {
+        "id": "9142",
+        "name": "Ice Mage Durm"
+    }, {
+        "id": "9172",
+        "name": "Witch Lavinia"
+    }, {
+        "id": "9239",
+        "name": "Druid Ozohr"
+    }, {
+        "id": "9253",
+        "name": "Sorcerer Zaim"
+    }, {
+        "id": "9369",
+        "name": "Arcanist Yan"
+    }, {
+        "id": "9379",
+        "name": "Sage"
+    }, {
+        "id": "9412",
+        "name": "Soya"
+    }, {
+        "id": "9522",
+        "name": "Bard Hadrien"
+    }, {
+        "id": "9525",
+        "name": "Witch Ekmira"
+    }, {
+        "id": "9533",
+        "name": "Hedge Wizard Blaise"
+    }, {
+        "id": "9574",
+        "name": "Shaman Hu"
+    }, {
+        "id": "9597",
+        "name": "Artificer Soya"
+    }, {
+        "id": "9600",
+        "name": "Crowley"
+    }, {
+        "id": "9633",
+        "name": "Battlemage Bullock"
+    }, {
+        "id": "9662",
+        "name": "Evil Arcanist Gomorrah"
+    }, {
+        "id": "9668",
+        "name": "Hadrien"
+    }, {
+        "id": "9690",
+        "name": "Wizard Lupa"
+    }, {
+        "id": "9713",
+        "name": "Alchemist Hagar"
+    }, {
+        "id": "9771",
+        "name": "Archmagus Basil"
+    }, {
+        "id": "9825",
+        "name": "Aldus"
+    }],
+    "Tartarus": [{
+        "id": "1704",
+        "name": "Ghost Eater Diabolos of Tartarus"
+    }, {
+        "id": "1713",
+        "name": "Sorcerer Crowley of Tartarus"
+    }, {
+        "id": "1714",
+        "name": "Arcanist Qaid of Tartarus"
+    }, {
+        "id": "2161",
+        "name": "Battle Mage Godfrey of Tartarus"
+    }, {
+        "id": "3912",
+        "name": "Artificer Zane of Tartarus"
+    }, {
+        "id": "4276",
+        "name": "Cairon of Tartarus"
+    }, {
+        "id": "4684",
+        "name": "Shaman Flamos of Tartarus"
+    }, {
+        "id": "4969",
+        "name": "Hedge Wizard Rowena of Tartarus"
+    }, {
+        "id": "5310",
+        "name": "Geomancer Cromwell of Tartarus"
+    }, {
+        "id": "5667",
+        "name": "Pyromancer Azar of Tartarus"
+    }, {
+        "id": "5864",
+        "name": "Sorcerer Uvlius of Tartarus"
+    }, {
+        "id": "6690",
+        "name": "Mystic Jezebel of Tartarus"
+    }, {
+        "id": "6876",
+        "name": "Arcanist Aleister of Tartarus"
+    }, {
+        "id": "7010",
+        "name": "Arcanist Maia of Tartarus"
+    }, {
+        "id": "7092",
+        "name": "Alchemist Homer of Tartarus"
+    }, {
+        "id": "7305",
+        "name": "Battle Mage Cassius of Tartarus"
+    }, {
+        "id": "7665",
+        "name": "Druid Zelroth of Tartarus"
+    }, {
+        "id": "7765",
+        "name": "Archmagus Aleister of Tartarus"
+    }, {
+        "id": "7968",
+        "name": "Arcanist Gil of Tartarus"
+    }, {
+        "id": "8012",
+        "name": "Scorch of Tartarus"
+    }, {
+        "id": "8249",
+        "name": "Witch Enigma of Tartarus"
+    }, {
+        "id": "8268",
+        "name": "Spellsinger Homer of Tartarus"
+    }, {
+        "id": "8372",
+        "name": "Enchanter Nicolas of Tartarus"
+    }, {
+        "id": "8524",
+        "name": "Augurer Eizo of Tartarus"
+    }, {
+        "id": "9208",
+        "name": "Witch Sylvia of Tartarus"
+    }, {
+        "id": "9561",
+        "name": "Druid Scorch of Tartarus"
+    }, {
+        "id": "9910",
+        "name": "Summoner Peppy of Tartarus"
+    }],
+    "Hills": [{
+        "id": "99",
+        "name": "Archmagus Jeldor of the Hills"
+    }, {
+        "id": "113",
+        "name": "Sorcerer Hadrien of the Hills"
+    }, {
+        "id": "210",
+        "name": "Sorcerer Apollo of the Hills"
+    }, {
+        "id": "248",
+        "name": "Uvlius of the Hills"
+    }, {
+        "id": "250",
+        "name": "Hedge Wizard Enigma of the Hills"
+    }, {
+        "id": "289",
+        "name": "Archmagus Udor of the Hills"
+    }, {
+        "id": "317",
+        "name": "Battle Mage Dutorn of the Hills"
+    }, {
+        "id": "370",
+        "name": "Thaumaturge Daria of the Hills"
+    }, {
+        "id": "400",
+        "name": "Illusionist Fumiko of the Hills"
+    }, {
+        "id": "428",
+        "name": "Witch Ivy of the Hills"
+    }, {
+        "id": "468",
+        "name": "Charmer Celeste of the Hills"
+    }, {
+        "id": "486",
+        "name": "Maia of the Hills"
+    }, {
+        "id": "532",
+        "name": "Archmagus Cairon of the Hills"
+    }, {
+        "id": "537",
+        "name": "Arch-Magician Asphodel of the Hills"
+    }, {
+        "id": "555",
+        "name": "Arcanist Goliath of the Hills"
+    }, {
+        "id": "628",
+        "name": "Arch-Magician Otto of the Hills"
+    }, {
+        "id": "757",
+        "name": "Archmagus Pumlo of the Hills"
+    }, {
+        "id": "803",
+        "name": "Hedge Wizard Ursula of the Hills"
+    }, {
+        "id": "822",
+        "name": "Alchemist Rita of the Hills"
+    }, {
+        "id": "900",
+        "name": "Magus Atlanta of the Hills"
+    }, {
+        "id": "934",
+        "name": "Geomancer Apollo of the Hills"
+    }, {
+        "id": "1073",
+        "name": "Alatar of the Hills"
+    }, {
+        "id": "1145",
+        "name": "Cryptomancer Rita of the Hills"
+    }, {
+        "id": "1168",
+        "name": "Hex Mage Toadstool of the Hills"
+    }, {
+        "id": "1232",
+        "name": "Sorcerer Hadrien of the Hills"
+    }, {
+        "id": "1266",
+        "name": "Magus Victoria of the Hills"
+    }, {
+        "id": "1403",
+        "name": "Witch Velorina of the Hills"
+    }, {
+        "id": "1460",
+        "name": "Cairon of the Hills"
+    }, {
+        "id": "1527",
+        "name": "Magus Chiyo of the Hills"
+    }, {
+        "id": "1643",
+        "name": "Alchemist Shigenjo of the Hills"
+    }, {
+        "id": "1657",
+        "name": "Battle Mage Caligula of the Hills"
+    }, {
+        "id": "1670",
+        "name": "Pyromancer Azar of the Hills"
+    }, {
+        "id": "1705",
+        "name": "Archmagus Oberon of the Hills"
+    }, {
+        "id": "1749",
+        "name": "Electromancer Drusilla of the Hills"
+    }, {
+        "id": "1811",
+        "name": "Battle Mage Homer of the Hills"
+    }, {
+        "id": "1818",
+        "name": "Geomancer  of the Hills"
+    }, {
+        "id": "1833",
+        "name": "Alchemist Giuseppe of the Hills"
+    }, {
+        "id": "1834",
+        "name": "Archmagus Oxnard of the Hills"
+    }, {
+        "id": "1854",
+        "name": "Arcanist Fungi of the Hills"
+    }, {
+        "id": "1891",
+        "name": "Enchanter Arabella of the Hills"
+    }, {
+        "id": "1973",
+        "name": "Wild Mage Rita of the Hills"
+    }, {
+        "id": "1988",
+        "name": "Archmagus Milo of the Hills"
+    }, {
+        "id": "1996",
+        "name": "Sorcerer George of the Hills"
+    }, {
+        "id": "2063",
+        "name": "Magus Jezebel of the Hills"
+    }, {
+        "id": "2095",
+        "name": "Arcanist Arcus of the Hills"
+    }, {
+        "id": "2138",
+        "name": "Sorcerer Ifran of the Hills"
+    }, {
+        "id": "2177",
+        "name": "Archmagus Azahl of the Hills"
+    }, {
+        "id": "2264",
+        "name": "Enchanter Atlanta of the Hills"
+    }, {
+        "id": "2318",
+        "name": "Cryptomancer Ambrosia of the Hills"
+    }, {
+        "id": "2378",
+        "name": "Chaos Mage Azahl of the Hills"
+    }, {
+        "id": "2382",
+        "name": "Sage Lenora of the Hills"
+    }, {
+        "id": "2426",
+        "name": "Sage Florah of the Hills"
+    }, {
+        "id": "2502",
+        "name": "Cosmic Mage Faye of the Hills"
+    }, {
+        "id": "2533",
+        "name": "Voodoo Priest Jean Leon of the Hills"
+    }, {
+        "id": "2671",
+        "name": "Witch Lenora of the Hills"
+    }, {
+        "id": "2707",
+        "name": "Druid Umber of the Hills"
+    }, {
+        "id": "2739",
+        "name": "Bard Celah of the Hills"
+    }, {
+        "id": "2740",
+        "name": "Battle Mage Angus of the Hills"
+    }, {
+        "id": "2814",
+        "name": "Hydromancer Ai of the Hills"
+    }, {
+        "id": "2822",
+        "name": "Wild Mage Gallo of the Hills"
+    }, {
+        "id": "2966",
+        "name": "Battle Mage Magnus of the Hills"
+    }, {
+        "id": "3025",
+        "name": "Ofaris of the Hills"
+    }, {
+        "id": "3161",
+        "name": "Sorcerer Jabir of the Hills"
+    }, {
+        "id": "3221",
+        "name": "Charmer Galatea of the Hills"
+    }, {
+        "id": "3231",
+        "name": "Arcanist Victoria of the Hills"
+    }, {
+        "id": "3283",
+        "name": "Sorcerer Oberon of the Hills"
+    }, {
+        "id": "3301",
+        "name": "Sorcerer Jeldor of the Hills"
+    }, {
+        "id": "3368",
+        "name": "Summoner Karasu of the Hills"
+    }, {
+        "id": "3404",
+        "name": "Druid Dario of the Hills"
+    }, {
+        "id": "3449",
+        "name": "Hydromancer Purple Boy of the Hills"
+    }, {
+        "id": "3481",
+        "name": "Sage Ursula of the Hills"
+    }, {
+        "id": "3588",
+        "name": "Magus Ixar of the Hills"
+    }, {
+        "id": "3615",
+        "name": "Alatar of the Hills"
+    }, {
+        "id": "3621",
+        "name": "Enchanter Katherine of the Hills"
+    }, {
+        "id": "3639",
+        "name": "Archmagus Tengu of the Hills"
+    }, {
+        "id": "3709",
+        "name": "Pyromancer Scorch of the Hills"
+    }, {
+        "id": "3718",
+        "name": "Archmagus Ozohr of the Hills"
+    }, {
+        "id": "3817",
+        "name": "Witch Ophelia of the Hills"
+    }, {
+        "id": "3879",
+        "name": "Battle Mage Baird of the Hills"
+    }, {
+        "id": "3891",
+        "name": "Artificer Hishoken of the Hills"
+    }, {
+        "id": "3902",
+        "name": "Wild Mage Sylvia of the Hills"
+    }, {
+        "id": "3937",
+        "name": "Conjurer Rook of the Hills"
+    }, {
+        "id": "4034",
+        "name": "Chronomancer Azahl of the Hills"
+    }, {
+        "id": "4083",
+        "name": "Arcanist Crowley of the Hills"
+    }, {
+        "id": "4087",
+        "name": "Enchanter Sondra of the Hills"
+    }, {
+        "id": "4113",
+        "name": "Enchanter Cybele of the Hills"
+    }, {
+        "id": "4140",
+        "name": "Summoner Celeste of the Hills"
+    }, {
+        "id": "4207",
+        "name": "Enchanter Devon of the Hills"
+    }, {
+        "id": "4220",
+        "name": "Archmagus David of the Hills"
+    }, {
+        "id": "4228",
+        "name": "Daria of the Hills"
+    }, {
+        "id": "4240",
+        "name": "Arcanist Fire Eater of the Hills"
+    }, {
+        "id": "4358",
+        "name": "Ghost Eater Ivy of the Hills"
+    }, {
+        "id": "4391",
+        "name": "Enchanter Jadis of the Hills"
+    }, {
+        "id": "4394",
+        "name": "Thana of the Hills"
+    }, {
+        "id": "4483",
+        "name": "Witch Lamia of the Hills"
+    }, {
+        "id": "4640",
+        "name": "Spellsinger Calista of the Hills"
+    }, {
+        "id": "4700",
+        "name": "Magus Finn of the Hills"
+    }, {
+        "id": "4719",
+        "name": "Alchemist Katherine of the Hills"
+    }, {
+        "id": "4793",
+        "name": "Archmagus Apollo of the Hills"
+    }, {
+        "id": "4795",
+        "name": "Magus Giuseppe of the Hills"
+    }, {
+        "id": "4899",
+        "name": "Archmagus Ozohr of the Hills"
+    }, {
+        "id": "4925",
+        "name": "Druid Brown Cow of the Hills"
+    }, {
+        "id": "4963",
+        "name": "Magus Brown Cow of the Hills"
+    }, {
+        "id": "4985",
+        "name": "Sorcerer Apollo of the Hills"
+    }, {
+        "id": "5015",
+        "name": "Druid Udor of the Hills"
+    }, {
+        "id": "5060",
+        "name": "Enchanter Titania of the Hills"
+    }, {
+        "id": "5077",
+        "name": "Charmer Ariadne of the Hills"
+    }, {
+        "id": "5100",
+        "name": "Druid Hishoken of the Hills"
+    }, {
+        "id": "5125",
+        "name": "Archmagus George of the Hills"
+    }, {
+        "id": "5159",
+        "name": "Sorcerer Basil of the Hills"
+    }, {
+        "id": "5223",
+        "name": "Magus Calliope of the Hills"
+    }, {
+        "id": "5278",
+        "name": "Illusionist Lamia of the Hills"
+    }, {
+        "id": "5309",
+        "name": "Void Disciple Ursula of the Hills"
+    }, {
+        "id": "5321",
+        "name": "Battle Mage Finn of the Hills"
+    }, {
+        "id": "5351",
+        "name": "Pumlo of the Hills"
+    }, {
+        "id": "5398",
+        "name": "Druid Astrid of the Hills"
+    }, {
+        "id": "5426",
+        "name": "Magus Soya of the Hills"
+    }, {
+        "id": "5597",
+        "name": "Hedge Wizard Cromwell of the Hills"
+    }, {
+        "id": "5635",
+        "name": "Hydromancer Xiuying of the Hills"
+    }, {
+        "id": "5703",
+        "name": "Enchanter Ariadne of the Hills"
+    }, {
+        "id": "5903",
+        "name": "Runecaster Aldus of the Hills"
+    }, {
+        "id": "5925",
+        "name": "Battle Mage Nicolas of the Hills"
+    }, {
+        "id": "5931",
+        "name": "Sorcerer Jerret of the Hills"
+    }, {
+        "id": "5947",
+        "name": "Hydromancer Rowena of the Hills"
+    }, {
+        "id": "6013",
+        "name": "Geomancer Muntjac of the Hills"
+    }, {
+        "id": "6051",
+        "name": "Archmagus Lumos of the Hills"
+    }, {
+        "id": "6059",
+        "name": "Battle Mage Horace of the Hills"
+    }, {
+        "id": "6061",
+        "name": "Diviner Caligari of the Hills"
+    }, {
+        "id": "6081",
+        "name": "Arch-Magician Robert of the Hills"
+    }, {
+        "id": "6171",
+        "name": "Archmagus Nazim of the Hills"
+    }, {
+        "id": "6180",
+        "name": "Charmer Lamia of the Hills"
+    }, {
+        "id": "6291",
+        "name": "Sage Shivra of the Hills"
+    }, {
+        "id": "6311",
+        "name": "Arch-Magician Nolan of the Hills"
+    }, {
+        "id": "6342",
+        "name": "Sage Aslan of the Hills"
+    }, {
+        "id": "6376",
+        "name": "Fortune Teller Shivra of the Hills"
+    }, {
+        "id": "6540",
+        "name": "Druid Ulysse of the Hills"
+    }, {
+        "id": "6563",
+        "name": "Magus Victoria of the Hills"
+    }, {
+        "id": "6579",
+        "name": "Cleric Bathsheba of the Hills"
+    }, {
+        "id": "6663",
+        "name": "Apollo of the Hills"
+    }, {
+        "id": "6665",
+        "name": "Magus Gully of the Hills"
+    }, {
+        "id": "6673",
+        "name": "Illusionist Epher of the Hills"
+    }, {
+        "id": "6834",
+        "name": "Archmagus Devon of the Hills"
+    }, {
+        "id": "6843",
+        "name": "Sage Tenguyama of the Hills"
+    }, {
+        "id": "6874",
+        "name": "Sorcerer Orpheus of the Hills"
+    }, {
+        "id": "6991",
+        "name": "Alchemist Actaeon of the Hills"
+    }, {
+        "id": "7004",
+        "name": "Thaumaturge Udor of the Hills"
+    }, {
+        "id": "7087",
+        "name": "Enchanter Victoria of the Hills"
+    }, {
+        "id": "7197",
+        "name": "Shaman Flynn of the Hills"
+    }, {
+        "id": "7293",
+        "name": "Archmagus Milton of the Hills"
+    }, {
+        "id": "7333",
+        "name": "Thaumaturge Calliope of the Hills"
+    }, {
+        "id": "7338",
+        "name": "Battle Mage Hothor of the Hills"
+    }, {
+        "id": "7391",
+        "name": "Enchanter Tundror of the Hills"
+    }, {
+        "id": "7409",
+        "name": "Runecaster Alatar of the Hills"
+    }, {
+        "id": "7460",
+        "name": "Necromancer Galatea of the Hills"
+    }, {
+        "id": "7522",
+        "name": "Witch Drusilla of the Hills"
+    }, {
+        "id": "7523",
+        "name": "Alchemist Faiz of the Hills"
+    }, {
+        "id": "7541",
+        "name": "Mystic Gunthor of the Hills"
+    }, {
+        "id": "7550",
+        "name": "Mystic Florah of the Hills"
+    }, {
+        "id": "7591",
+        "name": "Enchanter Fungi of the Hills"
+    }, {
+        "id": "7605",
+        "name": "Hydromancer Mina of the Hills"
+    }, {
+        "id": "7687",
+        "name": "Alchemist Sisk of the Hills"
+    }, {
+        "id": "7792",
+        "name": "Geomancer Tundror of the Hills"
+    }, {
+        "id": "7818",
+        "name": "Witch Hagatha of the Hills"
+    }, {
+        "id": "7820",
+        "name": "Magus Cromwell of the Hills"
+    }, {
+        "id": "7853",
+        "name": "Electromancer Leah of the Hills"
+    }, {
+        "id": "7949",
+        "name": "Illusionist Diana of the Hills"
+    }, {
+        "id": "8164",
+        "name": "Druid Thor of the Hills"
+    }, {
+        "id": "8169",
+        "name": "Alchemist Moloch of the Hills"
+    }, {
+        "id": "8257",
+        "name": "Mystic Axel of the Hills"
+    }, {
+        "id": "8281",
+        "name": "Charmer Daria of the Hills"
+    }, {
+        "id": "8346",
+        "name": "Arcanist Malthus of the Hills"
+    }, {
+        "id": "8381",
+        "name": "David of the Hills"
+    }, {
+        "id": "8432",
+        "name": "Clairvoyant Gully of the Hills"
+    }, {
+        "id": "8522",
+        "name": "Necromancer Fumiko of the Hills"
+    }, {
+        "id": "8562",
+        "name": "Enchanter Daria of the Hills"
+    }, {
+        "id": "8622",
+        "name": "Magus Salvatore of the Hills"
+    }, {
+        "id": "8756",
+        "name": "Alatar of the Hills"
+    }, {
+        "id": "8763",
+        "name": "Charmer Calliope of the Hills"
+    }, {
+        "id": "8819",
+        "name": "Sage Zelroth of the Hills"
+    }, {
+        "id": "8851",
+        "name": "Druid Artis of the Hills"
+    }, {
+        "id": "8926",
+        "name": "Wild Mage Ofaris of the Hills"
+    }, {
+        "id": "8929",
+        "name": "Battle Mage Goliath of the Hills"
+    }, {
+        "id": "9010",
+        "name": "Enchanter Pandora of the Hills"
+    }, {
+        "id": "9101",
+        "name": "Witch Delilah of the Hills"
+    }, {
+        "id": "9189",
+        "name": "Shaman Daria of the Hills"
+    }, {
+        "id": "9216",
+        "name": "Chronomancer Xiuying of the Hills"
+    }, {
+        "id": "9385",
+        "name": "Enchanter Arabella of the Hills"
+    }, {
+        "id": "9386",
+        "name": "Battlemage Amanita of the Hills"
+    }, {
+        "id": "9478",
+        "name": "Conjurer Sylvia of the Hills"
+    }, {
+        "id": "9520",
+        "name": "Archmagus Qasim of the Hills"
+    }, {
+        "id": "9599",
+        "name": "Sage Gary of the Hills"
+    }, {
+        "id": "9620",
+        "name": "Charmer Larissa of the Hills"
+    }, {
+        "id": "9629",
+        "name": "Battle Mage Ethan of the Hills"
+    }, {
+        "id": "9716",
+        "name": "Ofaris of the Hills"
+    }, {
+        "id": "9717",
+        "name": "Witch Liliana of the Hills"
+    }, {
+        "id": "9754",
+        "name": "Cryptomancer Durm of the Hills"
+    }, {
+        "id": "9757",
+        "name": "Arcanist Impy of the Hills"
+    }, {
+        "id": "9769",
+        "name": "Mystic Blaise of the Hills"
+    }, {
+        "id": "9786",
+        "name": "Mystic Aleister of the Hills"
+    }, {
+        "id": "9793",
+        "name": "Archmagus Aleister of the Hills"
+    }, {
+        "id": "9917",
+        "name": "Sorcerer Alizam of the Hills"
+    }, {
+        "id": "9960",
+        "name": "Hex Mage Remus of the Hills"
+    }],
+    "Platonic Shadow": [{
+        "id": "61",
+        "name": "Arch-Magician Leah of the Platonic Shadow"
+    }, {
+        "id": "98",
+        "name": "Bard Gourdon of the Platonic Shadow"
+    }, {
+        "id": "232",
+        "name": "Alchemist Malcom of the Platonic Shadow"
+    }, {
+        "id": "386",
+        "name": "Sorcerer Crowley of the Platonic Shadow"
+    }, {
+        "id": "445",
+        "name": "Archmagus Armstrong of the Platonic Shadow"
+    }, {
+        "id": "492",
+        "name": "Azahl of the Platonic Shadow"
+    }, {
+        "id": "514",
+        "name": "Chronomancer Apollo of the Platonic Shadow"
+    }, {
+        "id": "721",
+        "name": "Illusionist Salvatore of the Platonic Shadow"
+    }, {
+        "id": "929",
+        "name": "Bard Embrose of the Platonic Shadow"
+    }, {
+        "id": "1080",
+        "name": "Druid Hagar of the Platonic Shadow"
+    }, {
+        "id": "1218",
+        "name": "Cosmic Mage Cromwell of the Platonic Shadow"
+    }, {
+        "id": "1311",
+        "name": "Archmagus Milo of the Platonic Shadow"
+    }, {
+        "id": "1326",
+        "name": "Mystic Ofaris of the Platonic Shadow"
+    }, {
+        "id": "1567",
+        "name": "Shaman Sturgis of the Platonic Shadow"
+    }, {
+        "id": "1920",
+        "name": "Ghost Eater Milo of the Platonic Shadow"
+    }, {
+        "id": "2234",
+        "name": "Arch-Magician Artis of the Platonic Shadow"
+    }, {
+        "id": "2261",
+        "name": "Necromancer Crackerjack of the Platonic Shadow"
+    }, {
+        "id": "2556",
+        "name": "Archmagus Aleister of the Platonic Shadow"
+    }, {
+        "id": "2656",
+        "name": "Alchemist Magpie of the Platonic Shadow"
+    }, {
+        "id": "2677",
+        "name": "Necromancer Arcus of the Platonic Shadow"
+    }, {
+        "id": "2693",
+        "name": "Uvlius of the Platonic Shadow"
+    }, {
+        "id": "2758",
+        "name": "Medium Samuel of the Platonic Shadow"
+    }, {
+        "id": "2886",
+        "name": "Conjurer Bolin of the Platonic Shadow"
+    }, {
+        "id": "3102",
+        "name": "Crowley of the Platonic Shadow"
+    }, {
+        "id": "3108",
+        "name": "Geomancer JackDaw of the Platonic Shadow"
+    }, {
+        "id": "3245",
+        "name": "Archmagus Apollo of the Platonic Shadow"
+    }, {
+        "id": "3352",
+        "name": "Cosmic Mage Lavinia of the Platonic Shadow"
+    }, {
+        "id": "3724",
+        "name": "Sage Remus of the Platonic Shadow"
+    }, {
+        "id": "3905",
+        "name": "Enchanter Devon of the Platonic Shadow"
+    }, {
+        "id": "4298",
+        "name": "Necromancer Voidoth of the Platonic Shadow"
+    }, {
+        "id": "4462",
+        "name": "Chaos Mage Zaros of the Platonic Shadow"
+    }, {
+        "id": "4741",
+        "name": "Cosmic Mage Hugo of the Platonic Shadow"
+    }, {
+        "id": "4949",
+        "name": "Sorcerer Silas of the Platonic Shadow"
+    }, {
+        "id": "5037",
+        "name": "Battle Mage Wolfram of the Platonic Shadow"
+    }, {
+        "id": "5129",
+        "name": "Adept Rook of the Platonic Shadow"
+    }, {
+        "id": "5243",
+        "name": "Cosmic Mage Digby of the Platonic Shadow"
+    }, {
+        "id": "5317",
+        "name": "Thaumaturge Udor of the Platonic Shadow"
+    }, {
+        "id": "5362",
+        "name": "Sorcerer Jaffer of the Platonic Shadow"
+    }, {
+        "id": "5699",
+        "name": "Cleric Hecate of the Platonic Shadow"
+    }, {
+        "id": "6177",
+        "name": "Hedge Wizard Allistair of the Platonic Shadow"
+    }, {
+        "id": "6464",
+        "name": "Hedge Wizard Hadrien of the Platonic Shadow"
+    }, {
+        "id": "6564",
+        "name": "Adept  of the Platonic Shadow"
+    }, {
+        "id": "6598",
+        "name": "Hex Mage Tengukensei of the Platonic Shadow"
+    }, {
+        "id": "6931",
+        "name": "Enchanter Argus of the Platonic Shadow"
+    }, {
+        "id": "7221",
+        "name": "Sorcerer Aldus of the Platonic Shadow"
+    }, {
+        "id": "7310",
+        "name": "Spellsinger Artis of the Platonic Shadow"
+    }, {
+        "id": "7326",
+        "name": "Battle Mage Malthus of the Platonic Shadow"
+    }, {
+        "id": "7340",
+        "name": "Cryptomancer David of the Platonic Shadow"
+    }, {
+        "id": "7421",
+        "name": "Shaman Finn of the Platonic Shadow"
+    }, {
+        "id": "7567",
+        "name": "Archmagus Jahid of the Platonic Shadow"
+    }, {
+        "id": "7675",
+        "name": "Witch Lamia of the Platonic Shadow"
+    }, {
+        "id": "8048",
+        "name": "Illusionist Bao of the Platonic Shadow"
+    }, {
+        "id": "8549",
+        "name": "Druid Evangeline of the Platonic Shadow"
+    }, {
+        "id": "8614",
+        "name": "Battle Mage Luther of the Platonic Shadow"
+    }, {
+        "id": "8642",
+        "name": "Arch-Magician Finn of the Platonic Shadow"
+    }, {
+        "id": "8698",
+        "name": "Alchemist Alatar of the Platonic Shadow"
+    }, {
+        "id": "8742",
+        "name": "Pyromancer Merlon of the Platonic Shadow"
+    }, {
+        "id": "8777",
+        "name": "Archmagus Sisk of the Platonic Shadow"
+    }, {
+        "id": "9161",
+        "name": "Archmagus Merlon of the Platonic Shadow"
+    }, {
+        "id": "9518",
+        "name": "Sorcerer Celah of the Platonic Shadow"
+    }, {
+        "id": "9589",
+        "name": "Cryptomancer Jabir of the Platonic Shadow"
+    }, {
+        "id": "9740",
+        "name": "Archmagus Pumlo of the Platonic Shadow"
+    }, {
+        "id": "9892",
+        "name": "Arcanist Eliphas of the Platonic Shadow"
+    }],
+    "Marsh": [{
+        "id": "70",
+        "name": "Archmagus Oberon of the Marsh"
+    }, {
+        "id": "89",
+        "name": "Ghost Eater Layla of the Marsh"
+    }, {
+        "id": "107",
+        "name": "Adept David of the Marsh"
+    }, {
+        "id": "168",
+        "name": "Spellsinger Danny of the Marsh"
+    }, {
+        "id": "228",
+        "name": "Archmagus Adrienne of the Marsh"
+    }, {
+        "id": "261",
+        "name": "Shadow Mage Katherine of the Marsh"
+    }, {
+        "id": "335",
+        "name": "Enchanter Oxnard of the Marsh"
+    }, {
+        "id": "355",
+        "name": "Holy Monk Onaxx of the Marsh"
+    }, {
+        "id": "371",
+        "name": "Geomancer Hansel of the Marsh"
+    }, {
+        "id": "399",
+        "name": "Archmagus Alessar of the Marsh"
+    }, {
+        "id": "431",
+        "name": "Necromancer Shivra of the Marsh"
+    }, {
+        "id": "437",
+        "name": "Druid Jabir of the Marsh"
+    }, {
+        "id": "443",
+        "name": "Battle Mage Borak of the Marsh"
+    }, {
+        "id": "574",
+        "name": "Sorcerer Pumlo of the Marsh"
+    }, {
+        "id": "579",
+        "name": "Pyromancer Naoki of the Marsh"
+    }, {
+        "id": "604",
+        "name": "Archmagus Orpheus of the Marsh"
+    }, {
+        "id": "686",
+        "name": "Alchemist Nikolas of the Marsh"
+    }, {
+        "id": "750",
+        "name": "Thaumaturge Wolfram of the Marsh"
+    }, {
+        "id": "753",
+        "name": "Voodoo Priest Caligari of the Marsh"
+    }, {
+        "id": "806",
+        "name": "Magus Tabitha of the Marsh"
+    }, {
+        "id": "844",
+        "name": "Archmagus Aldus of the Marsh"
+    }, {
+        "id": "873",
+        "name": "Enchanter Bathsheba of the Marsh"
+    }, {
+        "id": "884",
+        "name": "Archmagus Jig of the Marsh"
+    }, {
+        "id": "899",
+        "name": "Chronomancer Udor of the Marsh"
+    }, {
+        "id": "901",
+        "name": "Battle Mage Durm of the Marsh"
+    }, {
+        "id": "918",
+        "name": "Sorcerer Ixar of the Marsh"
+    }, {
+        "id": "1029",
+        "name": "Adept Uvlius of the Marsh"
+    }, {
+        "id": "1035",
+        "name": "Adept Bullock of the Marsh"
+    }, {
+        "id": "1127",
+        "name": "Alchemist Caligula of the Marsh"
+    }, {
+        "id": "1132",
+        "name": "Hex Mage Aleister of the Marsh"
+    }, {
+        "id": "1214",
+        "name": "Witch Lilith of the Marsh"
+    }, {
+        "id": "1216",
+        "name": "Sorcerer  of the Marsh"
+    }, {
+        "id": "1222",
+        "name": "Druid Zubin of the Marsh"
+    }, {
+        "id": "1285",
+        "name": "Clairvoyant Chanterelle of the Marsh"
+    }, {
+        "id": "1334",
+        "name": "Cryptomancer Luther of the Marsh"
+    }, {
+        "id": "1347",
+        "name": "Battle Mage Homer of the Marsh"
+    }, {
+        "id": "1356",
+        "name": "Battle Mage Hagar of the Marsh"
+    }, {
+        "id": "1362",
+        "name": "Sorcerer Aldus of the Marsh"
+    }, {
+        "id": "1402",
+        "name": "Enchanter Adrienne of the Marsh"
+    }, {
+        "id": "1486",
+        "name": "Battle Mage Dutorn of the Marsh"
+    }, {
+        "id": "1495",
+        "name": "Sondra of the Marsh"
+    }, {
+        "id": "1499",
+        "name": "Enchanter Calista of the Marsh"
+    }, {
+        "id": "1520",
+        "name": "Illusionist Bucky of the Marsh"
+    }, {
+        "id": "1550",
+        "name": "Enchanter Carly of the Marsh"
+    }, {
+        "id": "1614",
+        "name": "Battle Mage Ulysse of the Marsh"
+    }, {
+        "id": "1659",
+        "name": "Battlemage Homer of the Marsh"
+    }, {
+        "id": "1660",
+        "name": "Archmagus Jeldor of the Marsh"
+    }, {
+        "id": "1792",
+        "name": "Battlemage Pumlo of the Marsh"
+    }, {
+        "id": "1796",
+        "name": "Archmagus Lumos of the Marsh"
+    }, {
+        "id": "1866",
+        "name": "Hedge Wizard Junko of the Marsh"
+    }, {
+        "id": "1889",
+        "name": "Enchanter Zorko of the Marsh"
+    }, {
+        "id": "2010",
+        "name": "Sage Hothor of the Marsh"
+    }, {
+        "id": "2104",
+        "name": "Summoner Zane of the Marsh"
+    }, {
+        "id": "2156",
+        "name": "Augurer Peppy of the Marsh"
+    }, {
+        "id": "2207",
+        "name": "Hedge Wizard Xiuying of the Marsh"
+    }, {
+        "id": "2227",
+        "name": "Ghost Eater Sarah of the Marsh"
+    }, {
+        "id": "2301",
+        "name": "Archmagus Alatar of the Marsh"
+    }, {
+        "id": "2317",
+        "name": "Chaos Mage Aiko of the Marsh"
+    }, {
+        "id": "2429",
+        "name": "Shadow Mage Angus of the Marsh"
+    }, {
+        "id": "2478",
+        "name": "Archmagus Properpine of the Marsh"
+    }, {
+        "id": "2522",
+        "name": "Alchemist Ratko of the Marsh"
+    }, {
+        "id": "2525",
+        "name": "Sorcerer Zaros of the Marsh"
+    }, {
+        "id": "2539",
+        "name": "Adept Aslan of the Marsh"
+    }, {
+        "id": "2569",
+        "name": "Archmagus Mina of the Marsh"
+    }, {
+        "id": "2651",
+        "name": "Summoner Isaac of the Marsh"
+    }, {
+        "id": "2685",
+        "name": "Sage Juniper of the Marsh"
+    }, {
+        "id": "2698",
+        "name": "Cleric Argus of the Marsh"
+    }, {
+        "id": "2733",
+        "name": "Charmer Calista of the Marsh"
+    }, {
+        "id": "2744",
+        "name": "Shaman Evangeline of the Marsh"
+    }, {
+        "id": "2757",
+        "name": "Charmer Thana of the Marsh"
+    }, {
+        "id": "2803",
+        "name": "Archmagus Uvlius of the Marsh"
+    }, {
+        "id": "2812",
+        "name": "Mina of the Marsh"
+    }, {
+        "id": "2830",
+        "name": "Artificer Tengu of the Marsh"
+    }, {
+        "id": "2895",
+        "name": "Sorcerer Chooki of the Marsh"
+    }, {
+        "id": "2897",
+        "name": "Alchemist Devon of the Marsh"
+    }, {
+        "id": "2923",
+        "name": "Enchanter Ambrosia of the Marsh"
+    }, {
+        "id": "2939",
+        "name": "Daria of the Marsh"
+    }, {
+        "id": "2974",
+        "name": "Cleric Lumos of the Marsh"
+    }, {
+        "id": "3081",
+        "name": "Druid Allistair of the Marsh"
+    }, {
+        "id": "3094",
+        "name": "Cosmic Mage Magpie of the Marsh"
+    }, {
+        "id": "3133",
+        "name": "Arch-Magician Fugh of the Marsh"
+    }, {
+        "id": "3144",
+        "name": "Shaman Ozohr of the Marsh"
+    }, {
+        "id": "3167",
+        "name": "Pyromancer Bobbin of the Marsh"
+    }, {
+        "id": "3299",
+        "name": "Archmagus Soya of the Marsh"
+    }, {
+        "id": "3310",
+        "name": "Cleric Xue of the Marsh"
+    }, {
+        "id": "3393",
+        "name": "Illusionist Herne of the Marsh"
+    }, {
+        "id": "3397",
+        "name": "Diabolist Sylvia of the Marsh"
+    }, {
+        "id": "3424",
+        "name": "Enchanter Aiko of the Marsh"
+    }, {
+        "id": "3441",
+        "name": "Adept Sylvia of the Marsh"
+    }, {
+        "id": "3453",
+        "name": "Battlemage Aden of the Marsh"
+    }, {
+        "id": "3483",
+        "name": "Magus Xiaosheng of the Marsh"
+    }, {
+        "id": "3492",
+        "name": "Druid Alatar of the Marsh"
+    }, {
+        "id": "3527",
+        "name": "Artificer Eden of the Marsh"
+    }, {
+        "id": "3579",
+        "name": "Artificer Dante of the Marsh"
+    }, {
+        "id": "3625",
+        "name": "Artificer Oxnard of the Marsh"
+    }, {
+        "id": "3675",
+        "name": "Oracle Tundror of the Marsh"
+    }, {
+        "id": "3734",
+        "name": "Enchanter Daria of the Marsh"
+    }, {
+        "id": "3747",
+        "name": "Adept Cassiopeia of the Marsh"
+    }, {
+        "id": "3806",
+        "name": "Magus Lumos of the Marsh"
+    }, {
+        "id": "3812",
+        "name": "Battle Mage Baird of the Marsh"
+    }, {
+        "id": "3875",
+        "name": "Evoker Angus of the Marsh"
+    }, {
+        "id": "3958",
+        "name": "Magus Aleister of the Marsh"
+    }, {
+        "id": "3982",
+        "name": "Thaumaturge Aiko of the Marsh"
+    }, {
+        "id": "4056",
+        "name": "Druid Artis of the Marsh"
+    }, {
+        "id": "4071",
+        "name": "Artificer Otto of the Marsh"
+    }, {
+        "id": "4073",
+        "name": "Sage Lamia of the Marsh"
+    }, {
+        "id": "4123",
+        "name": "Magus Cromwell of the Marsh"
+    }, {
+        "id": "4163",
+        "name": "Wild Mage Dante of the Marsh"
+    }, {
+        "id": "4232",
+        "name": "Fortune Teller Patch of the Marsh"
+    }, {
+        "id": "4336",
+        "name": "Zelroth of the Marsh"
+    }, {
+        "id": "4431",
+        "name": "Battlemage Isaac of the Marsh"
+    }, {
+        "id": "4463",
+        "name": "Cartomancer Sarah of the Marsh"
+    }, {
+        "id": "4471",
+        "name": "Arch-Magician Molek of the Marsh"
+    }, {
+        "id": "4535",
+        "name": "Magus Wazir of the Marsh"
+    }, {
+        "id": "4691",
+        "name": "Archmagus Silas of the Marsh"
+    }, {
+        "id": "4748",
+        "name": "Alchemist Miyo of the Marsh"
+    }, {
+        "id": "4856",
+        "name": "Magus Jahid of the Marsh"
+    }, {
+        "id": "4907",
+        "name": "Artificer Flynn of the Marsh"
+    }, {
+        "id": "4988",
+        "name": "Battle Mage Goliath of the Marsh"
+    }, {
+        "id": "5004",
+        "name": "Alchemist Jahid of the Marsh"
+    }, {
+        "id": "5073",
+        "name": "Alchemist Lei of the Marsh"
+    }, {
+        "id": "5093",
+        "name": "Chronomancer Ixar of the Marsh"
+    }, {
+        "id": "5101",
+        "name": "Arabella of the Marsh"
+    }, {
+        "id": "5143",
+        "name": "Geomancer Herne of the Marsh"
+    }, {
+        "id": "5158",
+        "name": "Alessar of the Marsh"
+    }, {
+        "id": "5175",
+        "name": "Shaman Bathsheba of the Marsh"
+    }, {
+        "id": "5195",
+        "name": "Battlemage Milton of the Marsh"
+    }, {
+        "id": "5206",
+        "name": "Sorcerer Udor of the Marsh"
+    }, {
+        "id": "5217",
+        "name": "Artificer Cromwell of the Marsh"
+    }, {
+        "id": "5312",
+        "name": "Bathsheba of the Marsh"
+    }, {
+        "id": "5315",
+        "name": "Enchanter Victoria of the Marsh"
+    }, {
+        "id": "5336",
+        "name": "Battle Mage Robert of the Marsh"
+    }, {
+        "id": "5349",
+        "name": "Magus Buttons of the Marsh"
+    }, {
+        "id": "5372",
+        "name": "Cosmic Mage Thana of the Marsh"
+    }, {
+        "id": "5452",
+        "name": "Shaman Jeldor of the Marsh"
+    }, {
+        "id": "5454",
+        "name": "Cryptomancer Goliath of the Marsh"
+    }, {
+        "id": "5467",
+        "name": "Adept Taqi of the Marsh"
+    }, {
+        "id": "5494",
+        "name": "Enchanter Circe of the Marsh"
+    }, {
+        "id": "5558",
+        "name": "Sage Atlanta of the Marsh"
+    }, {
+        "id": "5668",
+        "name": "Magus Kraken of the Marsh"
+    }, {
+        "id": "5680",
+        "name": "Evoker Nicolas of the Marsh"
+    }, {
+        "id": "5809",
+        "name": "Mystic Hagatha of the Marsh"
+    }, {
+        "id": "5829",
+        "name": "Hex Mage Milton of the Marsh"
+    }, {
+        "id": "5848",
+        "name": "Conjurer Bullock of the Marsh"
+    }, {
+        "id": "5862",
+        "name": "Artificer Zorko of the Marsh"
+    }, {
+        "id": "5876",
+        "name": "Electromancer Trollin of the Marsh"
+    }, {
+        "id": "5880",
+        "name": "Charmer Arabella of the Marsh"
+    }, {
+        "id": "5929",
+        "name": "Magus Casper of the Marsh"
+    }, {
+        "id": "6132",
+        "name": "Shaman Crackerjack of the Marsh"
+    }, {
+        "id": "6154",
+        "name": "Witch Tabitha of the Marsh"
+    }, {
+        "id": "6234",
+        "name": "Enchanter Pandora of the Marsh"
+    }, {
+        "id": "6236",
+        "name": "Shaman Faye of the Marsh"
+    }, {
+        "id": "6378",
+        "name": "Archmagus Digby of the Marsh"
+    }, {
+        "id": "6417",
+        "name": "Sage Yuki of the Marsh"
+    }, {
+        "id": "6437",
+        "name": "Enchanter Cybele of the Marsh"
+    }, {
+        "id": "6471",
+        "name": "Archmagus Jeldor of the Marsh"
+    }, {
+        "id": "6517",
+        "name": "Artificer Seth of the Marsh"
+    }, {
+        "id": "6534",
+        "name": "Transmuter Hothor of the Marsh"
+    }, {
+        "id": "6549",
+        "name": "Archmagus George of the Marsh"
+    }, {
+        "id": "6808",
+        "name": "Artificer Chiyo of the Marsh"
+    }, {
+        "id": "6820",
+        "name": "Witch Lilith of the Marsh"
+    }, {
+        "id": "6862",
+        "name": "Enchanter Artis of the Marsh"
+    }, {
+        "id": "6873",
+        "name": "Sorcerer Remus of the Marsh"
+    }, {
+        "id": "7042",
+        "name": "Adept Lavinia of the Marsh"
+    }, {
+        "id": "7046",
+        "name": "Wild Mage Nolan of the Marsh"
+    }, {
+        "id": "7077",
+        "name": "Sorcerer Idris of the Marsh"
+    }, {
+        "id": "7112",
+        "name": "Enchanter Mina of the Marsh"
+    }, {
+        "id": "7122",
+        "name": "Battle Mage Danny of the Marsh"
+    }, {
+        "id": "7206",
+        "name": "Cleric Properpine of the Marsh"
+    }, {
+        "id": "7213",
+        "name": "Archmagus Eden of the Marsh"
+    }, {
+        "id": "7303",
+        "name": "Battlemage Providence of the Marsh"
+    }, {
+        "id": "7308",
+        "name": "Thaumaturge Jastor of the Marsh"
+    }, {
+        "id": "7429",
+        "name": "Runecaster Hansel of the Marsh"
+    }, {
+        "id": "7644",
+        "name": "Arch-Magician Asphodel of the Marsh"
+    }, {
+        "id": "7651",
+        "name": "Archmagus Allistair of the Marsh"
+    }, {
+        "id": "7684",
+        "name": "Druid Gunthor of the Marsh"
+    }, {
+        "id": "7697",
+        "name": "Hydromancer Asphodel of the Marsh"
+    }, {
+        "id": "7708",
+        "name": "Enchanter Qaid of the Marsh"
+    }, {
+        "id": "7731",
+        "name": "Archmagus Ozohr of the Marsh"
+    }, {
+        "id": "7758",
+        "name": "Hedge Wizard Larissa of the Marsh"
+    }, {
+        "id": "7868",
+        "name": "Wizard Feng of the Marsh"
+    }, {
+        "id": "7875",
+        "name": "Magus Hind of the Marsh"
+    }, {
+        "id": "7883",
+        "name": "Sage Elena of the Marsh"
+    }, {
+        "id": "7898",
+        "name": "Mystic Rafiq of the Marsh"
+    }, {
+        "id": "7989",
+        "name": "Runecaster Ming of the Marsh"
+    }, {
+        "id": "8047",
+        "name": "Cosmic Mage Xiaosheng of the Marsh"
+    }, {
+        "id": "8052",
+        "name": "Enchanter Artis of the Marsh"
+    }, {
+        "id": "8087",
+        "name": "Charmer Sonja of the Marsh"
+    }, {
+        "id": "8092",
+        "name": "Diviner Devon of the Marsh"
+    }, {
+        "id": "8231",
+        "name": "Alchemist Daphne of the Marsh"
+    }, {
+        "id": "8325",
+        "name": "Charmer Ariadne of the Marsh"
+    }, {
+        "id": "8348",
+        "name": "Sage Asphodel of the Marsh"
+    }, {
+        "id": "8387",
+        "name": "Charmer Celeste of the Marsh"
+    }, {
+        "id": "8453",
+        "name": "Magus Atlanta of the Marsh"
+    }, {
+        "id": "8497",
+        "name": "Arcanist Cairon of the Marsh"
+    }, {
+        "id": "8512",
+        "name": "Hedge Wizard Argus of the Marsh"
+    }, {
+        "id": "8516",
+        "name": "Illusionist Diana of the Marsh"
+    }, {
+        "id": "8597",
+        "name": "Archmagus Onaxx of the Marsh"
+    }, {
+        "id": "8601",
+        "name": "Magus Nicolas of the Marsh"
+    }, {
+        "id": "8603",
+        "name": "Alchemist Rita of the Marsh"
+    }, {
+        "id": "8605",
+        "name": "Charmer Cybele of the Marsh"
+    }, {
+        "id": "8608",
+        "name": "Druid  of the Marsh"
+    }, {
+        "id": "8786",
+        "name": "Enchanter Astrid of the Marsh"
+    }, {
+        "id": "8791",
+        "name": "Enchanter Chooki of the Marsh"
+    }, {
+        "id": "8812",
+        "name": "Shaman Asmodeus of the Marsh"
+    }, {
+        "id": "8866",
+        "name": "Enchanter Daphne of the Marsh"
+    }, {
+        "id": "8904",
+        "name": "Witch Evangeline of the Marsh"
+    }, {
+        "id": "8934",
+        "name": "Wild Mage Nicolas of the Marsh"
+    }, {
+        "id": "8942",
+        "name": "Druid Crowley of the Marsh"
+    }, {
+        "id": "9069",
+        "name": "Cryptomancer Ratko of the Marsh"
+    }, {
+        "id": "9117",
+        "name": "Voodoo Priest Gorgana of the Marsh"
+    }, {
+        "id": "9120",
+        "name": "Magus Zane of the Marsh"
+    }, {
+        "id": "9207",
+        "name": "Enchanter Larissa of the Marsh"
+    }, {
+        "id": "9268",
+        "name": "Battle Mage Robert of the Marsh"
+    }, {
+        "id": "9280",
+        "name": "Geomancer Drokore of the Marsh"
+    }, {
+        "id": "9395",
+        "name": "Enchanter Astrid of the Marsh"
+    }, {
+        "id": "9416",
+        "name": "Conjurer Artis of the Marsh"
+    }, {
+        "id": "9422",
+        "name": "Archmagus Lumos of the Marsh"
+    }, {
+        "id": "9495",
+        "name": "Druid Jerret of the Marsh"
+    }, {
+        "id": "9511",
+        "name": "Archmagus Apollo of the Marsh"
+    }, {
+        "id": "9534",
+        "name": "Hedge Wizard Jack of the Marsh"
+    }, {
+        "id": "9602",
+        "name": "Archmagus Aleister of the Marsh"
+    }, {
+        "id": "9608",
+        "name": "Arcanist Xue of the Marsh"
+    }, {
+        "id": "9722",
+        "name": "Medium Cybele of the Marsh"
+    }, {
+        "id": "9744",
+        "name": "Druid Caligari of the Marsh"
+    }, {
+        "id": "9868",
+        "name": "Archmagus Udor of the Marsh"
+    }, {
+        "id": "9877",
+        "name": "Cassiopeia of the Marsh"
+    }, {
+        "id": "9886",
+        "name": "Hydromancer Lin of the Marsh"
+    }, {
+        "id": "9915",
+        "name": "Scryer Rowena of the Marsh"
+    }, {
+        "id": "9929",
+        "name": "Hedge Wizard Larissa of the Marsh"
+    }, {
+        "id": "9931",
+        "name": "Sorcerer Cassiopeia of the Marsh"
+    }, {
+        "id": "9941",
+        "name": "Arch-Magician Soran of the Marsh"
+    }, {
+        "id": "9976",
+        "name": "Alchemist Rita of the Marsh"
+    }],
+    "Waste": [{
+        "id": "253",
+        "name": "Archmagus Zaros of the Waste"
+    }, {
+        "id": "467",
+        "name": "Null Mage Drusilla of the Waste"
+    }, {
+        "id": "619",
+        "name": "Battlemage Jastor of the Waste"
+    }, {
+        "id": "700",
+        "name": "Sorcerer George of the Waste"
+    }, {
+        "id": "1005",
+        "name": "Magus Gully of the Waste"
+    }, {
+        "id": "1146",
+        "name": "Davos of the Waste"
+    }, {
+        "id": "1245",
+        "name": "Enchanter Lumos of the Waste"
+    }, {
+        "id": "1315",
+        "name": "Aleister of the Waste"
+    }, {
+        "id": "1531",
+        "name": "Shaman Faiz of the Waste"
+    }, {
+        "id": "1762",
+        "name": "Druid Udor of the Waste"
+    }, {
+        "id": "1951",
+        "name": "Alchemist Eric of the Waste"
+    }, {
+        "id": "2931",
+        "name": "Ghost Eater Optimus of the Waste"
+    }, {
+        "id": "2932",
+        "name": "Enchanter Daphne of the Waste"
+    }, {
+        "id": "2948",
+        "name": "Pyromancer Hagar of the Waste"
+    }, {
+        "id": "3628",
+        "name": "Shaman Alizam of the Waste"
+    }, {
+        "id": "4016",
+        "name": "Archmagus Shanyuan of the Waste"
+    }, {
+        "id": "4802",
+        "name": "Spellsinger Apollo of the Waste"
+    }, {
+        "id": "4941",
+        "name": "Sorcerer Remus of the Waste"
+    }, {
+        "id": "4967",
+        "name": "Mystic Azar of the Waste"
+    }, {
+        "id": "5245",
+        "name": "Magus Jaffer of the Waste"
+    }, {
+        "id": "6106",
+        "name": "Necromancer Brown Cow of the Waste"
+    }, {
+        "id": "6326",
+        "name": "Druid Tundror of the Waste"
+    }, {
+        "id": "6492",
+        "name": "Void Disciple Thoth of the Waste"
+    }, {
+        "id": "7266",
+        "name": "Void Disciple Anton of the Waste"
+    }, {
+        "id": "8129",
+        "name": "Magus Ifran of the Waste"
+    }, {
+        "id": "8428",
+        "name": "Artificer Chipper of the Waste"
+    }, {
+        "id": "8454",
+        "name": "Void Disciple Voidoth of the Waste"
+    }, {
+        "id": "8883",
+        "name": "Artificer Atlas of the Waste"
+    }, {
+        "id": "9792",
+        "name": "Necromancer Jabir of the Waste"
+    }],
+    "Isle": [{
+        "id": "142",
+        "name": "Ghost Eater Galatea of the Isle"
+    }, {
+        "id": "688",
+        "name": "Battle Mage Nolan of the Isle"
+    }, {
+        "id": "705",
+        "name": "Zaros of the Isle"
+    }, {
+        "id": "1892",
+        "name": "Hedge Wizard Danny of the Isle"
+    }, {
+        "id": "3106",
+        "name": "Shadow Mage Rook of the Isle"
+    }, {
+        "id": "3892",
+        "name": "Archmagus Samuel of the Isle"
+    }, {
+        "id": "4061",
+        "name": "Archmagus Azahl of the Isle"
+    }, {
+        "id": "4063",
+        "name": "Archmagus Aldo of the Isle"
+    }, {
+        "id": "5984",
+        "name": "Shaman  of the Isle"
+    }, {
+        "id": "6065",
+        "name": "Battle Mage Dutorn of the Isle"
+    }, {
+        "id": "6741",
+        "name": "Sorcerer Lux of the Isle"
+    }, {
+        "id": "6923",
+        "name": "Archmagus Celeste of the Isle"
+    }, {
+        "id": "6951",
+        "name": "Battle Mage Talon of the Isle"
+    }, {
+        "id": "7462",
+        "name": "Sorcerer David of the Isle"
+    }, {
+        "id": "7797",
+        "name": "Shaman Adrienne of the Isle"
+    }, {
+        "id": "8340",
+        "name": "Magus Homer of the Isle"
+    }, {
+        "id": "9041",
+        "name": "Hydromancer Baird of the Isle"
+    }, {
+        "id": "9521",
+        "name": "Battle Mage Sturgis of the Isle"
+    }, {
+        "id": "9672",
+        "name": "Thaumaturge Ophelia of the Isle"
+    }, {
+        "id": "9682",
+        "name": "Battle Mage Gary of the Isle"
+    }],
+    "Citadel": [{
+        "id": "51",
+        "name": "Cleric Orpheus of the Citadel"
+    }, {
+        "id": "74",
+        "name": "Runecaster Gee of the Citadel"
+    }, {
+        "id": "87",
+        "name": "Shaman Mace of the Citadel"
+    }, {
+        "id": "90",
+        "name": "Spellsinger Brutus of the Citadel"
+    }, {
+        "id": "340",
+        "name": "Conjurer Chiyo of the Citadel"
+    }, {
+        "id": "398",
+        "name": "Hedge Wizard Edge of the Citadel"
+    }, {
+        "id": "442",
+        "name": "Runecaster David of the Citadel"
+    }, {
+        "id": "586",
+        "name": "Battlemage Uvlius of the Citadel"
+    }, {
+        "id": "635",
+        "name": "Summoner Cedric of the Citadel"
+    }, {
+        "id": "843",
+        "name": "Archmagus David of the Citadel"
+    }, {
+        "id": "846",
+        "name": "Clairvoyant Uvlius of the Citadel"
+    }, {
+        "id": "856",
+        "name": "Artificer Orpheus of the Citadel"
+    }, {
+        "id": "945",
+        "name": "Alchemist Lumos of the Citadel"
+    }, {
+        "id": "1034",
+        "name": "Sorcerer Eizo of the Citadel"
+    }, {
+        "id": "1045",
+        "name": "Archmagus Soya of the Citadel"
+    }, {
+        "id": "1071",
+        "name": "Alchemist Cairon of the Citadel"
+    }, {
+        "id": "1076",
+        "name": "Illusionist Victor of the Citadel"
+    }, {
+        "id": "1123",
+        "name": "Archmagus Milton of the Citadel"
+    }, {
+        "id": "1318",
+        "name": "Chronomancer Fugh of the Citadel"
+    }, {
+        "id": "1471",
+        "name": "Evoker Bogey of the Citadel"
+    }, {
+        "id": "1579",
+        "name": "Alchemist Solomon of the Citadel"
+    }, {
+        "id": "1780",
+        "name": "Sorcerer Ifran of the Citadel"
+    }, {
+        "id": "2052",
+        "name": "Archmagus Aleister of the Citadel"
+    }, {
+        "id": "2175",
+        "name": "Medium Ali of the Citadel"
+    }, {
+        "id": "2258",
+        "name": "Oracle Fugh of the Citadel"
+    }, {
+        "id": "2354",
+        "name": "Magus Hobbs of the Citadel"
+    }, {
+        "id": "2748",
+        "name": "Medium Hugo of the Citadel"
+    }, {
+        "id": "2796",
+        "name": "Thaumaturge Dante of the Citadel"
+    }, {
+        "id": "2808",
+        "name": "Oracle Yuki of the Citadel"
+    }, {
+        "id": "3060",
+        "name": "Archmagus Amir of the Citadel"
+    }, {
+        "id": "3089",
+        "name": "Geomancer Ariadne of the Citadel"
+    }, {
+        "id": "3097",
+        "name": "Battlemage Pierre of the Citadel"
+    }, {
+        "id": "3183",
+        "name": "Evoker Kalo of the Citadel"
+    }, {
+        "id": "3344",
+        "name": "Pyromancer Calista of the Citadel"
+    }, {
+        "id": "3376",
+        "name": "Sorcerer Nadeem of the Citadel"
+    }, {
+        "id": "3617",
+        "name": "Chaos Mage Devon of the Citadel"
+    }, {
+        "id": "3619",
+        "name": "Shadow Mage Lumos of the Citadel"
+    }, {
+        "id": "3811",
+        "name": "Sky Master Hank of the Citadel"
+    }, {
+        "id": "3818",
+        "name": "Voodoo Priest Edward of the Citadel"
+    }, {
+        "id": "3854",
+        "name": "Thaumaturge Celah of the Citadel"
+    }, {
+        "id": "3866",
+        "name": "Archmagus Lumos of the Citadel"
+    }, {
+        "id": "4225",
+        "name": "Arch-Magician Aleister of the Citadel"
+    }, {
+        "id": "4283",
+        "name": "Transmuter Gogol of the Citadel"
+    }, {
+        "id": "4315",
+        "name": "Artificer Misumi of the Citadel"
+    }, {
+        "id": "4425",
+        "name": "Summoner Jig of the Citadel"
+    }, {
+        "id": "4432",
+        "name": "Lux of the Citadel"
+    }, {
+        "id": "4439",
+        "name": "Hedge Wizard Baird of the Citadel"
+    }, {
+        "id": "4492",
+        "name": "Shaman Ilyas of the Citadel"
+    }, {
+        "id": "4566",
+        "name": "Magus Kazud of the Citadel"
+    }, {
+        "id": "4570",
+        "name": "Archmagus Oberon of the Citadel"
+    }, {
+        "id": "4588",
+        "name": "Magus Misumi of the Citadel"
+    }, {
+        "id": "4619",
+        "name": "Archmagus Adium of the Citadel"
+    }, {
+        "id": "4634",
+        "name": "Battle Mage Wolfram of the Citadel"
+    }, {
+        "id": "4912",
+        "name": "Voodoo Priest Auguste of the Citadel"
+    }, {
+        "id": "5198",
+        "name": "Archmagus David of the Citadel"
+    }, {
+        "id": "5282",
+        "name": "Chronomancer Goliath of the Citadel"
+    }, {
+        "id": "5314",
+        "name": "Arcanist Hobbs of the Citadel"
+    }, {
+        "id": "5419",
+        "name": "Diabolist Nori of the Citadel"
+    }, {
+        "id": "5475",
+        "name": "Bard Zagan of the Citadel"
+    }, {
+        "id": "5507",
+        "name": "Conjurer Lucien of the Citadel"
+    }, {
+        "id": "5645",
+        "name": "Azahl of the Citadel"
+    }, {
+        "id": "5786",
+        "name": "Battle Mage Hagar of the Citadel"
+    }, {
+        "id": "5927",
+        "name": "Wild Mage Kingsley of the Citadel"
+    }, {
+        "id": "5930",
+        "name": "Enchanter Davos of the Citadel"
+    }, {
+        "id": "5958",
+        "name": "Conjurer Aiko of the Citadel"
+    }, {
+        "id": "6022",
+        "name": "Enchanter Hadrien of the Citadel"
+    }, {
+        "id": "6255",
+        "name": "Artificer Impy of the Citadel"
+    }, {
+        "id": "6268",
+        "name": "Voodoo Priest Hugo of the Citadel"
+    }, {
+        "id": "6280",
+        "name": "Vampyre Vlad of the Citadel"
+    }, {
+        "id": "6318",
+        "name": "Ghost Eater Setsuko of the Citadel"
+    }, {
+        "id": "6323",
+        "name": "Enchanter Cassiopeia of the Citadel"
+    }, {
+        "id": "6472",
+        "name": "Thaumaturge Lucien of the Citadel"
+    }, {
+        "id": "6672",
+        "name": "Alchemist Uvlius of the Citadel"
+    }, {
+        "id": "6790",
+        "name": "Archmagus Lumos of the Citadel"
+    }, {
+        "id": "6798",
+        "name": "Charmer Calista of the Citadel"
+    }, {
+        "id": "7034",
+        "name": "Archmagus Pumlo of the Citadel"
+    }, {
+        "id": "7149",
+        "name": "Sage Thor of the Citadel"
+    }, {
+        "id": "7270",
+        "name": "Archmagus Oberon of the Citadel"
+    }, {
+        "id": "7276",
+        "name": "Archmagus Oxnard of the Citadel"
+    }, {
+        "id": "7300",
+        "name": "Archmagus Ozohr of the Citadel"
+    }, {
+        "id": "7357",
+        "name": "Apollo of the Citadel"
+    }, {
+        "id": "7392",
+        "name": "Holy Monk Sisk of the Citadel"
+    }, {
+        "id": "7791",
+        "name": "Battle Mage Ulysse of the Citadel"
+    }, {
+        "id": "7929",
+        "name": "Alchemist Alessar of the Citadel"
+    }, {
+        "id": "7958",
+        "name": "Alchemist Merlon of the Citadel"
+    }, {
+        "id": "7974",
+        "name": "Alchemist Luther of the Citadel"
+    }, {
+        "id": "8002",
+        "name": "Asphodel of the Citadel"
+    }, {
+        "id": "8013",
+        "name": "Zubin of the Citadel"
+    }, {
+        "id": "8030",
+        "name": "Archmagus Asphodel of the Citadel"
+    }, {
+        "id": "8096",
+        "name": "Thaumaturge Ixar of the Citadel"
+    }, {
+        "id": "8181",
+        "name": "Archmagus Lumos of the Citadel"
+    }, {
+        "id": "8388",
+        "name": "Archmagus Allistair of the Citadel"
+    }, {
+        "id": "8541",
+        "name": "Witch Rowena of the Citadel"
+    }, {
+        "id": "8546",
+        "name": "Archmagus Soya of the Citadel"
+    }, {
+        "id": "8652",
+        "name": "Ghost Eater Zagan of the Citadel"
+    }, {
+        "id": "8792",
+        "name": "Hedge Wizard Calypso of the Citadel"
+    }, {
+        "id": "8811",
+        "name": "Cosmic Mage Azahl of the Citadel"
+    }, {
+        "id": "8833",
+        "name": "Archmagus Ravana of the Citadel"
+    }, {
+        "id": "9096",
+        "name": "Sorcerer Jeldor of the Citadel"
+    }, {
+        "id": "9171",
+        "name": "Sage Solomon of the Citadel"
+    }, {
+        "id": "9232",
+        "name": "Charmer Astrid of the Citadel"
+    }, {
+        "id": "9274",
+        "name": "Sorcerer Uday of the Citadel"
+    }, {
+        "id": "9286",
+        "name": "Arch-Magician Corvin of the Citadel"
+    }, {
+        "id": "9448",
+        "name": "Druid Kalo of the Citadel"
+    }, {
+        "id": "9650",
+        "name": "Archmagus Zelroth of the Citadel"
+    }, {
+        "id": "9658",
+        "name": "Magus Rita of the Citadel"
+    }, {
+        "id": "9670",
+        "name": "Druid Setsuko of the Citadel"
+    }, {
+        "id": "9804",
+        "name": "Soya of the Citadel"
+    }, {
+        "id": "9908",
+        "name": "Arch-Magician Louis of the Citadel"
+    }],
+    "Undead": [{
+        "id": "6854",
+        "name": "Hedge Wizard Pandora of the Undead"
+    }],
+    "Belfry": [{
+        "id": "212",
+        "name": "Archmagus Samuel of the Belfry"
+    }, {
+        "id": "262",
+        "name": "Archmagus Ethan of the Belfry"
+    }, {
+        "id": "296",
+        "name": "Runecaster Asmodeus of the Belfry"
+    }, {
+        "id": "460",
+        "name": "Arcanist Eden of the Belfry"
+    }, {
+        "id": "533",
+        "name": "Hedge Wizard Alatar of the Belfry"
+    }, {
+        "id": "558",
+        "name": "Clairvoyant Titania of the Belfry"
+    }, {
+        "id": "741",
+        "name": "Archmagus Solomon of the Belfry"
+    }, {
+        "id": "1517",
+        "name": "Sorcerer Alessar of the Belfry"
+    }, {
+        "id": "1559",
+        "name": "Mystic Otto of the Belfry"
+    }, {
+        "id": "2045",
+        "name": "Atlanta of the Belfry"
+    }, {
+        "id": "2068",
+        "name": "Thaumaturge Eden of the Belfry"
+    }, {
+        "id": "2125",
+        "name": "Shaman Homer of the Belfry"
+    }, {
+        "id": "2167",
+        "name": "Battle Mage Nicolas of the Belfry"
+    }, {
+        "id": "2557",
+        "name": "Runecaster Homer of the Belfry"
+    }, {
+        "id": "2718",
+        "name": "Chaos Mage George of the Belfry"
+    }, {
+        "id": "2887",
+        "name": "Diabolist Rowena of the Belfry"
+    }, {
+        "id": "2919",
+        "name": "Oracle Bayard of the Belfry"
+    }, {
+        "id": "3158",
+        "name": "Ghost Eater Lucinda of the Belfry"
+    }, {
+        "id": "3708",
+        "name": "Alchemist Casper of the Belfry"
+    }, {
+        "id": "3827",
+        "name": "Witch Faiz of the Belfry"
+    }, {
+        "id": "3916",
+        "name": "Battle Mage Baird of the Belfry"
+    }, {
+        "id": "4031",
+        "name": "Shaman Nicolas of the Belfry"
+    }, {
+        "id": "4069",
+        "name": "Geomancer Goliath of the Belfry"
+    }, {
+        "id": "4281",
+        "name": "Adept Basil of the Belfry"
+    }, {
+        "id": "4346",
+        "name": "Hedge Wizard Voidoth of the Belfry"
+    }, {
+        "id": "4347",
+        "name": "Thana of the Belfry"
+    }, {
+        "id": "4488",
+        "name": "Conjurer Larissa of the Belfry"
+    }, {
+        "id": "4617",
+        "name": "Shaman Caligula of the Belfry"
+    }, {
+        "id": "4715",
+        "name": "Sorcerer Jiang of the Belfry"
+    }, {
+        "id": "4983",
+        "name": "Arch-Magician Impy of the Belfry"
+    }, {
+        "id": "5434",
+        "name": "Artificer Herne of the Belfry"
+    }, {
+        "id": "5561",
+        "name": "Hedge Wizard Argus of the Belfry"
+    }, {
+        "id": "5649",
+        "name": "Arcanist Asphodel of the Belfry"
+    }, {
+        "id": "5697",
+        "name": "Geomancer Florah of the Belfry"
+    }, {
+        "id": "5745",
+        "name": "Mystic Wolfram of the Belfry"
+    }, {
+        "id": "6104",
+        "name": "Sorcerer Ozohr of the Belfry"
+    }, {
+        "id": "6521",
+        "name": "Witch Shivra of the Belfry"
+    }, {
+        "id": "6576",
+        "name": "Battle Mage Aslan of the Belfry"
+    }, {
+        "id": "6599",
+        "name": "Cryptomancer Milton of the Belfry"
+    }, {
+        "id": "6730",
+        "name": "Illusionist Uvlius of the Belfry"
+    }, {
+        "id": "6878",
+        "name": "Archmagus Ofaris of the Belfry"
+    }, {
+        "id": "7161",
+        "name": "Hedge Wizard Zeromus of the Belfry"
+    }, {
+        "id": "7359",
+        "name": "Artificer Danny of the Belfry"
+    }, {
+        "id": "7366",
+        "name": "Druid Jerret of the Belfry"
+    }, {
+        "id": "7594",
+        "name": "Enchanter Mina of the Belfry"
+    }, {
+        "id": "7740",
+        "name": "Sorcerer Amir of the Belfry"
+    }, {
+        "id": "7800",
+        "name": "Hex Mage Merlon of the Belfry"
+    }, {
+        "id": "7937",
+        "name": "Necromancer Hadrien of the Belfry"
+    }, {
+        "id": "7971",
+        "name": "Shadow Mage Sarah of the Belfry"
+    }, {
+        "id": "8043",
+        "name": "Archmagus  of the Belfry"
+    }, {
+        "id": "8137",
+        "name": "Archmagus Adium of the Belfry"
+    }, {
+        "id": "8245",
+        "name": "Battle Mage Hagar of the Belfry"
+    }, {
+        "id": "8552",
+        "name": "Druid Shivra of the Belfry"
+    }, {
+        "id": "8638",
+        "name": "Archmagus Salah of the Belfry"
+    }, {
+        "id": "8674",
+        "name": "Witch Shivra of the Belfry"
+    }, {
+        "id": "8675",
+        "name": "Battlemage Aleister of the Belfry"
+    }, {
+        "id": "8774",
+        "name": "Ghost Eater Eizo of the Belfry"
+    }, {
+        "id": "8958",
+        "name": "Chronomancer Cedric of the Belfry"
+    }, {
+        "id": "9196",
+        "name": "Necromancer Anton of the Belfry"
+    }, {
+        "id": "9199",
+        "name": "Artificer Artis of the Belfry"
+    }, {
+        "id": "9258",
+        "name": "Sky Master Jay of the Belfry"
+    }, {
+        "id": "9483",
+        "name": "Battle Mage Brutus of the Belfry"
+    }, {
+        "id": "9492",
+        "name": "Archmagus Hadrien of the Belfry"
+    }, {
+        "id": "9531",
+        "name": "Aldus of the Belfry"
+    }, {
+        "id": "9567",
+        "name": "Pyromancer Abaddon of the Belfry"
+    }, {
+        "id": "9609",
+        "name": "Alchemist Gunthor of the Belfry"
+    }, {
+        "id": "9751",
+        "name": "Archmagus Zaros of the Belfry"
+    }, {
+        "id": "9850",
+        "name": "Scorch of the Belfry"
+    }],
+    "Alfheim": [{
+        "id": "350",
+        "name": "George of Alfheim"
+    }, {
+        "id": "405",
+        "name": "Larissa of Alfheim"
+    }, {
+        "id": "411",
+        "name": "Conjurer Alessar of Alfheim"
+    }, {
+        "id": "903",
+        "name": "Druid Anton of Alfheim"
+    }, {
+        "id": "913",
+        "name": "Battle Mage Danny of Alfheim"
+    }, {
+        "id": "1017",
+        "name": "Arch-Magician Ulysse of Alfheim"
+    }, {
+        "id": "1244",
+        "name": "Enchanter Pandora of Alfheim"
+    }, {
+        "id": "2476",
+        "name": "Archmagus Ixar of Alfheim"
+    }, {
+        "id": "2940",
+        "name": "Magus Herne of Alfheim"
+    }, {
+        "id": "3216",
+        "name": "Sorcerer Cairon of Alfheim"
+    }, {
+        "id": "3526",
+        "name": "Arch-Magician Froggy of Alfheim"
+    }, {
+        "id": "3599",
+        "name": "Alchemist Xerxes of Alfheim"
+    }, {
+        "id": "3649",
+        "name": "Sage Hansel of Alfheim"
+    }, {
+        "id": "4614",
+        "name": "Enchanter Arabella of Alfheim"
+    }, {
+        "id": "5183",
+        "name": "Archmagus Apollo of Alfheim"
+    }, {
+        "id": "5732",
+        "name": "Alchemist Sharx of Alfheim"
+    }, {
+        "id": "6412",
+        "name": "Hex Mage Jean Leon of Alfheim"
+    }, {
+        "id": "6849",
+        "name": "Archmagus Pumlo of Alfheim"
+    }, {
+        "id": "6879",
+        "name": "Enchanter Thana of Alfheim"
+    }, {
+        "id": "6958",
+        "name": "Electromancer Angus of Alfheim"
+    }, {
+        "id": "7386",
+        "name": "Archmagus Iprix of Alfheim"
+    }, {
+        "id": "7390",
+        "name": "Shaman Jasper of Alfheim"
+    }, {
+        "id": "7530",
+        "name": "Battle Mage Atlas of Alfheim"
+    }, {
+        "id": "7657",
+        "name": "Archmagus Zhan of Alfheim"
+    }, {
+        "id": "7795",
+        "name": "Conjurer Sondra of Alfheim"
+    }, {
+        "id": "7975",
+        "name": "Hedge Wizard Impy of Alfheim"
+    }, {
+        "id": "8538",
+        "name": "Holy Monk Chandler of Alfheim"
+    }, {
+        "id": "8647",
+        "name": "Hedge Wizard Lavinia of Alfheim"
+    }, {
+        "id": "9413",
+        "name": "Archmagus Zubin of Alfheim"
+    }, {
+        "id": "9806",
+        "name": "Enchanter Calliope of Alfheim"
+    }],
+    "Veil": [{
+        "id": "145",
+        "name": "Cryptomancer Blaise of the Veil"
+    }, {
+        "id": "164",
+        "name": "Archmagus Pumlo of the Veil"
+    }, {
+        "id": "188",
+        "name": "Alchemist Fark of the Veil"
+    }, {
+        "id": "298",
+        "name": "Illusionist Pozzik of the Veil"
+    }, {
+        "id": "363",
+        "name": "Magus Raul of the Veil"
+    }, {
+        "id": "557",
+        "name": "Spellsinger Magnus of the Veil"
+    }, {
+        "id": "612",
+        "name": "Witch Ambrosia of the Veil"
+    }, {
+        "id": "667",
+        "name": "Void Disciple Voidoth of the Veil"
+    }, {
+        "id": "707",
+        "name": "Magus Zorko of the Veil"
+    }, {
+        "id": "780",
+        "name": "Diviner Jahid of the Veil"
+    }, {
+        "id": "890",
+        "name": "Mystic JackDaw of the Veil"
+    }, {
+        "id": "948",
+        "name": "Runecaster Davos of the Veil"
+    }, {
+        "id": "965",
+        "name": "Necromancer Voidoth of the Veil"
+    }, {
+        "id": "1051",
+        "name": "Eden of the Veil"
+    }, {
+        "id": "1053",
+        "name": "Aeromancer Ixar of the Veil"
+    }, {
+        "id": "1251",
+        "name": "Mystic Milo of the Veil"
+    }, {
+        "id": "1257",
+        "name": "Archmagus Uvlius of the Veil"
+    }, {
+        "id": "1288",
+        "name": "Archmagus Bane of the Veil"
+    }, {
+        "id": "1370",
+        "name": "Bard Gogol of the Veil"
+    }, {
+        "id": "1385",
+        "name": "Enchanter Maia of the Veil"
+    }, {
+        "id": "1497",
+        "name": "Necromancer Diabolos of the Veil"
+    }, {
+        "id": "1510",
+        "name": "Runecaster Ofaris of the Veil"
+    }, {
+        "id": "1896",
+        "name": "Alchemist Hagar of the Veil"
+    }, {
+        "id": "1905",
+        "name": "Battle Mage Malthus of the Veil"
+    }, {
+        "id": "1968",
+        "name": "Witch Imeena of the Veil"
+    }, {
+        "id": "2046",
+        "name": "Hedge Wizard Aslan of the Veil"
+    }, {
+        "id": "2070",
+        "name": "Artificer Crowley of the Veil"
+    }, {
+        "id": "2224",
+        "name": "Archmagus Uvlius of the Veil"
+    }, {
+        "id": "2228",
+        "name": "Magus Taqi of the Veil"
+    }, {
+        "id": "2287",
+        "name": "Hedge Wizard Hind of the Veil"
+    }, {
+        "id": "2341",
+        "name": "Void Disciple Arcus of the Veil"
+    }, {
+        "id": "2350",
+        "name": "Cleric Silas of the Veil"
+    }, {
+        "id": "2387",
+        "name": "Alchemist Cassiopeia of the Veil"
+    }, {
+        "id": "2475",
+        "name": "Artificer Pix of the Veil"
+    }, {
+        "id": "2498",
+        "name": "Hedge Wizard Onaxx of the Veil"
+    }, {
+        "id": "2561",
+        "name": "Alchemist Godfrey of the Veil"
+    }, {
+        "id": "2568",
+        "name": "Charmer Daphne of the Veil"
+    }, {
+        "id": "2613",
+        "name": "Void Disciple Juniper of the Veil"
+    }, {
+        "id": "2663",
+        "name": "Arcanist Juniper of the Veil"
+    }, {
+        "id": "2730",
+        "name": "Arcanist Celah of the Veil"
+    }, {
+        "id": "2779",
+        "name": "Sorcerer Oberon of the Veil"
+    }, {
+        "id": "2852",
+        "name": "Adept Crowley of the Veil"
+    }, {
+        "id": "2963",
+        "name": "Archmagus Crowley of the Veil"
+    }, {
+        "id": "3008",
+        "name": "Illusionist Celah of the Veil"
+    }, {
+        "id": "3044",
+        "name": "Althea of the Veil"
+    }, {
+        "id": "3083",
+        "name": "Archmagus Soya of the Veil"
+    }, {
+        "id": "3118",
+        "name": "Sorcerer Oberon of the Veil"
+    }, {
+        "id": "3171",
+        "name": "Archmagus Celah of the Veil"
+    }, {
+        "id": "3287",
+        "name": "Scryer Numpty of the Veil"
+    }, {
+        "id": "3395",
+        "name": "Battle Mage Finn of the Veil"
+    }, {
+        "id": "3451",
+        "name": "Artificer Moloch of the Veil"
+    }, {
+        "id": "3466",
+        "name": "Battle Mage Otto of the Veil"
+    }, {
+        "id": "3538",
+        "name": "Arcanist Bartholomew of the Veil"
+    }, {
+        "id": "3574",
+        "name": "Ghost Eater Udor of the Veil"
+    }, {
+        "id": "3605",
+        "name": "Archmagus Casper of the Veil"
+    }, {
+        "id": "3737",
+        "name": "Hedge Wizard Luther of the Veil"
+    }, {
+        "id": "3802",
+        "name": "Archmagus Iris of the Veil"
+    }, {
+        "id": "3938",
+        "name": "Sorcerer Davos of the Veil"
+    }, {
+        "id": "3975",
+        "name": "Sorcerer Harley of the Veil"
+    }, {
+        "id": "4043",
+        "name": "Sky Master Corvin of the Veil"
+    }, {
+        "id": "4148",
+        "name": "Chronomancer Taqi of the Veil"
+    }, {
+        "id": "4149",
+        "name": "Cleric Ramiz of the Veil"
+    }, {
+        "id": "4170",
+        "name": "Void Disciple Moloch of the Veil"
+    }, {
+        "id": "4237",
+        "name": "Enchanter Bolin of the Veil"
+    }, {
+        "id": "4243",
+        "name": "Arch-Magician Ulysse of the Veil"
+    }, {
+        "id": "4250",
+        "name": "Necromancer Impy of the Veil"
+    }, {
+        "id": "4323",
+        "name": "Adept Bogey of the Veil"
+    }, {
+        "id": "4424",
+        "name": "Battle Mage Borak of the Veil"
+    }, {
+        "id": "4548",
+        "name": "Arcanist Alizam of the Veil"
+    }, {
+        "id": "5035",
+        "name": "Wizard Huizhong of the Veil"
+    }, {
+        "id": "5090",
+        "name": "Hex Mage Hellspawn of the Veil"
+    }, {
+        "id": "5151",
+        "name": "Alessar of the Veil"
+    }, {
+        "id": "5157",
+        "name": "Archmagus Alessar of the Veil"
+    }, {
+        "id": "5167",
+        "name": "Orpheus of the Veil"
+    }, {
+        "id": "5263",
+        "name": "Isaac of the Veil"
+    }, {
+        "id": "5274",
+        "name": "Enchanter Bathsheba of the Veil"
+    }, {
+        "id": "5298",
+        "name": "Magus Nazim of the Veil"
+    }, {
+        "id": "5302",
+        "name": "Artificer Milton of the Veil"
+    }, {
+        "id": "5380",
+        "name": "Conjurer Allistair of the Veil"
+    }, {
+        "id": "5420",
+        "name": "Druid Blaise of the Veil"
+    }, {
+        "id": "5532",
+        "name": "Magus Alizam of the Veil"
+    }, {
+        "id": "5602",
+        "name": "Magus Mad Apple of the Veil"
+    }, {
+        "id": "5647",
+        "name": "Sorcerer Nazim of the Veil"
+    }, {
+        "id": "5960",
+        "name": "Alchemist Helix of the Veil"
+    }, {
+        "id": "5971",
+        "name": "Spellsinger Hecate of the Veil"
+    }, {
+        "id": "5992",
+        "name": "Magus Nazim of the Veil"
+    }, {
+        "id": "6095",
+        "name": "Spellsinger Eric of the Veil"
+    }, {
+        "id": "6153",
+        "name": "Archmagus Pandora of the Veil"
+    }, {
+        "id": "6199",
+        "name": "Cryptomancer Gil of the Veil"
+    }, {
+        "id": "6211",
+        "name": "Hex Mage Chaos of the Veil"
+    }, {
+        "id": "6372",
+        "name": "Illusionist David of the Veil"
+    }, {
+        "id": "6527",
+        "name": "Runecaster Eden of the Veil"
+    }, {
+        "id": "6635",
+        "name": "Wild Mage Angus of the Veil"
+    }, {
+        "id": "6693",
+        "name": "Runecaster Hagar of the Veil"
+    }, {
+        "id": "6829",
+        "name": "Witch Marceline of the Veil"
+    }, {
+        "id": "6845",
+        "name": "Holy Magus Illuminus of the Veil"
+    }, {
+        "id": "6867",
+        "name": "Charmer Beyna of the Veil"
+    }, {
+        "id": "7009",
+        "name": "Wild Mage Blaise of the Veil"
+    }, {
+        "id": "7173",
+        "name": "Archmagus Celah of the Veil"
+    }, {
+        "id": "7255",
+        "name": "Sorcerer Faiz of the Veil"
+    }, {
+        "id": "7298",
+        "name": "Hedge Wizard Aleister of the Veil"
+    }, {
+        "id": "7501",
+        "name": "Void Disciple Thoth of the Veil"
+    }, {
+        "id": "7536",
+        "name": "Adept Cairon of the Veil"
+    }, {
+        "id": "7609",
+        "name": "Eden of the Veil"
+    }, {
+        "id": "7632",
+        "name": "Hex Mage Basil of the Veil"
+    }, {
+        "id": "7641",
+        "name": "Aeromancer Oberon of the Veil"
+    }, {
+        "id": "7688",
+        "name": "Sorcerer David of the Veil"
+    }, {
+        "id": "7692",
+        "name": "Shaman Koop of the Veil"
+    }, {
+        "id": "7739",
+        "name": "Sondra of the Veil"
+    }, {
+        "id": "7927",
+        "name": "Illusionist Solomon of the Veil"
+    }, {
+        "id": "7931",
+        "name": "Spellsinger Oberon of the Veil"
+    }, {
+        "id": "8066",
+        "name": "Archmagus Pezo of the Veil"
+    }, {
+        "id": "8121",
+        "name": "Alchemist Cromwell of the Veil"
+    }, {
+        "id": "8166",
+        "name": "Milo of the Veil"
+    }, {
+        "id": "8250",
+        "name": "Archmagus Allistair of the Veil"
+    }, {
+        "id": "8277",
+        "name": "Necromancer Abbadon of the Veil"
+    }, {
+        "id": "8298",
+        "name": "Enchanter Wolfram of the Veil"
+    }, {
+        "id": "8315",
+        "name": "Druid Zaros of the Veil"
+    }, {
+        "id": "8519",
+        "name": "Charmer Katherine of the Veil"
+    }, {
+        "id": "8649",
+        "name": "Archmagus Aleister of the Veil"
+    }, {
+        "id": "8718",
+        "name": "Archmagus Merlon of the Veil"
+    }, {
+        "id": "8815",
+        "name": "Cartomancer Idris of the Veil"
+    }, {
+        "id": "9125",
+        "name": "Artificer Apollo of the Veil"
+    }, {
+        "id": "9165",
+        "name": "Arcanist Aldo of the Veil"
+    }, {
+        "id": "9185",
+        "name": "Summoner Magpie of the Veil"
+    }, {
+        "id": "9187",
+        "name": "Spellsinger Mina of the Veil"
+    }, {
+        "id": "9220",
+        "name": "Enchanter Astrid of the Veil"
+    }, {
+        "id": "9367",
+        "name": "Artificer Amanita of the Veil"
+    }, {
+        "id": "9519",
+        "name": "Ofaris of the Veil"
+    }, {
+        "id": "9541",
+        "name": "Void Disciple Seth of the Veil"
+    }, {
+        "id": "9688",
+        "name": "Magus Jahid of the Veil"
+    }, {
+        "id": "9708",
+        "name": "Magus Jabir of the Veil"
+    }, {
+        "id": "9715",
+        "name": "Lumos of the Veil"
+    }, {
+        "id": "9718",
+        "name": "Geomancer Ratko of the Veil"
+    }],
+    "Shadows": [{
+        "id": "146",
+        "name": "Allistair in the Shadows"
+    }, {
+        "id": "528",
+        "name": "Shaman Beyna in the Shadows"
+    }, {
+        "id": "567",
+        "name": "Mystic Pix in the Shadows"
+    }, {
+        "id": "599",
+        "name": "Shaman Aleister in the Shadows"
+    }, {
+        "id": "708",
+        "name": "Archmagus Milo in the Shadows"
+    }, {
+        "id": "892",
+        "name": "Archmagus Ixar in the Shadows"
+    }, {
+        "id": "897",
+        "name": "Sorcerer Alatar in the Shadows"
+    }, {
+        "id": "914",
+        "name": "Druid Soya in the Shadows"
+    }, {
+        "id": "1102",
+        "name": "Archmagus Poppy in the Shadows"
+    }, {
+        "id": "1111",
+        "name": "Archmagus Lumos in the Shadows"
+    }, {
+        "id": "1330",
+        "name": "Archmagus Ixar in the Shadows"
+    }, {
+        "id": "1893",
+        "name": "Shadow Mage Tenguyama in the Shadows"
+    }, {
+        "id": "2107",
+        "name": "Hedge Wizard Cybele in the Shadows"
+    }, {
+        "id": "2529",
+        "name": "Arcanist Hobbs in the Shadows"
+    }, {
+        "id": "2755",
+        "name": "Battle Mage Eric in the Shadows"
+    }, {
+        "id": "2872",
+        "name": "Chaos Mage Thoth in the Shadows"
+    }, {
+        "id": "2890",
+        "name": "Battlemage Eizo in the Shadows"
+    }, {
+        "id": "2917",
+        "name": "Archmagus Amir in the Shadows"
+    }, {
+        "id": "2977",
+        "name": "Pyromancer Crowley in the Shadows"
+    }, {
+        "id": "3154",
+        "name": "Archmagus Ixar in the Shadows"
+    }, {
+        "id": "3210",
+        "name": "Archmagus Ixar in the Shadows"
+    }, {
+        "id": "3232",
+        "name": "Void Disciple Azahl in the Shadows"
+    }, {
+        "id": "3273",
+        "name": "Archmagus Nikolas in the Shadows"
+    }, {
+        "id": "3711",
+        "name": "Mystic Apollo in the Shadows"
+    }, {
+        "id": "3753",
+        "name": "Aeromancer Willow in the Shadows"
+    }, {
+        "id": "3793",
+        "name": "Archmagus Apollo in the Shadows"
+    }, {
+        "id": "3828",
+        "name": "Alchemist Crackerjack in the Shadows"
+    }, {
+        "id": "4122",
+        "name": "Sage Argus in the Shadows"
+    }, {
+        "id": "4594",
+        "name": "Cleric Kobold in the Shadows"
+    }, {
+        "id": "4759",
+        "name": "Illusionist Celah in the Shadows"
+    }, {
+        "id": "4895",
+        "name": "Archmagus Nikolas in the Shadows"
+    }, {
+        "id": "4915",
+        "name": "Illusionist Aslan in the Shadows"
+    }, {
+        "id": "4950",
+        "name": "Archmagus Mace in the Shadows"
+    }, {
+        "id": "4998",
+        "name": "Archmagus Orlando in the Shadows"
+    }, {
+        "id": "5308",
+        "name": "Witch Jahid in the Shadows"
+    }, {
+        "id": "5368",
+        "name": "Ghost Eater Aamon in the Shadows"
+    }, {
+        "id": "5489",
+        "name": "Chronomancer Eden in the Shadows"
+    }, {
+        "id": "5613",
+        "name": "Sky Master Corvin in the Shadows"
+    }, {
+        "id": "5636",
+        "name": "Sorcerer Uvlius in the Shadows"
+    }, {
+        "id": "5839",
+        "name": "Sorcerer Alizam in the Shadows"
+    }, {
+        "id": "5859",
+        "name": "Necromancer Voidoth in the Shadows"
+    }, {
+        "id": "5970",
+        "name": "Magus Argus in the Shadows"
+    }, {
+        "id": "6097",
+        "name": "Magus Uur'lok in the Shadows"
+    }, {
+        "id": "6451",
+        "name": "Transmuter Casper in the Shadows"
+    }, {
+        "id": "6761",
+        "name": "Necromancer Billy in the Shadows"
+    }, {
+        "id": "7030",
+        "name": "Shadow Mage Oxnard in the Shadows"
+    }, {
+        "id": "7418",
+        "name": "Arch-Magician Aldus in the Shadows"
+    }, {
+        "id": "7658",
+        "name": "Hex Mage Magpie in the Shadows"
+    }, {
+        "id": "7799",
+        "name": "Sage Ulysse in the Shadows"
+    }, {
+        "id": "7871",
+        "name": "Shaman Faiz in the Shadows"
+    }, {
+        "id": "7926",
+        "name": "Archmagus Azahl in the Shadows"
+    }, {
+        "id": "8017",
+        "name": "Archmagus Solomon in the Shadows"
+    }, {
+        "id": "8094",
+        "name": "Arch-Magician Bogey in the Shadows"
+    }, {
+        "id": "8144",
+        "name": "Void Disciple Voidoth in the Shadows"
+    }, {
+        "id": "8202",
+        "name": "Alchemist Casper in the Shadows"
+    }, {
+        "id": "8296",
+        "name": "Archmagus Jeldor in the Shadows"
+    }, {
+        "id": "8364",
+        "name": "Archmagus Apollo in the Shadows"
+    }, {
+        "id": "8469",
+        "name": "Witch Lenora in the Shadows"
+    }, {
+        "id": "8722",
+        "name": "Sky Master Corvin in the Shadows"
+    }, {
+        "id": "8841",
+        "name": "Archmagus Lumos in the Shadows"
+    }, {
+        "id": "9248",
+        "name": "Summoner Kazem in the Shadows"
+    }, {
+        "id": "9404",
+        "name": "Archmagus Merlon in the Shadows"
+    }, {
+        "id": "9612",
+        "name": "Archmagus Milton in the Shadows"
+    }, {
+        "id": "9613",
+        "name": "Evoker Zane in the Shadows"
+    }, {
+        "id": "9643",
+        "name": "Arcanist Gwendolin in the Shadows"
+    }, {
+        "id": "9928",
+        "name": "Druid Lumos in the Shadows"
+    }],
+    "Carnival": [{
+        "id": "139",
+        "name": "Archmagus George of the Carnival"
+    }, {
+        "id": "525",
+        "name": "Sage Rita of the Carnival"
+    }, {
+        "id": "863",
+        "name": "Mystic Nicolas of the Carnival"
+    }, {
+        "id": "977",
+        "name": "Alchemist Ulthar of the Carnival"
+    }, {
+        "id": "1122",
+        "name": "Magus Robert of the Carnival"
+    }, {
+        "id": "1186",
+        "name": "Battle Mage Angus of the Carnival"
+    }, {
+        "id": "1247",
+        "name": "Diabolist Ivy of the Carnival"
+    }, {
+        "id": "2329",
+        "name": "Shaman Angus of the Carnival"
+    }, {
+        "id": "2377",
+        "name": "Archmagus Aldus of the Carnival"
+    }, {
+        "id": "2873",
+        "name": "Enchanter Le Blanc of the Carnival"
+    }, {
+        "id": "3052",
+        "name": "Adept Corky of the Carnival"
+    }, {
+        "id": "3247",
+        "name": "Magus Lamia of the Carnival"
+    }, {
+        "id": "3285",
+        "name": "Adept Aleister of the Carnival"
+    }, {
+        "id": "3322",
+        "name": "Archmagus Solomon of the Carnival"
+    }, {
+        "id": "3758",
+        "name": "Evoker Magnus of the Carnival"
+    }, {
+        "id": "3788",
+        "name": "Archmagus Apollo of the Carnival"
+    }, {
+        "id": "4495",
+        "name": "Cassiopeia of the Carnival"
+    }, {
+        "id": "4676",
+        "name": "Illusionist Thana of the Carnival"
+    }, {
+        "id": "4712",
+        "name": "Cryptomancer Woomba of the Carnival"
+    }, {
+        "id": "4770",
+        "name": "Charmer Adrienne of the Carnival"
+    }, {
+        "id": "5075",
+        "name": "Magus Nolan of the Carnival"
+    }, {
+        "id": "5448",
+        "name": "Shaman Goober of the Carnival"
+    }, {
+        "id": "6008",
+        "name": "Runecaster Aleister of the Carnival"
+    }, {
+        "id": "6044",
+        "name": "Hedge Wizard Dotta of the Carnival"
+    }, {
+        "id": "6092",
+        "name": "Witch Orpheus of the Carnival"
+    }, {
+        "id": "6093",
+        "name": "Voodoo Priest Auguste of the Carnival"
+    }, {
+        "id": "6164",
+        "name": "Sorcerer Kamil of the Carnival"
+    }, {
+        "id": "6446",
+        "name": "Archmagus Remus of the Carnival"
+    }, {
+        "id": "6537",
+        "name": "Arcanist Goliath of the Carnival"
+    }, {
+        "id": "6670",
+        "name": "Chronomancer Lux of the Carnival"
+    }, {
+        "id": "6851",
+        "name": "Witch Rita of the Carnival"
+    }, {
+        "id": "7232",
+        "name": "Battlemage Ursula of the Carnival"
+    }, {
+        "id": "7503",
+        "name": "Alchemist Muntjac of the Carnival"
+    }, {
+        "id": "7784",
+        "name": "Adept Gunthor of the Carnival"
+    }, {
+        "id": "7944",
+        "name": "Magus Alizam of the Carnival"
+    }, {
+        "id": "7984",
+        "name": "Battle Mage Khudalf of the Carnival"
+    }, {
+        "id": "8136",
+        "name": "Mystic Ilyas of the Carnival"
+    }, {
+        "id": "8220",
+        "name": "Archmagus Jerret of the Carnival"
+    }, {
+        "id": "8246",
+        "name": "Artificer Jasper of the Carnival"
+    }, {
+        "id": "8386",
+        "name": "Battle Mage Blaise of the Carnival"
+    }, {
+        "id": "8712",
+        "name": "Witch Rita of the Carnival"
+    }, {
+        "id": "9089",
+        "name": "Sorcerer Ramiz of the Carnival"
+    }, {
+        "id": "9093",
+        "name": "Arcanist Ulysse of the Carnival"
+    }, {
+        "id": "9737",
+        "name": "Magus Chooki of the Carnival"
+    }, {
+        "id": "9902",
+        "name": "Summoner Kobold of the Carnival"
+    }],
+    "Keep": [{
+        "id": "48",
+        "name": "Bard Finch of the Keep"
+    }, {
+        "id": "52",
+        "name": "Runecaster Eric of the Keep"
+    }, {
+        "id": "117",
+        "name": "Diabolist Elena of the Keep"
+    }, {
+        "id": "163",
+        "name": "Scryer Milton of the Keep"
+    }, {
+        "id": "218",
+        "name": "Archmagus Orpheus of the Keep"
+    }, {
+        "id": "304",
+        "name": "Archmagus Merlon of the Keep"
+    }, {
+        "id": "349",
+        "name": "Artificer Hanataka of the Keep"
+    }, {
+        "id": "434",
+        "name": "Cosmic Mage Soya of the Keep"
+    }, {
+        "id": "461",
+        "name": "Hedge Wizard Dr. Death of the Keep"
+    }, {
+        "id": "506",
+        "name": "Scorch of the Keep"
+    }, {
+        "id": "559",
+        "name": "Ghost Eater Bartholomew of the Keep"
+    }, {
+        "id": "662",
+        "name": "Archmagus Zaros of the Keep"
+    }, {
+        "id": "664",
+        "name": "Battlemage Caligula of the Keep"
+    }, {
+        "id": "723",
+        "name": "Hydromancer Quddus of the Keep"
+    }, {
+        "id": "734",
+        "name": "Illusionist Qianfan of the Keep"
+    }, {
+        "id": "815",
+        "name": "Adept Jahid of the Keep"
+    }, {
+        "id": "872",
+        "name": "Ghost Eater Jig of the Keep"
+    }, {
+        "id": "936",
+        "name": "Alchemist Amir of the Keep"
+    }, {
+        "id": "940",
+        "name": "Bard Tengu of the Keep"
+    }, {
+        "id": "968",
+        "name": "Sage Axel of the Keep"
+    }, {
+        "id": "988",
+        "name": "Shadow Mage Maia of the Keep"
+    }, {
+        "id": "1015",
+        "name": "Arcanist Toka of the Keep"
+    }, {
+        "id": "1046",
+        "name": "Cosmic Mage Artis of the Keep"
+    }, {
+        "id": "1092",
+        "name": "Archmagus Aleister of the Keep"
+    }, {
+        "id": "1107",
+        "name": "Sage Circe of the Keep"
+    }, {
+        "id": "1116",
+        "name": "Thaumaturge Cassiopeia of the Keep"
+    }, {
+        "id": "1133",
+        "name": "Witch Hagatha of the Keep"
+    }, {
+        "id": "1174",
+        "name": "Hex Mage Casper of the Keep"
+    }, {
+        "id": "1231",
+        "name": "Wild Mage Demos of the Keep"
+    }, {
+        "id": "1237",
+        "name": "Electromancer Fugh of the Keep"
+    }, {
+        "id": "1307",
+        "name": "Conjurer Celah of the Keep"
+    }, {
+        "id": "1340",
+        "name": "Witch Rowena of the Keep"
+    }, {
+        "id": "1358",
+        "name": "Conjurer Udor of the Keep"
+    }, {
+        "id": "1368",
+        "name": "Alchemist Goomer of the Keep"
+    }, {
+        "id": "1390",
+        "name": "Aldus of the Keep"
+    }, {
+        "id": "1470",
+        "name": "Arcanist Sondra of the Keep"
+    }, {
+        "id": "1472",
+        "name": "Archmagus Davos of the Keep"
+    }, {
+        "id": "1484",
+        "name": "Archmagus Burnside of the Keep"
+    }, {
+        "id": "1545",
+        "name": "Shaman Voidoth of the Keep"
+    }, {
+        "id": "1570",
+        "name": "Artificer Reza of the Keep"
+    }, {
+        "id": "1650",
+        "name": "Battle Mage Angus of the Keep"
+    }, {
+        "id": "1668",
+        "name": "Sorcerer Kamil of the Keep"
+    }, {
+        "id": "1690",
+        "name": "Illusionist Milo of the Keep"
+    }, {
+        "id": "1715",
+        "name": "Voodoo Priest Louis of the Keep"
+    }, {
+        "id": "1785",
+        "name": "Archmagus Zorko of the Keep"
+    }, {
+        "id": "1825",
+        "name": "Solar Mage Jean Leon of the Keep"
+    }, {
+        "id": "1934",
+        "name": "Druid Ravana of the Keep"
+    }, {
+        "id": "1948",
+        "name": "Artificer Chandler of the Keep"
+    }, {
+        "id": "1956",
+        "name": "Solar Mage Carly of the Keep"
+    }, {
+        "id": "1985",
+        "name": "Uvlius of the Keep"
+    }, {
+        "id": "2039",
+        "name": "Shaman Jean Leon of the Keep"
+    }, {
+        "id": "2085",
+        "name": "Alchemist Eizo of the Keep"
+    }, {
+        "id": "2133",
+        "name": "Aleister of the Keep"
+    }, {
+        "id": "2163",
+        "name": "Druid Diana of the Keep"
+    }, {
+        "id": "2179",
+        "name": "Charmer Victoria of the Keep"
+    }, {
+        "id": "2271",
+        "name": "Magus Requiem of the Keep"
+    }, {
+        "id": "2276",
+        "name": "Archmagus Davos of the Keep"
+    }, {
+        "id": "2351",
+        "name": "Magus Lux of the Keep"
+    }, {
+        "id": "2381",
+        "name": "Cleric Tundror of the Keep"
+    }, {
+        "id": "2396",
+        "name": "Arch-Magician Ratko of the Keep"
+    }, {
+        "id": "2419",
+        "name": "Battle Mage Ethan of the Keep"
+    }, {
+        "id": "2482",
+        "name": "Sage Solomon of the Keep"
+    }, {
+        "id": "2519",
+        "name": "Archmagus Amir of the Keep"
+    }, {
+        "id": "2523",
+        "name": "Embrose of the Keep"
+    }, {
+        "id": "2564",
+        "name": "Charmer Jadis of the Keep"
+    }, {
+        "id": "2600",
+        "name": "Arcanist Eliphas of the Keep"
+    }, {
+        "id": "2647",
+        "name": "Arcanist Zaros of the Keep"
+    }, {
+        "id": "2703",
+        "name": "Adept Fredo of the Keep"
+    }, {
+        "id": "2786",
+        "name": "Battle Mage Cassius of the Keep"
+    }, {
+        "id": "2797",
+        "name": "Archmagus Aldo of the Keep"
+    }, {
+        "id": "2798",
+        "name": "Alchemist Samuel of the Keep"
+    }, {
+        "id": "2862",
+        "name": "Enchanter Layla of the Keep"
+    }, {
+        "id": "2868",
+        "name": "Electromancer Requiem of the Keep"
+    }, {
+        "id": "2924",
+        "name": "Archmagus David of the Keep"
+    }, {
+        "id": "2961",
+        "name": "Archmagus Aleister of the Keep"
+    }, {
+        "id": "2992",
+        "name": "Sorcerer Jerret of the Keep"
+    }, {
+        "id": "3022",
+        "name": "Cryptomancer Aleister of the Keep"
+    }, {
+        "id": "3157",
+        "name": "Witch Velorina of the Keep"
+    }, {
+        "id": "3163",
+        "name": "Archmagus Zelroth of the Keep"
+    }, {
+        "id": "3178",
+        "name": "Diabolist Ariadne of the Keep"
+    }, {
+        "id": "3182",
+        "name": "Hedge Wizard Karasu of the Keep"
+    }, {
+        "id": "3203",
+        "name": "Sorcerer Alatar of the Keep"
+    }, {
+        "id": "3223",
+        "name": "Alchemist Suyin of the Keep"
+    }, {
+        "id": "3248",
+        "name": "Battle Mage Hagar of the Keep"
+    }, {
+        "id": "3256",
+        "name": "Illusionist  of the Keep"
+    }, {
+        "id": "3276",
+        "name": "Sorcerer Milton of the Keep"
+    }, {
+        "id": "3325",
+        "name": "Azahl of the Keep"
+    }, {
+        "id": "3327",
+        "name": "Archmagus Digby of the Keep"
+    }, {
+        "id": "3479",
+        "name": "Magus Gorgana of the Keep"
+    }, {
+        "id": "3542",
+        "name": "Druid Pezo of the Keep"
+    }, {
+        "id": "3603",
+        "name": "Medium Oiq of the Keep"
+    }, {
+        "id": "3613",
+        "name": "Magus Rita of the Keep"
+    }, {
+        "id": "3658",
+        "name": "Archmagus Zubin of the Keep"
+    }, {
+        "id": "3680",
+        "name": "Magus Zafar of the Keep"
+    }, {
+        "id": "3762",
+        "name": "Hedge Wizard Kalo of the Keep"
+    }, {
+        "id": "3790",
+        "name": "Solar Mage  of the Keep"
+    }, {
+        "id": "3896",
+        "name": "Evoker Aleister of the Keep"
+    }, {
+        "id": "4028",
+        "name": "Druid Aleister of the Keep"
+    }, {
+        "id": "4035",
+        "name": "Adept Lumos of the Keep"
+    }, {
+        "id": "4121",
+        "name": "Sorcerer Udor of the Keep"
+    }, {
+        "id": "4155",
+        "name": "Enchanter  of the Keep"
+    }, {
+        "id": "4183",
+        "name": "Arcanist Alatar of the Keep"
+    }, {
+        "id": "4214",
+        "name": "Archmagus Aleister of the Keep"
+    }, {
+        "id": "4218",
+        "name": "Clairvoyant Talbot of the Keep"
+    }, {
+        "id": "4302",
+        "name": "Oberon of the Keep"
+    }, {
+        "id": "4316",
+        "name": "Runecaster Jean Leon of the Keep"
+    }, {
+        "id": "4324",
+        "name": "Hex Mage Gaspard of the Keep"
+    }, {
+        "id": "4326",
+        "name": "Artificer Jastor of the Keep"
+    }, {
+        "id": "4515",
+        "name": "Battle Mage Homer of the Keep"
+    }, {
+        "id": "4524",
+        "name": "Sky Master Rook of the Keep"
+    }, {
+        "id": "4569",
+        "name": "Chaos Mage Nala of the Keep"
+    }, {
+        "id": "4571",
+        "name": "Cleric Patch of the Keep"
+    }, {
+        "id": "4591",
+        "name": "Bard Homer of the Keep"
+    }, {
+        "id": "4613",
+        "name": "Magus Homer of the Keep"
+    }, {
+        "id": "4682",
+        "name": "Arcanist Moloch of the Keep"
+    }, {
+        "id": "4735",
+        "name": "Wild Mage Hagar of the Keep"
+    }, {
+        "id": "4780",
+        "name": "Hedge Wizard Jianyu of the Keep"
+    }, {
+        "id": "4807",
+        "name": "Alchemist Talbot of the Keep"
+    }, {
+        "id": "4977",
+        "name": "Archmagus Eden of the Keep"
+    }, {
+        "id": "4982",
+        "name": "Mystic Allistair of the Keep"
+    }, {
+        "id": "5029",
+        "name": "Battle Mage Finn of the Keep"
+    }, {
+        "id": "5052",
+        "name": "Artificer Jerret of the Keep"
+    }, {
+        "id": "5095",
+        "name": "Illusionist Hecate of the Keep"
+    }, {
+        "id": "5120",
+        "name": "Alchemist Toadstool of the Keep"
+    }, {
+        "id": "5168",
+        "name": "Sorcerer Ali of the Keep"
+    }, {
+        "id": "5222",
+        "name": "Archmagus Aldus of the Keep"
+    }, {
+        "id": "5248",
+        "name": "Shadow Mage Ratko of the Keep"
+    }, {
+        "id": "5285",
+        "name": "Battle Mage Magnus of the Keep"
+    }, {
+        "id": "5330",
+        "name": "Alchemist Hanko of the Keep"
+    }, {
+        "id": "5360",
+        "name": "Aleister of the Keep"
+    }, {
+        "id": "5369",
+        "name": "Alchemist Asphodel of the Keep"
+    }, {
+        "id": "5401",
+        "name": "Witch Keziah of the Keep"
+    }, {
+        "id": "5402",
+        "name": "Arch-Magician Aslan of the Keep"
+    }, {
+        "id": "5453",
+        "name": "Druid Ravana of the Keep"
+    }, {
+        "id": "5528",
+        "name": "Druid Duzzle of the Keep"
+    }, {
+        "id": "5530",
+        "name": "Necromancer  of the Keep"
+    }, {
+        "id": "5584",
+        "name": "Diabolist Hobbs of the Keep"
+    }, {
+        "id": "5782",
+        "name": "Void Disciple Milo of the Keep"
+    }, {
+        "id": "5795",
+        "name": "Runecaster Nazim of the Keep"
+    }, {
+        "id": "5834",
+        "name": "Sorcerer Kamil of the Keep"
+    }, {
+        "id": "5888",
+        "name": "Pyromancer Daria of the Keep"
+    }, {
+        "id": "5898",
+        "name": "Thaumaturge Aleister of the Keep"
+    }, {
+        "id": "5922",
+        "name": "Cleric Darick of the Keep"
+    }, {
+        "id": "5939",
+        "name": "Ozohr of the Keep"
+    }, {
+        "id": "5967",
+        "name": "Magus Gully of the Keep"
+    }, {
+        "id": "5977",
+        "name": "Zelroth of the Keep"
+    }, {
+        "id": "6015",
+        "name": "Witch Hestia of the Keep"
+    }, {
+        "id": "6062",
+        "name": "Artificer Udor of the Keep"
+    }, {
+        "id": "6186",
+        "name": "Sage Vadim of the Keep"
+    }, {
+        "id": "6239",
+        "name": "Enchanter Diana of the Keep"
+    }, {
+        "id": "6293",
+        "name": "Pyromancer Udor of the Keep"
+    }, {
+        "id": "6489",
+        "name": "Alchemist Remus of the Keep"
+    }, {
+        "id": "6530",
+        "name": "Hedge Wizard Ivy of the Keep"
+    }, {
+        "id": "6552",
+        "name": "Archmagus Apollo of the Keep"
+    }, {
+        "id": "6561",
+        "name": "Enchanter Pandora of the Keep"
+    }, {
+        "id": "6782",
+        "name": "Evoker Armstrong of the Keep"
+    }, {
+        "id": "6788",
+        "name": "Archmagus Crowley of the Keep"
+    }, {
+        "id": "6814",
+        "name": "Runecaster Milton of the Keep"
+    }, {
+        "id": "6847",
+        "name": "Archmagus Lumos of the Keep"
+    }, {
+        "id": "6924",
+        "name": "Archmagus Casper of the Keep"
+    }, {
+        "id": "6932",
+        "name": "Sorcerer Kazem of the Keep"
+    }, {
+        "id": "6967",
+        "name": "Battle Mage Cromwell of the Keep"
+    }, {
+        "id": "7005",
+        "name": "Battle Mage Caligula of the Keep"
+    }, {
+        "id": "7048",
+        "name": "Thaumaturge Zixin of the Keep"
+    }, {
+        "id": "7089",
+        "name": "Archmagus Lux of the Keep"
+    }, {
+        "id": "7175",
+        "name": "Archmagus Alessar of the Keep"
+    }, {
+        "id": "7195",
+        "name": "Sage Trollin of the Keep"
+    }, {
+        "id": "7247",
+        "name": "Archmagus Jerret of the Keep"
+    }, {
+        "id": "7296",
+        "name": "Archmagus Jerret of the Keep"
+    }, {
+        "id": "7347",
+        "name": "Arcanist Xue of the Keep"
+    }, {
+        "id": "7352",
+        "name": "Necromancer Thoth of the Keep"
+    }, {
+        "id": "7372",
+        "name": "Magus Ifran of the Keep"
+    }, {
+        "id": "7414",
+        "name": "Druid Crowley of the Keep"
+    }, {
+        "id": "7467",
+        "name": "Alchemist Ilyas of the Keep"
+    }, {
+        "id": "7532",
+        "name": "Mystic Aldo of the Keep"
+    }, {
+        "id": "7547",
+        "name": "Artificer Qasim of the Keep"
+    }, {
+        "id": "7585",
+        "name": "Archmagus Crobas of the Keep"
+    }, {
+        "id": "7600",
+        "name": "Magus Lamia of the Keep"
+    }, {
+        "id": "7647",
+        "name": "Hedge Wizard Brutus of the Keep"
+    }, {
+        "id": "7672",
+        "name": "Chronomancer Ifran of the Keep"
+    }, {
+        "id": "7723",
+        "name": "Alchemist  of the Keep"
+    }, {
+        "id": "7806",
+        "name": "Shadow Mage Optimus of the Keep"
+    }, {
+        "id": "7866",
+        "name": "Geomancer Zhan of the Keep"
+    }, {
+        "id": "7902",
+        "name": "Electromancer Bathsheba of the Keep"
+    }, {
+        "id": "7911",
+        "name": "Archmagus Lumos of the Keep"
+    }, {
+        "id": "7932",
+        "name": "Holy Monk Eronin of the Keep"
+    }, {
+        "id": "7941",
+        "name": "Illusionist Galatea of the Keep"
+    }, {
+        "id": "7954",
+        "name": "Shadow Mage Iprix of the Keep"
+    }, {
+        "id": "7960",
+        "name": "Shaman Nadeem of the Keep"
+    }, {
+        "id": "7966",
+        "name": "Druid Nolan of the Keep"
+    }, {
+        "id": "7982",
+        "name": "Magus Alessar of the Keep"
+    }, {
+        "id": "7992",
+        "name": "Alchemist Silas of the Keep"
+    }, {
+        "id": "8000",
+        "name": "Bard Hadrien of the Keep"
+    }, {
+        "id": "8025",
+        "name": "Chronomancer Gellert of the Keep"
+    }, {
+        "id": "8068",
+        "name": "Enchanter Iprix of the Keep"
+    }, {
+        "id": "8077",
+        "name": "Arcanist Zelroth of the Keep"
+    }, {
+        "id": "8095",
+        "name": "Adept Marceau of the Keep"
+    }, {
+        "id": "8115",
+        "name": "Enchanter Ariadne of the Keep"
+    }, {
+        "id": "8139",
+        "name": "Magus Danny of the Keep"
+    }, {
+        "id": "8241",
+        "name": "Sorcerer Uday of the Keep"
+    }, {
+        "id": "8314",
+        "name": "Diabolist Alatar of the Keep"
+    }, {
+        "id": "8458",
+        "name": "Summoner Pezo of the Keep"
+    }, {
+        "id": "8473",
+        "name": "Sage Aleister of the Keep"
+    }, {
+        "id": "8502",
+        "name": "Wild Mage Yuki of the Keep"
+    }, {
+        "id": "8589",
+        "name": "Artificer Le Blanc of the Keep"
+    }, {
+        "id": "8595",
+        "name": "Archmagus Ravana of the Keep"
+    }, {
+        "id": "8615",
+        "name": "Necromancer Asmodeus of the Keep"
+    }, {
+        "id": "8620",
+        "name": "Sky Master Magpie of the Keep"
+    }, {
+        "id": "8635",
+        "name": "Arcanist Cairon of the Keep"
+    }, {
+        "id": "8726",
+        "name": "Hedge Wizard Oberon of the Keep"
+    }, {
+        "id": "8729",
+        "name": "Shaman Blaise of the Keep"
+    }, {
+        "id": "8746",
+        "name": "Archmagus Uvlius of the Keep"
+    }, {
+        "id": "8773",
+        "name": "Archmagus Alatar of the Keep"
+    }, {
+        "id": "8775",
+        "name": "Evoker Moloch of the Keep"
+    }, {
+        "id": "8783",
+        "name": "Alchemist Uday of the Keep"
+    }, {
+        "id": "8805",
+        "name": "Sorcerer Apollo of the Keep"
+    }, {
+        "id": "8914",
+        "name": "Alchemist Ixar of the Keep"
+    }, {
+        "id": "8923",
+        "name": "Arcanist Sahir of the Keep"
+    }, {
+        "id": "8948",
+        "name": "Arcanist Cromwell of the Keep"
+    }, {
+        "id": "8960",
+        "name": "Hex Mage Suki of the Keep"
+    }, {
+        "id": "9102",
+        "name": "Magus Aldus of the Keep"
+    }, {
+        "id": "9148",
+        "name": "Pyromancer George of the Keep"
+    }, {
+        "id": "9150",
+        "name": "Holy Monk Fark of the Keep"
+    }, {
+        "id": "9163",
+        "name": "Summoner Casper of the Keep"
+    }, {
+        "id": "9175",
+        "name": "Archmagus Lumos of the Keep"
+    }, {
+        "id": "9191",
+        "name": "Sorcerer Lux of the Keep"
+    }, {
+        "id": "9192",
+        "name": "Archmagus Gary of the Keep"
+    }, {
+        "id": "9222",
+        "name": "Clairvoyant Soya of the Keep"
+    }, {
+        "id": "9225",
+        "name": "Hadrien of the Keep"
+    }, {
+        "id": "9257",
+        "name": "Diabolist Hothor of the Keep"
+    }, {
+        "id": "9260",
+        "name": "Alchemist Thor of the Keep"
+    }, {
+        "id": "9303",
+        "name": "Thaumaturge Cairon of the Keep"
+    }, {
+        "id": "9319",
+        "name": "Arcanist Homer of the Keep"
+    }, {
+        "id": "9588",
+        "name": "Druid Cairon of the Keep"
+    }, {
+        "id": "9611",
+        "name": "Arch-Magician Nazim of the Keep"
+    }, {
+        "id": "9628",
+        "name": "Sage Jeldor of the Keep"
+    }, {
+        "id": "9661",
+        "name": "Sorcerer George of the Keep"
+    }, {
+        "id": "9719",
+        "name": "Illusionist Pan of the Keep"
+    }, {
+        "id": "9727",
+        "name": "Arcanist Azahl of the Keep"
+    }, {
+        "id": "9736",
+        "name": "Adept Merlon of the Keep"
+    }, {
+        "id": "9738",
+        "name": "Electromancer Moloch of the Keep"
+    }, {
+        "id": "9830",
+        "name": "Alchemist Allistair of the Keep"
+    }, {
+        "id": "9856",
+        "name": "Sorcerer Ofaris of the Keep"
+    }, {
+        "id": "9859",
+        "name": "Aleister of the Keep"
+    }, {
+        "id": "9864",
+        "name": "Witch Cromwell of the Keep"
+    }, {
+        "id": "9888",
+        "name": "Necromancer Abaddon of the Keep"
+    }],
+    "End Times": [{
+        "id": "9999",
+        "name": "Bringer of the End Times"
+    }],
+    "Oz": [{
+        "id": "1900",
+        "name": "Wizard of Oz"
+    }],
+    "Wold": [{
+        "id": "34",
+        "name": "Druid Rowena of the Wold"
+    }, {
+        "id": "160",
+        "name": "Daphne of the Wold"
+    }, {
+        "id": "211",
+        "name": "Enchanter Arabella of the Wold"
+    }, {
+        "id": "236",
+        "name": "Witch Sylvia of the Wold"
+    }, {
+        "id": "283",
+        "name": "Hex Mage Trollin of the Wold"
+    }, {
+        "id": "284",
+        "name": "Alchemist Oberon of the Wold"
+    }, {
+        "id": "391",
+        "name": "Enchanter Ariadne of the Wold"
+    }, {
+        "id": "488",
+        "name": "Archmagus Baozhai of the Wold"
+    }, {
+        "id": "671",
+        "name": "Oracle Lin of the Wold"
+    }, {
+        "id": "683",
+        "name": "Battle Mage Hansel of the Wold"
+    }, {
+        "id": "725",
+        "name": "Archmagus Aleister of the Wold"
+    }, {
+        "id": "790",
+        "name": "Necromancer Samael of the Wold"
+    }, {
+        "id": "859",
+        "name": "Conjurer Azar of the Wold"
+    }, {
+        "id": "972",
+        "name": "Enchanter Circe of the Wold"
+    }, {
+        "id": "1069",
+        "name": "Chronomancer Zixin of the Wold"
+    }, {
+        "id": "1170",
+        "name": "Alchemist Merlon of the Wold"
+    }, {
+        "id": "1393",
+        "name": "Conjurer Iprix of the Wold"
+    }, {
+        "id": "1425",
+        "name": "Archmagus Apollo of the Wold"
+    }, {
+        "id": "1437",
+        "name": "Runecaster Ivy of the Wold"
+    }, {
+        "id": "1451",
+        "name": "Wild Mage Merlon of the Wold"
+    }, {
+        "id": "1526",
+        "name": "Enchanter Rowena of the Wold"
+    }, {
+        "id": "1548",
+        "name": "Alchemist Gully of the Wold"
+    }, {
+        "id": "1635",
+        "name": "Artificer Aslan of the Wold"
+    }, {
+        "id": "1719",
+        "name": "Astrid of the Wold"
+    }, {
+        "id": "1787",
+        "name": "Arch-Magician Chu Hua of the Wold"
+    }, {
+        "id": "1837",
+        "name": "Illusionist Diana of the Wold"
+    }, {
+        "id": "1992",
+        "name": "Alessar of the Wold"
+    }, {
+        "id": "2080",
+        "name": "Sorcerer Soran of the Wold"
+    }, {
+        "id": "2081",
+        "name": "Arcanist Luther of the Wold"
+    }, {
+        "id": "2166",
+        "name": "Illusionist Woomba of the Wold"
+    }, {
+        "id": "2338",
+        "name": "Archmagus Isaac of the Wold"
+    }, {
+        "id": "2506",
+        "name": "Celeste of the Wold"
+    }, {
+        "id": "2520",
+        "name": "Adept Alessar of the Wold"
+    }, {
+        "id": "2542",
+        "name": "Clairvoyant Eric of the Wold"
+    }, {
+        "id": "2679",
+        "name": "Battle Mage Blaise of the Wold"
+    }, {
+        "id": "2681",
+        "name": "Mystic Wolfram of the Wold"
+    }, {
+        "id": "2720",
+        "name": "Cleric Shu of the Wold"
+    }, {
+        "id": "2817",
+        "name": "Enchanter Adrienne of the Wold"
+    }, {
+        "id": "2881",
+        "name": "Enchanter Larissa of the Wold"
+    }, {
+        "id": "2967",
+        "name": "Battle Mage Homer of the Wold"
+    }, {
+        "id": "2997",
+        "name": "Hedge Wizard Angus of the Wold"
+    }, {
+        "id": "3036",
+        "name": "Witch Lilith of the Wold"
+    }, {
+        "id": "3193",
+        "name": "Pyromancer Tengu of the Wold"
+    }, {
+        "id": "3195",
+        "name": "Diabolist Gorgana of the Wold"
+    }, {
+        "id": "3359",
+        "name": "Charmer Sondra of the Wold"
+    }, {
+        "id": "3392",
+        "name": "Illusionist Aiko of the Wold"
+    }, {
+        "id": "3507",
+        "name": "Artificer Thor of the Wold"
+    }, {
+        "id": "3564",
+        "name": "Mystic Suyin of the Wold"
+    }, {
+        "id": "3607",
+        "name": "Clairvoyant Ariadne of the Wold"
+    }, {
+        "id": "3757",
+        "name": "Cryptomancer Artis of the Wold"
+    }, {
+        "id": "3773",
+        "name": "Enchanter Angus of the Wold"
+    }, {
+        "id": "3808",
+        "name": "Hedge Wizard Cromwell of the Wold"
+    }, {
+        "id": "3831",
+        "name": "Alchemist David of the Wold"
+    }, {
+        "id": "4004",
+        "name": "Enchanter Bathsheba of the Wold"
+    }, {
+        "id": "4020",
+        "name": "Cryptomancer Amir of the Wold"
+    }, {
+        "id": "4032",
+        "name": "Witch Ursula of the Wold"
+    }, {
+        "id": "4160",
+        "name": "Mystic Celeste of the Wold"
+    }, {
+        "id": "4261",
+        "name": "Battle Mage Magnus of the Wold"
+    }, {
+        "id": "4274",
+        "name": "Battle Mage Khudalf of the Wold"
+    }, {
+        "id": "4405",
+        "name": "Enchanter Artis of the Wold"
+    }, {
+        "id": "4421",
+        "name": "Magus Aleister of the Wold"
+    }, {
+        "id": "4441",
+        "name": "Archmagus Argus of the Wold"
+    }, {
+        "id": "4458",
+        "name": "Milton of the Wold"
+    }, {
+        "id": "4701",
+        "name": "Battle Mage Otto of the Wold"
+    }, {
+        "id": "4826",
+        "name": "Archmagus David of the Wold"
+    }, {
+        "id": "4852",
+        "name": "Magus Tundror of the Wold"
+    }, {
+        "id": "5115",
+        "name": "Artificer Qianfan of the Wold"
+    }, {
+        "id": "5209",
+        "name": "Enchanter Iris of the Wold"
+    }, {
+        "id": "5328",
+        "name": "Alchemist Angus of the Wold"
+    }, {
+        "id": "5333",
+        "name": "Thaumaturge Zaros of the Wold"
+    }, {
+        "id": "5361",
+        "name": "Enchanter Pandora of the Wold"
+    }, {
+        "id": "5486",
+        "name": "Druid Moka of the Wold"
+    }, {
+        "id": "5493",
+        "name": "Sorcerer Qasim of the Wold"
+    }, {
+        "id": "5806",
+        "name": "Bathsheba of the Wold"
+    }, {
+        "id": "5818",
+        "name": "Shaman Ariadne of the Wold"
+    }, {
+        "id": "5849",
+        "name": "Cybele of the Wold"
+    }, {
+        "id": "5851",
+        "name": "Witch Rita of the Wold"
+    }, {
+        "id": "5973",
+        "name": "Archmagus Victor of the Wold"
+    }, {
+        "id": "6473",
+        "name": "Magus Kamil of the Wold"
+    }, {
+        "id": "6597",
+        "name": "Magus Amir of the Wold"
+    }, {
+        "id": "6603",
+        "name": "Enchanter Enigma of the Wold"
+    }, {
+        "id": "6773",
+        "name": "Battle Mage Armstrong of the Wold"
+    }, {
+        "id": "6902",
+        "name": "Witch Hecate of the Wold"
+    }, {
+        "id": "6911",
+        "name": "Archmagus Eronin of the Wold"
+    }, {
+        "id": "6995",
+        "name": "Merlon of the Wold"
+    }, {
+        "id": "7170",
+        "name": "Hydromancer Angus of the Wold"
+    }, {
+        "id": "7178",
+        "name": "Sorcerer Alatar of the Wold"
+    }, {
+        "id": "7194",
+        "name": "Battle Mage Homer of the Wold"
+    }, {
+        "id": "7210",
+        "name": "Archmagus Katherine of the Wold"
+    }, {
+        "id": "7223",
+        "name": "Hedge Wizard Gellert of the Wold"
+    }, {
+        "id": "7250",
+        "name": "Arcanist Nicolas of the Wold"
+    }, {
+        "id": "7353",
+        "name": "Archmagus Crowley of the Wold"
+    }, {
+        "id": "7364",
+        "name": "Artificer Ulysse of the Wold"
+    }, {
+        "id": "7408",
+        "name": "Pyromancer Jaffer of the Wold"
+    }, {
+        "id": "7442",
+        "name": "Aeromancer Zelroth of the Wold"
+    }, {
+        "id": "7473",
+        "name": "Archmagus Voidoth of the Wold"
+    }, {
+        "id": "7482",
+        "name": "Arcanist Angus of the Wold"
+    }, {
+        "id": "7533",
+        "name": "Witch Gwendolin of the Wold"
+    }, {
+        "id": "7566",
+        "name": "Sage Thana of the Wold"
+    }, {
+        "id": "7598",
+        "name": "Battle Mage Homer of the Wold"
+    }, {
+        "id": "7720",
+        "name": "Hedge Wizard Keziah of the Wold"
+    }, {
+        "id": "7735",
+        "name": "Geomancer Sylvia of the Wold"
+    }, {
+        "id": "7837",
+        "name": "Charmer Victoria of the Wold"
+    }, {
+        "id": "7890",
+        "name": "Sage Jadis of the Wold"
+    }, {
+        "id": "7894",
+        "name": "Chaos Mage Katherine of the Wold"
+    }, {
+        "id": "7946",
+        "name": "Archmagus Uvlius of the Wold"
+    }, {
+        "id": "8067",
+        "name": "Archmagus Aleister of the Wold"
+    }, {
+        "id": "8258",
+        "name": "Hydromancer Naoki of the Wold"
+    }, {
+        "id": "8274",
+        "name": "Charmer Diana of the Wold"
+    }, {
+        "id": "8323",
+        "name": "Cryptomancer Carly of the Wold"
+    }, {
+        "id": "8413",
+        "name": "Archmagus Fark of the Wold"
+    }, {
+        "id": "8554",
+        "name": "Oracle Kazud of the Wold"
+    }, {
+        "id": "8575",
+        "name": "Battle Mage Ethan of the Wold"
+    }, {
+        "id": "8594",
+        "name": "Sorcerer Hashim of the Wold"
+    }, {
+        "id": "8667",
+        "name": "Voodoo Priest Carly of the Wold"
+    }, {
+        "id": "8768",
+        "name": "Magus Rita of the Wold"
+    }, {
+        "id": "9020",
+        "name": "Necromancer Voidoth of the Wold"
+    }, {
+        "id": "9204",
+        "name": "Alchemist Shivra of the Wold"
+    }, {
+        "id": "9363",
+        "name": "Runecaster Layla of the Wold"
+    }, {
+        "id": "9398",
+        "name": "Shaman Ixar of the Wold"
+    }, {
+        "id": "9461",
+        "name": "Geomancer Cassius of the Wold"
+    }, {
+        "id": "9479",
+        "name": "Adept Konoha of the Wold"
+    }, {
+        "id": "9500",
+        "name": "Battle Mage Ulysse of the Wold"
+    }, {
+        "id": "9502",
+        "name": "Archmagus Crowley of the Wold"
+    }, {
+        "id": "9506",
+        "name": "Oracle Nicolas of the Wold"
+    }, {
+        "id": "9554",
+        "name": "Sorcerer Ixar of the Wold"
+    }, {
+        "id": "9627",
+        "name": "Alchemist Yan of the Wold"
+    }, {
+        "id": "9790",
+        "name": "Charmer Devon of the Wold"
+    }, {
+        "id": "9807",
+        "name": "Hydromancer Ratko of the Wold"
+    }, {
+        "id": "9840",
+        "name": "Hedge Wizard Darick of the Wold"
+    }, {
+        "id": "9988",
+        "name": "Charmer Sondra of the Wold"
+    }],
+    "Spots Hunter": [{
+        "id": "19",
+        "name": "Master of Spots Hunter"
+    }],
+    "Tower": [{
+        "id": "38",
+        "name": "Sorcerer Zaros of the Tower"
+    }, {
+        "id": "83",
+        "name": "Archmagus Alessar of the Tower"
+    }, {
+        "id": "198",
+        "name": "Alchemist Moka of the Tower"
+    }, {
+        "id": "208",
+        "name": "Artificer Lumos of the Tower"
+    }, {
+        "id": "227",
+        "name": "Conjurer Samuel of the Tower"
+    }, {
+        "id": "331",
+        "name": "Ghost Eater Judas of the Tower"
+    }, {
+        "id": "393",
+        "name": "Adept David of the Tower"
+    }, {
+        "id": "518",
+        "name": "Battle Mage Nicolas of the Tower"
+    }, {
+        "id": "541",
+        "name": "Alchemist Axel of the Tower"
+    }, {
+        "id": "546",
+        "name": "Sage Solomon of the Tower"
+    }, {
+        "id": "561",
+        "name": "Alchemist Lumos of the Tower"
+    }, {
+        "id": "569",
+        "name": "Transmuter Hadrien of the Tower"
+    }, {
+        "id": "648",
+        "name": "Sorcerer Lamia of the Tower"
+    }, {
+        "id": "747",
+        "name": "Milo of the Tower"
+    }, {
+        "id": "762",
+        "name": "Holy Monk Aldo of the Tower"
+    }, {
+        "id": "810",
+        "name": "Augurer Eric of the Tower"
+    }, {
+        "id": "885",
+        "name": "Sorcerer Jeldor of the Tower"
+    }, {
+        "id": "981",
+        "name": "Enchanter Sondra of the Tower"
+    }, {
+        "id": "992",
+        "name": "Crowley of the Tower"
+    }, {
+        "id": "1070",
+        "name": "Magus Ambrosia of the Tower"
+    }, {
+        "id": "1088",
+        "name": "Arch-Magician Bane of the Tower"
+    }, {
+        "id": "1258",
+        "name": "Pyromancer Nixie of the Tower"
+    }, {
+        "id": "1262",
+        "name": "Magus Pezo of the Tower"
+    }, {
+        "id": "1265",
+        "name": "Arch-Magician Rowena of the Tower"
+    }, {
+        "id": "1269",
+        "name": "Adept Oiq of the Tower"
+    }, {
+        "id": "1271",
+        "name": "Necromancer Diabolos of the Tower"
+    }, {
+        "id": "1308",
+        "name": "Stellar Mage Shukri of the Tower"
+    }, {
+        "id": "1312",
+        "name": "Druid Edge of the Tower"
+    }, {
+        "id": "1324",
+        "name": "Alchemist Lumos of the Tower"
+    }, {
+        "id": "1435",
+        "name": "Sorcerer Taqi of the Tower"
+    }, {
+        "id": "1443",
+        "name": "Magus Tengu of the Tower"
+    }, {
+        "id": "1522",
+        "name": "Druid Nixie of the Tower"
+    }, {
+        "id": "1700",
+        "name": "Hedge Wizard Asmodeus of the Tower"
+    }, {
+        "id": "1729",
+        "name": "Aleister of the Tower"
+    }, {
+        "id": "1843",
+        "name": "Artificer Quddus of the Tower"
+    }, {
+        "id": "1899",
+        "name": "Battle Mage Caligula of the Tower"
+    }, {
+        "id": "1923",
+        "name": "Argus of the Tower"
+    }, {
+        "id": "1998",
+        "name": "Magus Hagatha of the Tower"
+    }, {
+        "id": "2250",
+        "name": "Cairon of the Tower"
+    }, {
+        "id": "2265",
+        "name": "Aeromancer Cassius of the Tower"
+    }, {
+        "id": "2353",
+        "name": "Battle Mage Talbot of the Tower"
+    }, {
+        "id": "2365",
+        "name": "Electromancer Darick of the Tower"
+    }, {
+        "id": "2409",
+        "name": "Solar Mage Aiko of the Tower"
+    }, {
+        "id": "2421",
+        "name": "Cosmic Mage Gwendolin of the Tower"
+    }, {
+        "id": "2445",
+        "name": "Aeromancer Giacomo of the Tower"
+    }, {
+        "id": "2546",
+        "name": "Sorcerer Lumos of the Tower"
+    }, {
+        "id": "2639",
+        "name": "Sorcerer Taqi of the Tower"
+    }, {
+        "id": "2646",
+        "name": "Witch Imeena of the Tower"
+    }, {
+        "id": "2770",
+        "name": "Geomancer Ethan of the Tower"
+    }, {
+        "id": "2806",
+        "name": "Chaos Mage Allistair of the Tower"
+    }, {
+        "id": "2815",
+        "name": "Alchemist Properpine of the Tower"
+    }, {
+        "id": "2836",
+        "name": "Chaos Mage Uday of the Tower"
+    }, {
+        "id": "2846",
+        "name": "Hedge Wizard Aslan of the Tower"
+    }, {
+        "id": "2861",
+        "name": "Adept Azahl of the Tower"
+    }, {
+        "id": "2968",
+        "name": "Druid Salty of the Tower"
+    }, {
+        "id": "3040",
+        "name": "Medium Le Blanc of the Tower"
+    }, {
+        "id": "3054",
+        "name": "Alchemist Ifran of the Tower"
+    }, {
+        "id": "3056",
+        "name": "Soya of the Tower"
+    }, {
+        "id": "3128",
+        "name": "Archmagus Celah of the Tower"
+    }, {
+        "id": "3151",
+        "name": "Archmagus Ozohr of the Tower"
+    }, {
+        "id": "3211",
+        "name": "Sorcerer George of the Tower"
+    }, {
+        "id": "3222",
+        "name": "Clairvoyant Baptiste of the Tower"
+    }, {
+        "id": "3239",
+        "name": "Sorcerer Lux of the Tower"
+    }, {
+        "id": "3314",
+        "name": "Cosmic Mage Celeste of the Tower"
+    }, {
+        "id": "3348",
+        "name": "Magus Wazir of the Tower"
+    }, {
+        "id": "3349",
+        "name": "Hedge Wizard Allistair of the Tower"
+    }, {
+        "id": "3361",
+        "name": "Magus Numpty of the Tower"
+    }, {
+        "id": "3391",
+        "name": "Sorcerer Casper of the Tower"
+    }, {
+        "id": "3422",
+        "name": "Ghost Eater Aleister of the Tower"
+    }, {
+        "id": "3431",
+        "name": "Hedge Wizard Salah of the Tower"
+    }, {
+        "id": "3469",
+        "name": "Bard David of the Tower"
+    }, {
+        "id": "3482",
+        "name": "Shadow Mage Kobold of the Tower"
+    }, {
+        "id": "3583",
+        "name": "Sorcerer Chooki of the Tower"
+    }, {
+        "id": "3652",
+        "name": "Fortune Teller Marceline of the Tower"
+    }, {
+        "id": "3824",
+        "name": "Mystic Rafiq of the Tower"
+    }, {
+        "id": "3861",
+        "name": "Charmer Sondra of the Tower"
+    }, {
+        "id": "3897",
+        "name": "Adept Impy of the Tower"
+    }, {
+        "id": "3947",
+        "name": "Magus Aleister of the Tower"
+    }, {
+        "id": "3977",
+        "name": "Augurer Mad Apple of the Tower"
+    }, {
+        "id": "4003",
+        "name": "Void Disciple Aiko of the Tower"
+    }, {
+        "id": "4019",
+        "name": "Sorcerer Allistair of the Tower"
+    }, {
+        "id": "4039",
+        "name": "Hedge Wizard Orpheus of the Tower"
+    }, {
+        "id": "4052",
+        "name": "Hedge Wizard Cassiopeia of the Tower"
+    }, {
+        "id": "4079",
+        "name": "Hedge Wizard Zubin of the Tower"
+    }, {
+        "id": "4108",
+        "name": "Druid Lumos of the Tower"
+    }, {
+        "id": "4145",
+        "name": "Artificer Pino of the Tower"
+    }, {
+        "id": "4175",
+        "name": "Artificer Twinkletoes of the Tower"
+    }, {
+        "id": "4190",
+        "name": "Battle Mage Magnus of the Tower"
+    }, {
+        "id": "4206",
+        "name": "Hedge Wizard Aiko of the Tower"
+    }, {
+        "id": "4221",
+        "name": "Shaman Celah of the Tower"
+    }, {
+        "id": "4242",
+        "name": "Aeromancer Cosmo of the Tower"
+    }, {
+        "id": "4258",
+        "name": "Arch-Magician Chooki of the Tower"
+    }, {
+        "id": "4273",
+        "name": "Adept Jean Leon of the Tower"
+    }, {
+        "id": "4280",
+        "name": "Witch Gwendolin of the Tower"
+    }, {
+        "id": "4345",
+        "name": "Conjurer Thoth of the Tower"
+    }, {
+        "id": "4597",
+        "name": "Magus Jabir of the Tower"
+    }, {
+        "id": "4628",
+        "name": "Shaman Milo of the Tower"
+    }, {
+        "id": "4721",
+        "name": "Solomon of the Tower"
+    }, {
+        "id": "4762",
+        "name": "Holy Monk Alex of the Tower"
+    }, {
+        "id": "4764",
+        "name": "Sorcerer Pumlo of the Tower"
+    }, {
+        "id": "4812",
+        "name": "Sorcerer Merlon of the Tower"
+    }, {
+        "id": "4849",
+        "name": "Magus Ozohr of the Tower"
+    }, {
+        "id": "5016",
+        "name": "Battle Mage Hagar of the Tower"
+    }, {
+        "id": "5211",
+        "name": "Battle Mage Ethan of the Tower"
+    }, {
+        "id": "5272",
+        "name": "Chronomancer Milo of the Tower"
+    }, {
+        "id": "5304",
+        "name": "Conjurer Tengu of the Tower"
+    }, {
+        "id": "5350",
+        "name": "Magus  of the Tower"
+    }, {
+        "id": "5481",
+        "name": "Battle Mage Khudalf of the Tower"
+    }, {
+        "id": "5554",
+        "name": "Pumlo of the Tower"
+    }, {
+        "id": "5658",
+        "name": "Alchemist Gogol of the Tower"
+    }, {
+        "id": "5662",
+        "name": "Ghost Eater Nicolas of the Tower"
+    }, {
+        "id": "5676",
+        "name": "Battle Mage Sturgis of the Tower"
+    }, {
+        "id": "5693",
+        "name": "Druid Ixar of the Tower"
+    }, {
+        "id": "5714",
+        "name": "Shaman Magnus of the Tower"
+    }, {
+        "id": "5778",
+        "name": "Aeromancer Huizhong of the Tower"
+    }, {
+        "id": "5784",
+        "name": "Runecaster Merlon of the Tower"
+    }, {
+        "id": "5794",
+        "name": "Adept Alessar of the Tower"
+    }, {
+        "id": "5798",
+        "name": "Voodoo Priest Eliphas of the Tower"
+    }, {
+        "id": "5994",
+        "name": "Battle Mage Magnus of the Tower"
+    }, {
+        "id": "6041",
+        "name": "Witch Shivra of the Tower"
+    }, {
+        "id": "6120",
+        "name": "Archmagus Alatar of the Tower"
+    }, {
+        "id": "6123",
+        "name": "Battle Mage Magnus of the Tower"
+    }, {
+        "id": "6141",
+        "name": "Sage Nixie of the Tower"
+    }, {
+        "id": "6192",
+        "name": "Scryer Atlas of the Tower"
+    }, {
+        "id": "6240",
+        "name": "Enchanter Azahl of the Tower"
+    }, {
+        "id": "6257",
+        "name": "Enchanter Mina of the Tower"
+    }, {
+        "id": "6264",
+        "name": "Battle Mage Bartholomew of the Tower"
+    }, {
+        "id": "6277",
+        "name": "Sorcerer Axel of the Tower"
+    }, {
+        "id": "6301",
+        "name": "Adept Merlon of the Tower"
+    }, {
+        "id": "6341",
+        "name": "Magus Danny of the Tower"
+    }, {
+        "id": "6415",
+        "name": "Runecaster Argus of the Tower"
+    }, {
+        "id": "6449",
+        "name": "Adept Jagger of the Tower"
+    }, {
+        "id": "6518",
+        "name": "Battle Mage Baird of the Tower"
+    }, {
+        "id": "6577",
+        "name": "Battle Mage Armstrong of the Tower"
+    }, {
+        "id": "6590",
+        "name": "Diabolist Woomba of the Tower"
+    }, {
+        "id": "6602",
+        "name": "Druid Iris of the Tower"
+    }, {
+        "id": "6646",
+        "name": "Alchemist Hagar of the Tower"
+    }, {
+        "id": "6852",
+        "name": "Illusionist Basil of the Tower"
+    }, {
+        "id": "6875",
+        "name": "Bard Salvatore of the Tower"
+    }, {
+        "id": "6895",
+        "name": "Archmagus Udor of the Tower"
+    }, {
+        "id": "6986",
+        "name": "Conjurer Caligula of the Tower"
+    }, {
+        "id": "7036",
+        "name": "Sorcerer Jiang of the Tower"
+    }, {
+        "id": "7062",
+        "name": "Geomancer Hugo of the Tower"
+    }, {
+        "id": "7121",
+        "name": "Sorcerer Ilyas of the Tower"
+    }, {
+        "id": "7125",
+        "name": "Hedge Wizard Aldus of the Tower"
+    }, {
+        "id": "7150",
+        "name": "Augurer Tenguyama of the Tower"
+    }, {
+        "id": "7180",
+        "name": "Archmagus Jasper of the Tower"
+    }, {
+        "id": "7244",
+        "name": "Illusionist David of the Tower"
+    }, {
+        "id": "7258",
+        "name": "Sorcerer George of the Tower"
+    }, {
+        "id": "7274",
+        "name": "Shaman Pino of the Tower"
+    }, {
+        "id": "7290",
+        "name": "Hedge Wizard Molek of the Tower"
+    }, {
+        "id": "7330",
+        "name": "Milton of the Tower"
+    }, {
+        "id": "7332",
+        "name": "Battle Mage Cromwell of the Tower"
+    }, {
+        "id": "7335",
+        "name": "Electromancer Rumpleskin of the Tower"
+    }, {
+        "id": "7355",
+        "name": "Voodoo Priest Marius of the Tower"
+    }, {
+        "id": "7385",
+        "name": "Charmer Layla of the Tower"
+    }, {
+        "id": "7388",
+        "name": "Adept Daria of the Tower"
+    }, {
+        "id": "7401",
+        "name": "Archmagus Goober of the Tower"
+    }, {
+        "id": "7581",
+        "name": "Artificer Dante of the Tower"
+    }, {
+        "id": "7596",
+        "name": "of the Tower"
+    }, {
+        "id": "7613",
+        "name": "Archmagus Gil of the Tower"
+    }, {
+        "id": "7842",
+        "name": "Alchemist Hydra of the Tower"
+    }, {
+        "id": "7845",
+        "name": "Oracle Godfrey of the Tower"
+    }, {
+        "id": "7933",
+        "name": "Shaman Poppy of the Tower"
+    }, {
+        "id": "7963",
+        "name": "Battle Mage Bartholomew of the Tower"
+    }, {
+        "id": "8037",
+        "name": "Artificer Rowena of the Tower"
+    }, {
+        "id": "8064",
+        "name": "Arch-Magician Udor of the Tower"
+    }, {
+        "id": "8113",
+        "name": "Summoner Cairon of the Tower"
+    }, {
+        "id": "8142",
+        "name": "Shadow Mage Froggy of the Tower"
+    }, {
+        "id": "8199",
+        "name": "Sorcerer Ali of the Tower"
+    }, {
+        "id": "8219",
+        "name": "Scryer Apollo of the Tower"
+    }, {
+        "id": "8319",
+        "name": "Archmagus Jeldor of the Tower"
+    }, {
+        "id": "8328",
+        "name": "Sorcerer Chooki of the Tower"
+    }, {
+        "id": "8354",
+        "name": "Archmagus Iprix of the Tower"
+    }, {
+        "id": "8424",
+        "name": "Magus Jahid of the Tower"
+    }, {
+        "id": "8459",
+        "name": "Sorcerer Zelroth of the Tower"
+    }, {
+        "id": "8478",
+        "name": "Magus Casper of the Tower"
+    }, {
+        "id": "8523",
+        "name": "Battle Mage Armstrong of the Tower"
+    }, {
+        "id": "8561",
+        "name": "Arch-Magician Baozhai of the Tower"
+    }, {
+        "id": "8692",
+        "name": "Archmagus Gellert of the Tower"
+    }, {
+        "id": "8696",
+        "name": "Shaman Eizo of the Tower"
+    }, {
+        "id": "8824",
+        "name": "Witch Shivra of the Tower"
+    }, {
+        "id": "8844",
+        "name": "Summoner Shabbith-Ka of the Tower"
+    }, {
+        "id": "8900",
+        "name": "Archmagus Cedric of the Tower"
+    }, {
+        "id": "8907",
+        "name": "Archmagus Merlon of the Tower"
+    }, {
+        "id": "8909",
+        "name": "Battle Mage Hagar of the Tower"
+    }, {
+        "id": "8986",
+        "name": "Cleric Gogol of the Tower"
+    }, {
+        "id": "9068",
+        "name": "Shadow Mage Baird of the Tower"
+    }, {
+        "id": "9074",
+        "name": "Cosmic Mage Atlas of the Tower"
+    }, {
+        "id": "9119",
+        "name": "Arch-Magician Milo of the Tower"
+    }, {
+        "id": "9153",
+        "name": "Alchemist Lumos of the Tower"
+    }, {
+        "id": "9349",
+        "name": "Alchemist Alatar of the Tower"
+    }, {
+        "id": "9365",
+        "name": "Archmagus Alessar of the Tower"
+    }, {
+        "id": "9504",
+        "name": "Hedge Wizard Angus of the Tower"
+    }, {
+        "id": "9529",
+        "name": "Enchanter Bathsheba of the Tower"
+    }, {
+        "id": "9579",
+        "name": "Augurer Ali of the Tower"
+    }, {
+        "id": "9604",
+        "name": "Pyromancer Rita of the Tower"
+    }, {
+        "id": "9659",
+        "name": "Magus Azathoth of the Tower"
+    }, {
+        "id": "9689",
+        "name": "Thaumaturge Ulysse of the Tower"
+    }, {
+        "id": "9712",
+        "name": "Cleric Amir of the Tower"
+    }, {
+        "id": "9781",
+        "name": "Aeromancer Amanita of the Tower"
+    }, {
+        "id": "9944",
+        "name": "Alchemist Gizmo of the Tower"
+    }, {
+        "id": "9972",
+        "name": "Thaumaturge Circe of the Tower"
+    }, {
+        "id": "9993",
+        "name": "Sorcerer Lumos of the Tower"
+    }],
+    "River": [{
+        "id": "133",
+        "name": "Enchanter Maia of the River"
+    }, {
+        "id": "186",
+        "name": "Alchemist Ozohr of the River"
+    }, {
+        "id": "277",
+        "name": "Witch Zelda of the River"
+    }, {
+        "id": "339",
+        "name": "Solomon of the River"
+    }, {
+        "id": "388",
+        "name": "Sorcerer Iprix of the River"
+    }, {
+        "id": "450",
+        "name": "Battlemage Soya of the River"
+    }, {
+        "id": "457",
+        "name": "Battle Mage Horace of the River"
+    }, {
+        "id": "577",
+        "name": "Alchemist Lin of the River"
+    }, {
+        "id": "804",
+        "name": "Artificer Brown Cow of the River"
+    }, {
+        "id": "830",
+        "name": "Battle Mage Magnus of the River"
+    }, {
+        "id": "866",
+        "name": "Archmagus Devon of the River"
+    }, {
+        "id": "881",
+        "name": "Battlemage Zubin of the River"
+    }, {
+        "id": "983",
+        "name": "Artificer Atlas of the River"
+    }, {
+        "id": "1085",
+        "name": "Enchanter Shu of the River"
+    }, {
+        "id": "1166",
+        "name": "Enchanter Ophelia of the River"
+    }, {
+        "id": "1323",
+        "name": "Hedge Wizard Rowena of the River"
+    }, {
+        "id": "1332",
+        "name": "Charmer Circe of the River"
+    }, {
+        "id": "1407",
+        "name": "Hydromancer Goliath of the River"
+    }, {
+        "id": "1518",
+        "name": "Enchanter Devon of the River"
+    }, {
+        "id": "1532",
+        "name": "Archmagus Aleister of the River"
+    }, {
+        "id": "1558",
+        "name": "Adept Bayard of the River"
+    }, {
+        "id": "1633",
+        "name": "Magus Cybele of the River"
+    }, {
+        "id": "1653",
+        "name": "Alchemist Talbot of the River"
+    }, {
+        "id": "1688",
+        "name": "Bard Duzzle of the River"
+    }, {
+        "id": "1763",
+        "name": "Archmagus Diana of the River"
+    }, {
+        "id": "1830",
+        "name": "Necromancer Judas of the River"
+    }, {
+        "id": "2151",
+        "name": "Adept Adium of the River"
+    }, {
+        "id": "2471",
+        "name": "Evoker Oiq of the River"
+    }, {
+        "id": "2567",
+        "name": "Runecaster Artis of the River"
+    }, {
+        "id": "2581",
+        "name": "Charmer Adrienne of the River"
+    }, {
+        "id": "2617",
+        "name": "Cleric Carmilla of the River"
+    }, {
+        "id": "2664",
+        "name": "Enchanter Artis of the River"
+    }, {
+        "id": "2686",
+        "name": "Cleric Alatar of the River"
+    }, {
+        "id": "2711",
+        "name": "Shaman Talon of the River"
+    }, {
+        "id": "2738",
+        "name": "Mystic Zaim of the River"
+    }, {
+        "id": "3072",
+        "name": "Hedge Wizard Daphne of the River"
+    }, {
+        "id": "3103",
+        "name": "Evoker Jerret of the River"
+    }, {
+        "id": "3124",
+        "name": "Cleric Ravana of the River"
+    }, {
+        "id": "3265",
+        "name": "Arch-Magician Astrid of the River"
+    }, {
+        "id": "3286",
+        "name": "Diviner Faye of the River"
+    }, {
+        "id": "3292",
+        "name": "Devon of the River"
+    }, {
+        "id": "3343",
+        "name": "Hex Mage Jeldor of the River"
+    }, {
+        "id": "3540",
+        "name": "Augurer Maia of the River"
+    }, {
+        "id": "3611",
+        "name": "Void Disciple Qaid of the River"
+    }, {
+        "id": "3687",
+        "name": "Hedge Wizard Izible of the River"
+    }, {
+        "id": "3829",
+        "name": "Summoner Maia of the River"
+    }, {
+        "id": "3899",
+        "name": "Charmer Bathsheba of the River"
+    }, {
+        "id": "4022",
+        "name": "Sage Merlon of the River"
+    }, {
+        "id": "4036",
+        "name": "Mystic Florah of the River"
+    }, {
+        "id": "4109",
+        "name": "Sorcerer Venga of the River"
+    }, {
+        "id": "4176",
+        "name": "Cosmic Mage Rita of the River"
+    }, {
+        "id": "4313",
+        "name": "Magus Goliath of the River"
+    }, {
+        "id": "4354",
+        "name": "Conjurer Kobold of the River"
+    }, {
+        "id": "4447",
+        "name": "Magus Hagatha of the River"
+    }, {
+        "id": "4509",
+        "name": "Alchemist Cairon of the River"
+    }, {
+        "id": "4643",
+        "name": "Geomancer Oxnard of the River"
+    }, {
+        "id": "4758",
+        "name": "Enchanter Iris of the River"
+    }, {
+        "id": "4820",
+        "name": "Arch-Magician Hashim of the River"
+    }, {
+        "id": "4864",
+        "name": "Hedge Wizard Jaffer of the River"
+    }, {
+        "id": "5170",
+        "name": "Magus Merlon of the River"
+    }, {
+        "id": "5284",
+        "name": "Sorcerer  of the River"
+    }, {
+        "id": "5320",
+        "name": "Alchemist Kalo of the River"
+    }, {
+        "id": "5460",
+        "name": "Mystic Danny of the River"
+    }, {
+        "id": "5527",
+        "name": "Shadow Mage Iluzor of the River"
+    }, {
+        "id": "5540",
+        "name": "Shaman Sahir of the River"
+    }, {
+        "id": "5719",
+        "name": "Cleric Maia of the River"
+    }, {
+        "id": "5850",
+        "name": "Void Disciple Dr. Death of the River"
+    }, {
+        "id": "5854",
+        "name": "Pyromancer Calypso of the River"
+    }, {
+        "id": "5891",
+        "name": "Sorcerer Armstrong of the River"
+    }, {
+        "id": "5920",
+        "name": "Shaman Rowena of the River"
+    }, {
+        "id": "6020",
+        "name": "Cryptomancer Sonja of the River"
+    }, {
+        "id": "6021",
+        "name": "Ghost Eater Asmodeus of the River"
+    }, {
+        "id": "6068",
+        "name": "Enchanter Diana of the River"
+    }, {
+        "id": "6127",
+        "name": "Battlemage Malthus of the River"
+    }, {
+        "id": "6261",
+        "name": "Archmagus Pandora of the River"
+    }, {
+        "id": "6273",
+        "name": "Enchanter Daria of the River"
+    }, {
+        "id": "6455",
+        "name": "Witch Shivra of the River"
+    }, {
+        "id": "6495",
+        "name": "Hydromancer Homer of the River"
+    }, {
+        "id": "6509",
+        "name": "Enchanter Daria of the River"
+    }, {
+        "id": "6696",
+        "name": "Enchanter Carly of the River"
+    }, {
+        "id": "6700",
+        "name": "Thaumaturge Eden of the River"
+    }, {
+        "id": "6918",
+        "name": "Shadow Mage Nixie of the River"
+    }, {
+        "id": "6921",
+        "name": "Sage Galatea of the River"
+    }, {
+        "id": "6966",
+        "name": "Pyromancer Froggy of the River"
+    }, {
+        "id": "7133",
+        "name": "Hedge Wizard Zelroth of the River"
+    }, {
+        "id": "7174",
+        "name": "Sondra of the River"
+    }, {
+        "id": "7179",
+        "name": "Diabolist Juniper of the River"
+    }, {
+        "id": "7220",
+        "name": "Runecaster Willow of the River"
+    }, {
+        "id": "7583",
+        "name": "Arch-Magician Dante of the River"
+    }, {
+        "id": "7760",
+        "name": "Devon of the River"
+    }, {
+        "id": "7861",
+        "name": "Artificer Yanlin of the River"
+    }, {
+        "id": "7891",
+        "name": "Alchemist Ofaris of the River"
+    }, {
+        "id": "7991",
+        "name": "Witch Hecate of the River"
+    }, {
+        "id": "8032",
+        "name": "Archmagus Rocco of the River"
+    }, {
+        "id": "8116",
+        "name": "Druid Gunthor of the River"
+    }, {
+        "id": "8228",
+        "name": "Archmagus Salvatore of the River"
+    }, {
+        "id": "8415",
+        "name": "Magus Ming of the River"
+    }, {
+        "id": "8518",
+        "name": "Witch Cassandra of the River"
+    }, {
+        "id": "8579",
+        "name": "Sorcerer Gogol of the River"
+    }, {
+        "id": "9063",
+        "name": "Spellsinger Lucinda of the River"
+    }, {
+        "id": "9079",
+        "name": "Illusionist Layla of the River"
+    }, {
+        "id": "9118",
+        "name": "Archmagus Eizo of the River"
+    }, {
+        "id": "9231",
+        "name": "Alessar of the River"
+    }, {
+        "id": "9276",
+        "name": "Sorcerer Alessar of the River"
+    }, {
+        "id": "9321",
+        "name": "Alchemist Gary of the River"
+    }, {
+        "id": "9626",
+        "name": "Magus Elena of the River"
+    }, {
+        "id": "9647",
+        "name": "Druid Danny of the River"
+    }, {
+        "id": "9848",
+        "name": "Druid Robert of the River"
+    }, {
+        "id": "9854",
+        "name": "Shadow Mage Calista of the River"
+    }, {
+        "id": "9881",
+        "name": "Archmagus Davos of the River"
+    }, {
+        "id": "9884",
+        "name": "Archmagus Aldus of the River"
+    }, {
+        "id": "9911",
+        "name": "Alchemist Remus of the River"
+    }],
+    "Salt": [{
+        "id": "3045",
+        "name": "Holy Arcanist Illuminus of the Salt"
+    }, {
+        "id": "3139",
+        "name": "Sorcerer Salah of the Salt"
+    }, {
+        "id": "3166",
+        "name": "Sorcerer Merlon of the Salt"
+    }, {
+        "id": "3924",
+        "name": "Geomancer Stag of the Salt"
+    }, {
+        "id": "4080",
+        "name": "Archmagus Ozohr of the Salt"
+    }, {
+        "id": "4534",
+        "name": "Enchanter Astrid of the Salt"
+    }, {
+        "id": "4543",
+        "name": "Alchemist Mina of the Salt"
+    }, {
+        "id": "6167",
+        "name": "Hydromancer Devin of the Salt"
+    }, {
+        "id": "6882",
+        "name": "Archmagus Nazim of the Salt"
+    }, {
+        "id": "7294",
+        "name": "Magus Woomba of the Salt"
+    }, {
+        "id": "7988",
+        "name": "Hydromancer Danny of the Salt"
+    }, {
+        "id": "9081",
+        "name": "Wild Mage Hothor of the Salt"
+    }],
+    "Villa": [{
+        "id": "46",
+        "name": "Witch Gorgana of the Villa"
+    }, {
+        "id": "59",
+        "name": "Wild Mage Ratko of the Villa"
+    }, {
+        "id": "120",
+        "name": "Merlon of the Villa"
+    }, {
+        "id": "143",
+        "name": "Archmagus Cairon of the Villa"
+    }, {
+        "id": "193",
+        "name": "Arch-Magician Gully of the Villa"
+    }, {
+        "id": "205",
+        "name": "Arch-Magician Nassif of the Villa"
+    }, {
+        "id": "364",
+        "name": "Wild Mage Samuel of the Villa"
+    }, {
+        "id": "413",
+        "name": "Mystic Axel of the Villa"
+    }, {
+        "id": "414",
+        "name": "Adept Leah of the Villa"
+    }, {
+        "id": "423",
+        "name": "Archmagus Azahl of the Villa"
+    }, {
+        "id": "470",
+        "name": "Battle Mage Dutorn of the Villa"
+    }, {
+        "id": "498",
+        "name": "Aeromancer Aleister of the Villa"
+    }, {
+        "id": "505",
+        "name": "Pyromancer Chiyo of the Villa"
+    }, {
+        "id": "515",
+        "name": "Archmagus Aleister of the Villa"
+    }, {
+        "id": "568",
+        "name": "Arch-Magician Danny of the Villa"
+    }, {
+        "id": "572",
+        "name": "Geomancer Bathsheba of the Villa"
+    }, {
+        "id": "718",
+        "name": "Silas of the Villa"
+    }, {
+        "id": "752",
+        "name": "David of the Villa"
+    }, {
+        "id": "915",
+        "name": "Alchemist Kryll of the Villa"
+    }, {
+        "id": "957",
+        "name": "Hedge Wizard Impy of the Villa"
+    }, {
+        "id": "1157",
+        "name": "Arch-Magician Allistair of the Villa"
+    }, {
+        "id": "1415",
+        "name": "Arch-Magician Zaros of the Villa"
+    }, {
+        "id": "1416",
+        "name": "Druid Gully of the Villa"
+    }, {
+        "id": "1424",
+        "name": "Enchanter Marceline of the Villa"
+    }, {
+        "id": "1566",
+        "name": "Null Mage Milton of the Villa"
+    }, {
+        "id": "1786",
+        "name": "Druid Axel of the Villa"
+    }, {
+        "id": "1814",
+        "name": "Pyromancer Tengu of the Villa"
+    }, {
+        "id": "1852",
+        "name": "Magus Kazud of the Villa"
+    }, {
+        "id": "1853",
+        "name": "Alchemist Crowley of the Villa"
+    }, {
+        "id": "1953",
+        "name": "Electromancer Aleister of the Villa"
+    }, {
+        "id": "1989",
+        "name": "Witch Gwendolin of the Villa"
+    }, {
+        "id": "2041",
+        "name": "Pyromancer George of the Villa"
+    }, {
+        "id": "2057",
+        "name": "Necromancer Chiron of the Villa"
+    }, {
+        "id": "2061",
+        "name": "Cleric  of the Villa"
+    }, {
+        "id": "2143",
+        "name": "Augurer Carly of the Villa"
+    }, {
+        "id": "2186",
+        "name": "Battle Mage Thor of the Villa"
+    }, {
+        "id": "2201",
+        "name": "Magus Cosmo of the Villa"
+    }, {
+        "id": "2208",
+        "name": "Sorcerer Ifran of the Villa"
+    }, {
+        "id": "2337",
+        "name": "Adept Sondra of the Villa"
+    }, {
+        "id": "2355",
+        "name": "Druid Aslan of the Villa"
+    }, {
+        "id": "2453",
+        "name": "Hedge Wizard Astrid of the Villa"
+    }, {
+        "id": "2552",
+        "name": "Archmagus Homer of the Villa"
+    }, {
+        "id": "2590",
+        "name": "Diabolist Jastor of the Villa"
+    }, {
+        "id": "2736",
+        "name": "Evoker Finn of the Villa"
+    }, {
+        "id": "2826",
+        "name": "Arcanist Devo of the Villa"
+    }, {
+        "id": "2891",
+        "name": "Sage Lumos of the Villa"
+    }, {
+        "id": "2899",
+        "name": "Witch Hestia of the Villa"
+    }, {
+        "id": "2955",
+        "name": "Sage Iluzor of the Villa"
+    }, {
+        "id": "3055",
+        "name": "Battle Mage Nolan of the Villa"
+    }, {
+        "id": "3096",
+        "name": "Cryptomancer Elena of the Villa"
+    }, {
+        "id": "3176",
+        "name": "Adept Nazim of the Villa"
+    }, {
+        "id": "3184",
+        "name": "Void Disciple Orpheus of the Villa"
+    }, {
+        "id": "3339",
+        "name": "Zelroth of the Villa"
+    }, {
+        "id": "3411",
+        "name": "Ghost Eater Oiq of the Villa"
+    }, {
+        "id": "3417",
+        "name": "Archmagus Merlon of the Villa"
+    }, {
+        "id": "3530",
+        "name": "Shadow Mage Elvio of the Villa"
+    }, {
+        "id": "3536",
+        "name": "Archmagus Chandler of the Villa"
+    }, {
+        "id": "3589",
+        "name": "Druid Calista of the Villa"
+    }, {
+        "id": "3593",
+        "name": "Chaos Mage Victoria of the Villa"
+    }, {
+        "id": "3629",
+        "name": "Magus Faiz of the Villa"
+    }, {
+        "id": "3744",
+        "name": "Archmagus Moka of the Villa"
+    }, {
+        "id": "3830",
+        "name": "Mystic Trollin of the Villa"
+    }, {
+        "id": "3856",
+        "name": "Hedge Wizard Suyin of the Villa"
+    }, {
+        "id": "3890",
+        "name": "Scryer Celah of the Villa"
+    }, {
+        "id": "3914",
+        "name": "Hex Mage Bathsheba of the Villa"
+    }, {
+        "id": "3917",
+        "name": "Scryer Apollo of the Villa"
+    }, {
+        "id": "4001",
+        "name": "Thaumaturge Kazem of the Villa"
+    }, {
+        "id": "4142",
+        "name": "Sorcerer Faiz of the Villa"
+    }, {
+        "id": "4181",
+        "name": "Voodoo Priest Le Blanc of the Villa"
+    }, {
+        "id": "4292",
+        "name": "Hex Mage Faiz of the Villa"
+    }, {
+        "id": "4295",
+        "name": "Mystic Hadrien of the Villa"
+    }, {
+        "id": "4297",
+        "name": "Battle Mage Baird of the Villa"
+    }, {
+        "id": "4383",
+        "name": "Adept Izible of the Villa"
+    }, {
+        "id": "4427",
+        "name": "Mystic Nolan of the Villa"
+    }, {
+        "id": "4550",
+        "name": "Enchanter Arabella of the Villa"
+    }, {
+        "id": "4608",
+        "name": "Clairvoyant Soya of the Villa"
+    }, {
+        "id": "4724",
+        "name": "Witch Calypso of the Villa"
+    }, {
+        "id": "4868",
+        "name": "George of the Villa"
+    }, {
+        "id": "4946",
+        "name": "Illusionist Ulysse of the Villa"
+    }, {
+        "id": "5005",
+        "name": "Battle Mage Tundror of the Villa"
+    }, {
+        "id": "5013",
+        "name": "Archmagus Aleister of the Villa"
+    }, {
+        "id": "5269",
+        "name": "Witch Ekmira of the Villa"
+    }, {
+        "id": "5290",
+        "name": "Runecaster Kalo of the Villa"
+    }, {
+        "id": "5449",
+        "name": "Conjurer Davos of the Villa"
+    }, {
+        "id": "5495",
+        "name": "Battle Mage Sturgis of the Villa"
+    }, {
+        "id": "5503",
+        "name": "Hedge Wizard Atlanta of the Villa"
+    }, {
+        "id": "5611",
+        "name": "Arcanist Elizabeth of the Villa"
+    }, {
+        "id": "5652",
+        "name": "Archmagus Isaac of the Villa"
+    }, {
+        "id": "5686",
+        "name": "Runecaster Cosmo of the Villa"
+    }, {
+        "id": "5775",
+        "name": "Hedge Wizard Ixar of the Villa"
+    }, {
+        "id": "5838",
+        "name": "Clairvoyant Cullen of the Villa"
+    }, {
+        "id": "6118",
+        "name": "Sorcerer Alizam of the Villa"
+    }, {
+        "id": "6145",
+        "name": "Hedge Wizard Robert of the Villa"
+    }, {
+        "id": "6173",
+        "name": "Druid Izible of the Villa"
+    }, {
+        "id": "6258",
+        "name": "Sorcerer Zelroth of the Villa"
+    }, {
+        "id": "6269",
+        "name": "Conjurer Lux of the Villa"
+    }, {
+        "id": "6307",
+        "name": "Witch Rowena of the Villa"
+    }, {
+        "id": "6388",
+        "name": "Sorcerer Hashim of the Villa"
+    }, {
+        "id": "6402",
+        "name": "Voodoo Priest Gallo of the Villa"
+    }, {
+        "id": "6542",
+        "name": "Necromancer Zeromus of the Villa"
+    }, {
+        "id": "6613",
+        "name": "Illusionist Tengu of the Villa"
+    }, {
+        "id": "6710",
+        "name": "Alchemist Idris of the Villa"
+    }, {
+        "id": "6715",
+        "name": "Electromancer George of the Villa"
+    }, {
+        "id": "6781",
+        "name": "Archmagus Nixie of the Villa"
+    }, {
+        "id": "6793",
+        "name": "Archmagus Crowley of the Villa"
+    }, {
+        "id": "6841",
+        "name": "Battle Mage Gary of the Villa"
+    }, {
+        "id": "6886",
+        "name": "Devo of the Villa"
+    }, {
+        "id": "7026",
+        "name": "Sage Magnus of the Villa"
+    }, {
+        "id": "7138",
+        "name": "Magus Pumlo of the Villa"
+    }, {
+        "id": "7201",
+        "name": "Hedge Wizard Voidoth of the Villa"
+    }, {
+        "id": "7320",
+        "name": "Cosmic Mage Hagar of the Villa"
+    }, {
+        "id": "7448",
+        "name": "Sorcerer Hadrien of the Villa"
+    }, {
+        "id": "7505",
+        "name": "Sorcerer Impy of the Villa"
+    }, {
+        "id": "7771",
+        "name": "Archmagus Solomon of the Villa"
+    }, {
+        "id": "7803",
+        "name": "Conjurer Zixin of the Villa"
+    }, {
+        "id": "7834",
+        "name": "Enchanter Thana of the Villa"
+    }, {
+        "id": "7843",
+        "name": "Shadow Mage Zane of the Villa"
+    }, {
+        "id": "7919",
+        "name": "Oracle Isaac of the Villa"
+    }, {
+        "id": "7981",
+        "name": "Hex Mage Amanita of the Villa"
+    }, {
+        "id": "8039",
+        "name": "Geomancer Wolfram of the Villa"
+    }, {
+        "id": "8209",
+        "name": "Diabolist Aleister of the Villa"
+    }, {
+        "id": "8291",
+        "name": "Shaman Louis of the Villa"
+    }, {
+        "id": "8336",
+        "name": "Arch-Magician Aleister of the Villa"
+    }, {
+        "id": "8430",
+        "name": "Sage Lumos of the Villa"
+    }, {
+        "id": "8490",
+        "name": "Aleister of the Villa"
+    }, {
+        "id": "8609",
+        "name": "Thaumaturge Isaac of the Villa"
+    }, {
+        "id": "8716",
+        "name": "Cleric Davos of the Villa"
+    }, {
+        "id": "8891",
+        "name": "Magus Pezo of the Villa"
+    }, {
+        "id": "9013",
+        "name": "Bathsheba of the Villa"
+    }, {
+        "id": "9014",
+        "name": "Sage Sylvia of the Villa"
+    }, {
+        "id": "9065",
+        "name": "Clairvoyant Raul of the Villa"
+    }, {
+        "id": "9178",
+        "name": "Necromancer Azazel of the Villa"
+    }, {
+        "id": "9182",
+        "name": "Alchemist Salty of the Villa"
+    }, {
+        "id": "9356",
+        "name": "Adept Bartholomew of the Villa"
+    }, {
+        "id": "9536",
+        "name": "Archmagus George of the Villa"
+    }, {
+        "id": "9598",
+        "name": "Pyromancer Koop of the Villa"
+    }, {
+        "id": "9704",
+        "name": "Shadow Mage Aleister of the Villa"
+    }, {
+        "id": "9971",
+        "name": "Thaumaturge Cairon of the Villa"
+    }],
+    "Moors": [{
+        "id": "2",
+        "name": "Archmagus Poppy of the Moors"
+    }, {
+        "id": "16",
+        "name": "Sorcerer Alessar of the Moors"
+    }, {
+        "id": "109",
+        "name": "Enchanter Lucinda of the Moors"
+    }, {
+        "id": "187",
+        "name": "Enchanter Katherine of the Moors"
+    }, {
+        "id": "315",
+        "name": "Archmagus Hecate of the Moors"
+    }, {
+        "id": "327",
+        "name": "Battle Mage Ulysse of the Moors"
+    }, {
+        "id": "329",
+        "name": "Bard Poppy of the Moors"
+    }, {
+        "id": "372",
+        "name": "Archmagus George of the Moors"
+    }, {
+        "id": "409",
+        "name": "Magus Liliana of the Moors"
+    }, {
+        "id": "436",
+        "name": "Shaman Aslan of the Moors"
+    }, {
+        "id": "545",
+        "name": "Illusionist Idris of the Moors"
+    }, {
+        "id": "759",
+        "name": "Ozohr of the Moors"
+    }, {
+        "id": "809",
+        "name": "Wild Mage Bathsheba of the Moors"
+    }, {
+        "id": "855",
+        "name": "Artificer Baozhai of the Moors"
+    }, {
+        "id": "865",
+        "name": "Calista of the Moors"
+    }, {
+        "id": "911",
+        "name": "Archmagus Sisk of the Moors"
+    }, {
+        "id": "986",
+        "name": "Witch Lamia of the Moors"
+    }, {
+        "id": "990",
+        "name": "Arcanist Titania of the Moors"
+    }, {
+        "id": "1022",
+        "name": "Artificer Chipper of the Moors"
+    }, {
+        "id": "1030",
+        "name": "Cryptomancer Lumos of the Moors"
+    }, {
+        "id": "1048",
+        "name": "Alchemist Pezo of the Moors"
+    }, {
+        "id": "1096",
+        "name": "Enchanter Devon of the Moors"
+    }, {
+        "id": "1103",
+        "name": "Electromancer Gunthor of the Moors"
+    }, {
+        "id": "1156",
+        "name": "Shaman Celeste of the Moors"
+    }, {
+        "id": "1171",
+        "name": "Hedge Wizard Faye of the Moors"
+    }, {
+        "id": "1261",
+        "name": "Artificer Merlon of the Moors"
+    }, {
+        "id": "1349",
+        "name": "Battle Mage Caligula of the Moors"
+    }, {
+        "id": "1360",
+        "name": "Sonja of the Moors"
+    }, {
+        "id": "1375",
+        "name": "Magus Celah of the Moors"
+    }, {
+        "id": "1491",
+        "name": "Enchanter Pierre of the Moors"
+    }, {
+        "id": "1494",
+        "name": "Artificer Shi of the Moors"
+    }, {
+        "id": "1603",
+        "name": "Magus Asmodeus of the Moors"
+    }, {
+        "id": "1689",
+        "name": "Battle Mage Robert of the Moors"
+    }, {
+        "id": "1724",
+        "name": "Archmagus Adium of the Moors"
+    }, {
+        "id": "1809",
+        "name": "Magus Hagatha of the Moors"
+    }, {
+        "id": "1885",
+        "name": "Aeromancer Bathsheba of the Moors"
+    }, {
+        "id": "1950",
+        "name": "Spellsinger Jastor of the Moors"
+    }, {
+        "id": "2006",
+        "name": "Battle Mage Flynn of the Moors"
+    }, {
+        "id": "2015",
+        "name": "Shadow Mage Titania of the Moors"
+    }, {
+        "id": "2054",
+        "name": "Sage Argus of the Moors"
+    }, {
+        "id": "2172",
+        "name": "Arch-Magician Nixie of the Moors"
+    }, {
+        "id": "2200",
+        "name": "Geomancer Eden of the Moors"
+    }, {
+        "id": "2246",
+        "name": "Sorcerer Qasim of the Moors"
+    }, {
+        "id": "2275",
+        "name": "Hedge Wizard Chiyo of the Moors"
+    }, {
+        "id": "2279",
+        "name": "Archmagus Eden of the Moors"
+    }, {
+        "id": "2288",
+        "name": "Shaman Evangeline of the Moors"
+    }, {
+        "id": "2302",
+        "name": "Sage Cedric of the Moors"
+    }, {
+        "id": "2333",
+        "name": "Battle Mage Nolan of the Moors"
+    }, {
+        "id": "2349",
+        "name": "Archmagus Davos of the Moors"
+    }, {
+        "id": "2376",
+        "name": "Enchanter Daphne of the Moors"
+    }, {
+        "id": "2386",
+        "name": "Magus Zevi of the Moors"
+    }, {
+        "id": "2470",
+        "name": "Archmagus Victoria of the Moors"
+    }, {
+        "id": "2518",
+        "name": "Hedge Wizard Sylvia of the Moors"
+    }, {
+        "id": "2534",
+        "name": "Sorcerer Ixar of the Moors"
+    }, {
+        "id": "2597",
+        "name": "Runecaster Kalo of the Moors"
+    }, {
+        "id": "2655",
+        "name": "Chronomancer Ming of the Moors"
+    }, {
+        "id": "2675",
+        "name": "Alchemist Xue of the Moors"
+    }, {
+        "id": "2691",
+        "name": "Geomancer Brutus of the Moors"
+    }, {
+        "id": "2737",
+        "name": "Witch Elizabeth of the Moors"
+    }, {
+        "id": "2774",
+        "name": "Magus Kamil of the Moors"
+    }, {
+        "id": "2885",
+        "name": "Sage Otto of the Moors"
+    }, {
+        "id": "2904",
+        "name": "Archmagus Orange Menace of the Moors"
+    }, {
+        "id": "3006",
+        "name": "Shaman Althea of the Moors"
+    }, {
+        "id": "3023",
+        "name": "Transmuter Aleister of the Moors"
+    }, {
+        "id": "3125",
+        "name": "Artificer Suki of the Moors"
+    }, {
+        "id": "3155",
+        "name": "Enchanter Artis of the Moors"
+    }, {
+        "id": "3230",
+        "name": "Geomancer Hothor of the Moors"
+    }, {
+        "id": "3321",
+        "name": "Void Disciple Voidoth of the Moors"
+    }, {
+        "id": "3369",
+        "name": "David of the Moors"
+    }, {
+        "id": "3400",
+        "name": "Mystic Atlas of the Moors"
+    }, {
+        "id": "3679",
+        "name": "Artificer Chanterelle of the Moors"
+    }, {
+        "id": "3690",
+        "name": "Mystic Hansel of the Moors"
+    }, {
+        "id": "4018",
+        "name": "Alchemist Daria of the Moors"
+    }, {
+        "id": "4151",
+        "name": "Enchanter Thana of the Moors"
+    }, {
+        "id": "4361",
+        "name": "Adept Sarah of the Moors"
+    }, {
+        "id": "4470",
+        "name": "Sorcerer Jerret of the Moors"
+    }, {
+        "id": "4589",
+        "name": "Archmagus Eden of the Moors"
+    }, {
+        "id": "4601",
+        "name": "Pyromancer Nixie of the Moors"
+    }, {
+        "id": "4778",
+        "name": "Hedge Wizard Sondra of the Moors"
+    }, {
+        "id": "5111",
+        "name": "Willow of the Moors"
+    }, {
+        "id": "5386",
+        "name": "Hedge Wizard Karasu of the Moors"
+    }, {
+        "id": "5427",
+        "name": "Battle Mage Eric of the Moors"
+    }, {
+        "id": "5490",
+        "name": "Necromancer Norix of the Moors"
+    }, {
+        "id": "5537",
+        "name": "Witch Rita of the Moors"
+    }, {
+        "id": "5569",
+        "name": "Alchemist Cassius of the Moors"
+    }, {
+        "id": "5596",
+        "name": "Alchemist Yookoo of the Moors"
+    }, {
+        "id": "5606",
+        "name": "Druid Nixie of the Moors"
+    }, {
+        "id": "5698",
+        "name": "Archmagus Uvlius of the Moors"
+    }, {
+        "id": "5738",
+        "name": "Battle Mage Cromwell of the Moors"
+    }, {
+        "id": "5783",
+        "name": "Necromancer Caligula of the Moors"
+    }, {
+        "id": "5807",
+        "name": "Sorcerer Qaid of the Moors"
+    }, {
+        "id": "5820",
+        "name": "Shaman Alessar of the Moors"
+    }, {
+        "id": "5821",
+        "name": "Ghost Eater Gorgana of the Moors"
+    }, {
+        "id": "5826",
+        "name": "Druid Aleister of the Moors"
+    }, {
+        "id": "5856",
+        "name": "Enchanter Thana of the Moors"
+    }, {
+        "id": "5999",
+        "name": "Charmer Jadis of the Moors"
+    }, {
+        "id": "6014",
+        "name": "Artificer Thor of the Moors"
+    }, {
+        "id": "6017",
+        "name": "Runecaster Solomon of the Moors"
+    }, {
+        "id": "6265",
+        "name": "Arch-Magician Konoha of the Moors"
+    }, {
+        "id": "6279",
+        "name": "Witch Jezebel of the Moors"
+    }, {
+        "id": "6313",
+        "name": "Illusionist Silas of the Moors"
+    }, {
+        "id": "6339",
+        "name": "Arch-Magician Ratko of the Moors"
+    }, {
+        "id": "6462",
+        "name": "Azahl of the Moors"
+    }, {
+        "id": "6522",
+        "name": "Cosmic Mage Drusilla of the Moors"
+    }, {
+        "id": "6533",
+        "name": "Witch Ekmira of the Moors"
+    }, {
+        "id": "6538",
+        "name": "Arch-Magician Shigenjo of the Moors"
+    }, {
+        "id": "6568",
+        "name": "Pyromancer Cassiopeia of the Moors"
+    }, {
+        "id": "6581",
+        "name": "Adept Aden of the Moors"
+    }, {
+        "id": "6619",
+        "name": "Sorcerer Cairon of the Moors"
+    }, {
+        "id": "6634",
+        "name": "Archmagus Lumos of the Moors"
+    }, {
+        "id": "6684",
+        "name": "Druid Yuki of the Moors"
+    }, {
+        "id": "6686",
+        "name": "Hydromancer  of the Moors"
+    }, {
+        "id": "6687",
+        "name": "Battle Mage Cromwell of the Moors"
+    }, {
+        "id": "6699",
+        "name": "Charmer Astrid of the Moors"
+    }, {
+        "id": "6704",
+        "name": "Ghost Eater Jadis of the Moors"
+    }, {
+        "id": "6927",
+        "name": "Magus Devin of the Moors"
+    }, {
+        "id": "7119",
+        "name": "Beyna of the Moors"
+    }, {
+        "id": "7145",
+        "name": "Arch-Magician Ali of the Moors"
+    }, {
+        "id": "7192",
+        "name": "Shaman Lamia of the Moors"
+    }, {
+        "id": "7198",
+        "name": "Archmagus Soya of the Moors"
+    }, {
+        "id": "7218",
+        "name": "Necromancer Vossler of the Moors"
+    }, {
+        "id": "7262",
+        "name": "Hedge Wizard Eliphas of the Moors"
+    }, {
+        "id": "7495",
+        "name": "Shaman Ifran of the Moors"
+    }, {
+        "id": "7528",
+        "name": "Alchemist Lux of the Moors"
+    }, {
+        "id": "7722",
+        "name": "Cryptomancer Aiko of the Moors"
+    }, {
+        "id": "7768",
+        "name": "Artificer Jasper of the Moors"
+    }, {
+        "id": "7823",
+        "name": "Sorcerer Eden of the Moors"
+    }, {
+        "id": "7850",
+        "name": "Hydromancer Carly of the Moors"
+    }, {
+        "id": "7895",
+        "name": "Witch Lilith of the Moors"
+    }, {
+        "id": "7953",
+        "name": "Battle Mage Nicolas of the Moors"
+    }, {
+        "id": "8014",
+        "name": "Sorcerer Ifran of the Moors"
+    }, {
+        "id": "8021",
+        "name": "Archmagus Uvlius of the Moors"
+    }, {
+        "id": "8138",
+        "name": "Bard Voidoth of the Moors"
+    }, {
+        "id": "8155",
+        "name": "Necromancer Hansel of the Moors"
+    }, {
+        "id": "8330",
+        "name": "Arcanist Celeste of the Moors"
+    }, {
+        "id": "8333",
+        "name": "Hydromancer Ivy of the Moors"
+    }, {
+        "id": "8461",
+        "name": "Wild Mage Devin of the Moors"
+    }, {
+        "id": "8486",
+        "name": "Wild Mage Angus of the Moors"
+    }, {
+        "id": "8505",
+        "name": "Archmagus Isaac of the Moors"
+    }, {
+        "id": "8606",
+        "name": "Chaos Mage Blaise of the Moors"
+    }, {
+        "id": "8686",
+        "name": "Wild Mage Ethan of the Moors"
+    }, {
+        "id": "8724",
+        "name": "Enchanter Titania of the Moors"
+    }, {
+        "id": "8782",
+        "name": "Druid Milo of the Moors"
+    }, {
+        "id": "8869",
+        "name": "Solomon of the Moors"
+    }, {
+        "id": "8950",
+        "name": "Alchemist Alessar of the Moors"
+    }, {
+        "id": "8973",
+        "name": "Charmer Beyna of the Moors"
+    }, {
+        "id": "8978",
+        "name": "Hedge Wizard Cromwell of the Moors"
+    }, {
+        "id": "8981",
+        "name": "Charmer Althea of the Moors"
+    }, {
+        "id": "9053",
+        "name": "Magus Aslan of the Moors"
+    }, {
+        "id": "9156",
+        "name": "Illusionist Sonja of the Moors"
+    }, {
+        "id": "9167",
+        "name": "Archmagus Iprix of the Moors"
+    }, {
+        "id": "9298",
+        "name": "Diabolist Sabina of the Moors"
+    }, {
+        "id": "9382",
+        "name": "Battle Mage Luther of the Moors"
+    }, {
+        "id": "9527",
+        "name": "Sky Master Rook of the Moors"
+    }, {
+        "id": "9549",
+        "name": "Adept Cybele of the Moors"
+    }, {
+        "id": "9581",
+        "name": "Artificer Finch of the Moors"
+    }, {
+        "id": "9583",
+        "name": "Alchemist Bathsheba of the Moors"
+    }, {
+        "id": "9592",
+        "name": "Arcanist Oiq of the Moors"
+    }, {
+        "id": "9634",
+        "name": "Archmagus Milton of the Moors"
+    }, {
+        "id": "9649",
+        "name": "Pyromancer Velorina of the Moors"
+    }, {
+        "id": "9784",
+        "name": "Conjurer Calliope of the Moors"
+    }, {
+        "id": "9938",
+        "name": "Charmer Sonja of the Moors"
+    }, {
+        "id": "9982",
+        "name": "Diviner Sondra of the Moors"
+    }],
+    "Sands": [{
+        "id": "197",
+        "name": "Arch-Magician Aslan of the Sands"
+    }, {
+        "id": "307",
+        "name": "Adept Argus of the Sands"
+    }, {
+        "id": "485",
+        "name": "Arch-Magician George of the Sands"
+    }, {
+        "id": "520",
+        "name": "Battle Mage Bayard of the Sands"
+    }, {
+        "id": "564",
+        "name": "Hedge Wizard Otto of the Sands"
+    }, {
+        "id": "633",
+        "name": "Battle Mage Blaise of the Sands"
+    }, {
+        "id": "1033",
+        "name": "Druid Bullock of the Sands"
+    }, {
+        "id": "1176",
+        "name": "Aeromancer Aleister of the Sands"
+    }, {
+        "id": "1313",
+        "name": "Archmagus Celah of the Sands"
+    }, {
+        "id": "1331",
+        "name": "Sage Setsuko of the Sands"
+    }, {
+        "id": "1481",
+        "name": "Artificer Fabio of the Sands"
+    }, {
+        "id": "1666",
+        "name": "Chaos Mage Charlord of the Sands"
+    }, {
+        "id": "2216",
+        "name": "Cleric Samuel of the Sands"
+    }, {
+        "id": "2306",
+        "name": "Hedge Wizard Jig of the Sands"
+    }, {
+        "id": "2428",
+        "name": "Hedge Wizard Aslan of the Sands"
+    }, {
+        "id": "2461",
+        "name": "Sorcerer Remus of the Sands"
+    }, {
+        "id": "2509",
+        "name": "Magus Ifran of the Sands"
+    }, {
+        "id": "2920",
+        "name": "Electromancer Hashim of the Sands"
+    }, {
+        "id": "3031",
+        "name": "Sorcerer Alizam of the Sands"
+    }, {
+        "id": "3049",
+        "name": "Charmer Sondra of the Sands"
+    }, {
+        "id": "3100",
+        "name": "Adept Hank of the Sands"
+    }, {
+        "id": "3180",
+        "name": "Battle Mage Brutus of the Sands"
+    }, {
+        "id": "3244",
+        "name": "Udor of the Sands"
+    }, {
+        "id": "3280",
+        "name": "Enchanter Daphne of the Sands"
+    }, {
+        "id": "3493",
+        "name": "Mystic Danny of the Sands"
+    }, {
+        "id": "3641",
+        "name": "Battle Mage Eric of the Sands"
+    }, {
+        "id": "3759",
+        "name": "Arcanist Eronin of the Sands"
+    }, {
+        "id": "3768",
+        "name": "Battle Mage Goliath of the Sands"
+    }, {
+        "id": "3913",
+        "name": "Adept Umber of the Sands"
+    }, {
+        "id": "3927",
+        "name": "Arch-Magician Shanyuan of the Sands"
+    }, {
+        "id": "4106",
+        "name": "Chaos Mage Eric of the Sands"
+    }, {
+        "id": "4129",
+        "name": "Sorcerer George of the Sands"
+    }, {
+        "id": "4178",
+        "name": "Voodoo Priest Pierre of the Sands"
+    }, {
+        "id": "4683",
+        "name": "Shaman Lumos of the Sands"
+    }, {
+        "id": "4687",
+        "name": "Transmuter Feng of the Sands"
+    }, {
+        "id": "4698",
+        "name": "Shaman Aslan of the Sands"
+    }, {
+        "id": "4994",
+        "name": "Shaman Tumbaj of the Sands"
+    }, {
+        "id": "5268",
+        "name": "Arch-Magician Nikolas of the Sands"
+    }, {
+        "id": "5472",
+        "name": "Holy Monk Rocco of the Sands"
+    }, {
+        "id": "5477",
+        "name": "Arcanist Qasim of the Sands"
+    }, {
+        "id": "5512",
+        "name": "Enchanter Hadrien of the Sands"
+    }, {
+        "id": "5549",
+        "name": "Archmagus Crowley of the Sands"
+    }, {
+        "id": "5874",
+        "name": "Shaman Tundror of the Sands"
+    }, {
+        "id": "6073",
+        "name": "Battle Mage Durm of the Sands"
+    }, {
+        "id": "6221",
+        "name": "Arch-Magician Finch of the Sands"
+    }, {
+        "id": "6225",
+        "name": "Shaman Ekmira of the Sands"
+    }, {
+        "id": "6463",
+        "name": "Conjurer Casper of the Sands"
+    }, {
+        "id": "6475",
+        "name": "Shadow Mage George of the Sands"
+    }, {
+        "id": "6813",
+        "name": "Sorcerer Hadrien of the Sands"
+    }, {
+        "id": "6871",
+        "name": "Shaman Ozohr of the Sands"
+    }, {
+        "id": "6981",
+        "name": "Wild Mage Hansel of the Sands"
+    }, {
+        "id": "7151",
+        "name": "Enchanter Celeste of the Sands"
+    }, {
+        "id": "7177",
+        "name": "Illusionist Rafiq of the Sands"
+    }, {
+        "id": "7265",
+        "name": "Conjurer Kazem of the Sands"
+    }, {
+        "id": "8040",
+        "name": "Shaman Nazim of the Sands"
+    }, {
+        "id": "8150",
+        "name": "Magus Suyin of the Sands"
+    }, {
+        "id": "8285",
+        "name": "Battle Mage Nicolas of the Sands"
+    }, {
+        "id": "8303",
+        "name": "Sorcerer Reza of the Sands"
+    }, {
+        "id": "8327",
+        "name": "Sorcerer Kazem of the Sands"
+    }, {
+        "id": "8444",
+        "name": "Solomon of the Sands"
+    }, {
+        "id": "8448",
+        "name": "Hedge Wizard Samuel of the Sands"
+    }, {
+        "id": "8479",
+        "name": "Holy Monk Dario of the Sands"
+    }, {
+        "id": "8683",
+        "name": "Magus Kazem of the Sands"
+    }, {
+        "id": "8985",
+        "name": "Oracle Shivra of the Sands"
+    }, {
+        "id": "9576",
+        "name": "Magus Dante of the Sands"
+    }, {
+        "id": "9644",
+        "name": "Shadow Mage Onaxx of the Sands"
+    }, {
+        "id": "9756",
+        "name": "Battle Mage Talon of the Sands"
+    }, {
+        "id": "9761",
+        "name": "Magus Huizhong of the Sands"
+    }],
+    "Pit": [{
+        "id": "234",
+        "name": "Witch Edge of the Pit"
+    }, {
+        "id": "500",
+        "name": "Witch Lilith of the Pit"
+    }, {
+        "id": "552",
+        "name": "Sorcerer Merlon of the Pit"
+    }, {
+        "id": "740",
+        "name": "Solar Mage Liliana of the Pit"
+    }, {
+        "id": "1163",
+        "name": "Enchanter Artis of the Pit"
+    }, {
+        "id": "1287",
+        "name": "Necromancer Isaac of the Pit"
+    }, {
+        "id": "1553",
+        "name": "Magus Jameel of the Pit"
+    }, {
+        "id": "1620",
+        "name": "Archmagus Hadrien of the Pit"
+    }, {
+        "id": "2036",
+        "name": "Silas of the Pit"
+    }, {
+        "id": "2457",
+        "name": "Sage Demos of the Pit"
+    }, {
+        "id": "3558",
+        "name": "Battlemage Aleister of the Pit"
+    }, {
+        "id": "3568",
+        "name": "Archmagus Alessar of the Pit"
+    }, {
+        "id": "3756",
+        "name": "Archmagus Amir of the Pit"
+    }, {
+        "id": "3777",
+        "name": "Sorcerer Jerret of the Pit"
+    }, {
+        "id": "4179",
+        "name": "Archmagus Casper of the Pit"
+    }, {
+        "id": "4437",
+        "name": "Battle Mage Bayard of the Pit"
+    }, {
+        "id": "5055",
+        "name": "Archmagus Asmodeus of the Pit"
+    }, {
+        "id": "5747",
+        "name": "Archmagus Cullen of the Pit"
+    }, {
+        "id": "5748",
+        "name": "Shadow Mage Apollo of the Pit"
+    }, {
+        "id": "6063",
+        "name": "Battle Mage Brutus of the Pit"
+    }, {
+        "id": "6121",
+        "name": "Archmagus Lumos of the Pit"
+    }, {
+        "id": "6122",
+        "name": "Void Disciple Orbus of the Pit"
+    }, {
+        "id": "6425",
+        "name": "Battle Mage Ratko of the Pit"
+    }, {
+        "id": "6617",
+        "name": "Electromancer Flynn of the Pit"
+    }, {
+        "id": "6917",
+        "name": "Sorcerer Taqi of the Pit"
+    }, {
+        "id": "6969",
+        "name": "Thaumaturge Nicolas of the Pit"
+    }, {
+        "id": "6999",
+        "name": "Argus of the Pit"
+    }, {
+        "id": "7020",
+        "name": "Necromancer Scratch of the Pit"
+    }, {
+        "id": "7041",
+        "name": "Battle Mage Ulysse of the Pit"
+    }, {
+        "id": "7115",
+        "name": "Pyromancer Demos of the Pit"
+    }, {
+        "id": "7158",
+        "name": "Pyromancer Scorch of the Pit"
+    }, {
+        "id": "7617",
+        "name": "Mystic Magpie of the Pit"
+    }, {
+        "id": "8148",
+        "name": "Shadow Mage Lamia of the Pit"
+    }, {
+        "id": "9523",
+        "name": "Orpheus of the Pit"
+    }, {
+        "id": "9550",
+        "name": "Sky Master Magpie of the Pit"
+    }, {
+        "id": "9653",
+        "name": "Alchemist Zelroth of the Pit"
+    }],
+    "Psychic Leap": [{
+        "id": "95",
+        "name": "Sorcerer Soya of the Psychic Leap"
+    }, {
+        "id": "358",
+        "name": "Alchemist Eden of the Psychic Leap"
+    }, {
+        "id": "689",
+        "name": "Battle Mage Goliath of the Psychic Leap"
+    }, {
+        "id": "991",
+        "name": "Soran of the Psychic Leap"
+    }, {
+        "id": "1183",
+        "name": "Sage Vatar of the Psychic Leap"
+    }, {
+        "id": "1412",
+        "name": "Cleric Hadrien of the Psychic Leap"
+    }, {
+        "id": "1496",
+        "name": "Alchemist Azahl of the Psychic Leap"
+    }, {
+        "id": "1546",
+        "name": "Conjurer Mei of the Psychic Leap"
+    }, {
+        "id": "1678",
+        "name": "Shadow Mage Hagar of the Psychic Leap"
+    }, {
+        "id": "1720",
+        "name": "Necromancer Voidoth of the Psychic Leap"
+    }, {
+        "id": "1813",
+        "name": "Druid Arabella of the Psychic Leap"
+    }, {
+        "id": "1975",
+        "name": "Archmagus Remus of the Psychic Leap"
+    }, {
+        "id": "2003",
+        "name": "Diabolist Evangeline of the Psychic Leap"
+    }, {
+        "id": "2202",
+        "name": "Clairvoyant Nemo of the Psychic Leap"
+    }, {
+        "id": "2238",
+        "name": "Sorcerer Soran of the Psychic Leap"
+    }, {
+        "id": "2407",
+        "name": "Medium George of the Psychic Leap"
+    }, {
+        "id": "2549",
+        "name": "Archmagus Amir of the Psychic Leap"
+    }, {
+        "id": "2607",
+        "name": "Mystic Hadrien of the Psychic Leap"
+    }, {
+        "id": "2625",
+        "name": "Arcanist Huan of the Psychic Leap"
+    }, {
+        "id": "2653",
+        "name": "Druid Uvlius of the Psychic Leap"
+    }, {
+        "id": "2773",
+        "name": "Archmagus Eizo of the Psychic Leap"
+    }, {
+        "id": "3010",
+        "name": "Enchanter Sonja of the Psychic Leap"
+    }, {
+        "id": "3075",
+        "name": "Charmer Sondra of the Psychic Leap"
+    }, {
+        "id": "3084",
+        "name": "Enchanter Casper of the Psychic Leap"
+    }, {
+        "id": "3086",
+        "name": "Pyromancer Jay of the Psychic Leap"
+    }, {
+        "id": "3199",
+        "name": "Hex Mage Hagar of the Psychic Leap"
+    }, {
+        "id": "3291",
+        "name": "Archmagus Ofaris of the Psychic Leap"
+    }, {
+        "id": "3430",
+        "name": "Sorcerer Davos of the Psychic Leap"
+    }, {
+        "id": "3476",
+        "name": "Archmagus  of the Psychic Leap"
+    }, {
+        "id": "3894",
+        "name": "Diviner Soya of the Psychic Leap"
+    }, {
+        "id": "3942",
+        "name": "Holy Magus Providence of the Psychic Leap"
+    }, {
+        "id": "4204",
+        "name": "Runecaster Kalo of the Psychic Leap"
+    }, {
+        "id": "4303",
+        "name": "Magus Shanyuan of the Psychic Leap"
+    }, {
+        "id": "4355",
+        "name": "Voodoo Priest Lucien of the Psychic Leap"
+    }, {
+        "id": "4699",
+        "name": "Sky Master Crowley of the Psychic Leap"
+    }, {
+        "id": "4789",
+        "name": "Void Disciple Seth of the Psychic Leap"
+    }, {
+        "id": "5059",
+        "name": "Electromancer Baird of the Psychic Leap"
+    }, {
+        "id": "5146",
+        "name": "Thaumaturge Drokore of the Psychic Leap"
+    }, {
+        "id": "5221",
+        "name": "Chronomancer Faiz of the Psychic Leap"
+    }, {
+        "id": "5348",
+        "name": "Artificer Bayard of the Psychic Leap"
+    }, {
+        "id": "5564",
+        "name": "Hydromancer Soran of the Psychic Leap"
+    }, {
+        "id": "5628",
+        "name": "Battle Mage Ethan of the Psychic Leap"
+    }, {
+        "id": "5853",
+        "name": "Archmagus Lumos of the Psychic Leap"
+    }, {
+        "id": "5870",
+        "name": "Druid Ixar of the Psychic Leap"
+    }, {
+        "id": "5912",
+        "name": "Null Mage Flynn of the Psychic Leap"
+    }, {
+        "id": "6116",
+        "name": "Artificer Bathsheba of the Psychic Leap"
+    }, {
+        "id": "6119",
+        "name": "Summoner Wolfram of the Psychic Leap"
+    }, {
+        "id": "6187",
+        "name": "Evoker Samuel of the Psychic Leap"
+    }, {
+        "id": "6209",
+        "name": "Hedge Wizard Alessar of the Psychic Leap"
+    }, {
+        "id": "6612",
+        "name": "Magus Lux of the Psychic Leap"
+    }, {
+        "id": "6631",
+        "name": "Battle Mage Homer of the Psychic Leap"
+    }, {
+        "id": "7055",
+        "name": "Hedge Wizard Axis of the Psychic Leap"
+    }, {
+        "id": "7103",
+        "name": "Enchanter Circe of the Psychic Leap"
+    }, {
+        "id": "7135",
+        "name": "Alchemist Jezebel of the Psychic Leap"
+    }, {
+        "id": "7144",
+        "name": "Enchanter Ariadne of the Psychic Leap"
+    }, {
+        "id": "7263",
+        "name": "Archmagus Milo of the Psychic Leap"
+    }, {
+        "id": "7521",
+        "name": "Cosmic Mage Azar of the Psychic Leap"
+    }, {
+        "id": "7704",
+        "name": "Archmagus Oberon of the Psychic Leap"
+    }, {
+        "id": "7712",
+        "name": "Diabolist Beyna of the Psychic Leap"
+    }, {
+        "id": "7841",
+        "name": "Runecaster Taqi of the Psychic Leap"
+    }, {
+        "id": "8056",
+        "name": "Mystic Khudalf of the Psychic Leap"
+    }, {
+        "id": "8168",
+        "name": "Alchemist Jack of the Psychic Leap"
+    }, {
+        "id": "8205",
+        "name": "Cleric Nolan of the Psychic Leap"
+    }, {
+        "id": "9341",
+        "name": "Druid Sabina of the Psychic Leap"
+    }, {
+        "id": "9873",
+        "name": "Magus Aldus of the Psychic Leap"
+    }],
+    "Steppe": [{
+        "id": "63",
+        "name": "Magus Zhan of the Steppe"
+    }, {
+        "id": "84",
+        "name": "Alchemist Ratko of the Steppe"
+    }, {
+        "id": "102",
+        "name": "Battle Mage Cassius of the Steppe"
+    }, {
+        "id": "207",
+        "name": "Arch-Magician Zolona of the Steppe"
+    }, {
+        "id": "233",
+        "name": "Enchanter Daphne of the Steppe"
+    }, {
+        "id": "256",
+        "name": "Hedge Wizard Brown Cow of the Steppe"
+    }, {
+        "id": "402",
+        "name": "Enchanter Faye of the Steppe"
+    }, {
+        "id": "429",
+        "name": "Alchemist Hank of the Steppe"
+    }, {
+        "id": "456",
+        "name": "Charmer Layla of the Steppe"
+    }, {
+        "id": "538",
+        "name": "Enchanter Carly of the Steppe"
+    }, {
+        "id": "642",
+        "name": "Magus Kazem of the Steppe"
+    }, {
+        "id": "744",
+        "name": "Magus Cedric of the Steppe"
+    }, {
+        "id": "758",
+        "name": "Wild Mage Hadrien of the Steppe"
+    }, {
+        "id": "887",
+        "name": "Arcanist Aleister of the Steppe"
+    }, {
+        "id": "889",
+        "name": "Magus Taqi of the Steppe"
+    }, {
+        "id": "902",
+        "name": "Witch Sylvia of the Steppe"
+    }, {
+        "id": "941",
+        "name": "Ofaris of the Steppe"
+    }, {
+        "id": "1062",
+        "name": "Archmagus Silas of the Steppe"
+    }, {
+        "id": "1083",
+        "name": "Witch Zolona of the Steppe"
+    }, {
+        "id": "1086",
+        "name": "Witch Lilith of the Steppe"
+    }, {
+        "id": "1155",
+        "name": "Null Mage Chooki of the Steppe"
+    }, {
+        "id": "1212",
+        "name": "Arch-Magician Solomon of the Steppe"
+    }, {
+        "id": "1264",
+        "name": "Scryer Dutorn of the Steppe"
+    }, {
+        "id": "1339",
+        "name": "Battle Mage Baird of the Steppe"
+    }, {
+        "id": "1419",
+        "name": "Shaman Alice of the Steppe"
+    }, {
+        "id": "1428",
+        "name": "Magus Xiaosheng of the Steppe"
+    }, {
+        "id": "1530",
+        "name": "Alchemist Bartholomew of the Steppe"
+    }, {
+        "id": "1585",
+        "name": "Arch-Magician Miyo of the Steppe"
+    }, {
+        "id": "1634",
+        "name": "Druid Pepo of the Steppe"
+    }, {
+        "id": "1682",
+        "name": "Wizard Trollin of the Steppe"
+    }, {
+        "id": "1743",
+        "name": "Hedge Wizard Calista of the Steppe"
+    }, {
+        "id": "1781",
+        "name": "Arch-Magician Ixar of the Steppe"
+    }, {
+        "id": "1856",
+        "name": "Cleric Cromwell of the Steppe"
+    }, {
+        "id": "1880",
+        "name": "Shaman Leah of the Steppe"
+    }, {
+        "id": "1895",
+        "name": "Archmagus Isaac of the Steppe"
+    }, {
+        "id": "1946",
+        "name": "Hydromancer Diana of the Steppe"
+    }, {
+        "id": "2023",
+        "name": "Diabolist Dante of the Steppe"
+    }, {
+        "id": "2112",
+        "name": "Archmagus Aleister of the Steppe"
+    }, {
+        "id": "2257",
+        "name": "Sorcerer Oberon of the Steppe"
+    }, {
+        "id": "2320",
+        "name": "Shaman Flynn of the Steppe"
+    }, {
+        "id": "2321",
+        "name": "Sorcerer Jahid of the Steppe"
+    }, {
+        "id": "2403",
+        "name": "Enchanter Hothor of the Steppe"
+    }, {
+        "id": "2418",
+        "name": "Diana of the Steppe"
+    }, {
+        "id": "2451",
+        "name": "Hedge Wizard Pezo of the Steppe"
+    }, {
+        "id": "2477",
+        "name": "Shadow Mage Requiem of the Steppe"
+    }, {
+        "id": "2541",
+        "name": "Sorcerer Idris of the Steppe"
+    }, {
+        "id": "2570",
+        "name": "Geomancer Wolfram of the Steppe"
+    }, {
+        "id": "2578",
+        "name": "Aeromancer Rumpleskin of the Steppe"
+    }, {
+        "id": "2640",
+        "name": "Charmer Carly of the Steppe"
+    }, {
+        "id": "2658",
+        "name": "Hedge Wizard Nicolas of the Steppe"
+    }, {
+        "id": "2669",
+        "name": "Artificer Hanko of the Steppe"
+    }, {
+        "id": "2769",
+        "name": "Ghost Eater Ethan of the Steppe"
+    }, {
+        "id": "2810",
+        "name": "Druid Jahid of the Steppe"
+    }, {
+        "id": "2850",
+        "name": "Alchemist Rowena of the Steppe"
+    }, {
+        "id": "2860",
+        "name": "Augurer Corky of the Steppe"
+    }, {
+        "id": "2945",
+        "name": "Oracle Durm of the Steppe"
+    }, {
+        "id": "2985",
+        "name": "Archmagus  of the Steppe"
+    }, {
+        "id": "3043",
+        "name": "Adept Devo of the Steppe"
+    }, {
+        "id": "3078",
+        "name": "Enchanter Xiaobo of the Steppe"
+    }, {
+        "id": "3153",
+        "name": "Void Disciple Mina of the Steppe"
+    }, {
+        "id": "3218",
+        "name": "Thaumaturge Magnus of the Steppe"
+    }, {
+        "id": "3269",
+        "name": "Artificer Pezo of the Steppe"
+    }, {
+        "id": "3300",
+        "name": "Alchemist Uday of the Steppe"
+    }, {
+        "id": "3341",
+        "name": "Enchanter Davos of the Steppe"
+    }, {
+        "id": "3367",
+        "name": "Enchanter Misumi of the Steppe"
+    }, {
+        "id": "3373",
+        "name": "Wild Mage Ozohr of the Steppe"
+    }, {
+        "id": "3409",
+        "name": "Uvlius of the Steppe"
+    }, {
+        "id": "3446",
+        "name": "Stellar Mage Aamon of the Steppe"
+    }, {
+        "id": "3495",
+        "name": "Shadow Mage Seth of the Steppe"
+    }, {
+        "id": "3516",
+        "name": "Pyromancer Crowley of the Steppe"
+    }, {
+        "id": "3545",
+        "name": "Runecaster Atlanta of the Steppe"
+    }, {
+        "id": "3559",
+        "name": "Shaman Stag of the Steppe"
+    }, {
+        "id": "3577",
+        "name": "Milo of the Steppe"
+    }, {
+        "id": "3688",
+        "name": "Sorcerer Amir of the Steppe"
+    }, {
+        "id": "3703",
+        "name": "Ghost Eater Ghorhoth of the Steppe"
+    }, {
+        "id": "3796",
+        "name": "Celah of the Steppe"
+    }, {
+        "id": "3800",
+        "name": "Charmer Thana of the Steppe"
+    }, {
+        "id": "3884",
+        "name": "Illusionist Buttons of the Steppe"
+    }, {
+        "id": "3923",
+        "name": "Hedge Wizard Min of the Steppe"
+    }, {
+        "id": "3940",
+        "name": "Magus Lux of the Steppe"
+    }, {
+        "id": "3946",
+        "name": "Thaumaturge Sarah of the Steppe"
+    }, {
+        "id": "3956",
+        "name": "Void Disciple Anton of the Steppe"
+    }, {
+        "id": "4010",
+        "name": "Archmagus Aleister of the Steppe"
+    }, {
+        "id": "4091",
+        "name": "Arcanist Jerret of the Steppe"
+    }, {
+        "id": "4158",
+        "name": "Artificer Jabir of the Steppe"
+    }, {
+        "id": "4211",
+        "name": "Pyromancer Sisk of the Steppe"
+    }, {
+        "id": "4222",
+        "name": "Cleric Chiron of the Steppe"
+    }, {
+        "id": "4239",
+        "name": "Magus Rita of the Steppe"
+    }, {
+        "id": "4269",
+        "name": "Celeste of the Steppe"
+    }, {
+        "id": "4350",
+        "name": "Sage Sabina of the Steppe"
+    }, {
+        "id": "4528",
+        "name": "Diabolist Sarah of the Steppe"
+    }, {
+        "id": "4530",
+        "name": "Jadis of the Steppe"
+    }, {
+        "id": "4564",
+        "name": "Hedge Wizard Ursula of the Steppe"
+    }, {
+        "id": "4690",
+        "name": "Enchanter Cassiopeia of the Steppe"
+    }, {
+        "id": "4745",
+        "name": "Alchemist Mycho of the Steppe"
+    }, {
+        "id": "4784",
+        "name": "Sage Atlas of the Steppe"
+    }, {
+        "id": "4848",
+        "name": "Witch Drusilla of the Steppe"
+    }, {
+        "id": "4863",
+        "name": "Sage Bartholomew of the Steppe"
+    }, {
+        "id": "4873",
+        "name": "Archmagus Cedric of the Steppe"
+    }, {
+        "id": "4903",
+        "name": "Enchanter Carly of the Steppe"
+    }, {
+        "id": "5002",
+        "name": "Alchemist Remus of the Steppe"
+    }, {
+        "id": "5079",
+        "name": "Hedge Wizard Ratko of the Steppe"
+    }, {
+        "id": "5113",
+        "name": "Archmagus Basil of the Steppe"
+    }, {
+        "id": "5119",
+        "name": "Enchanter Titania of the Steppe"
+    }, {
+        "id": "5200",
+        "name": "Clairvoyant Chu Hua of the Steppe"
+    }, {
+        "id": "5210",
+        "name": "Arch-Magician Rowena of the Steppe"
+    }, {
+        "id": "5241",
+        "name": "Enchanter Celeste of the Steppe"
+    }, {
+        "id": "5332",
+        "name": "Hydromancer Homer of the Steppe"
+    }, {
+        "id": "5342",
+        "name": "Battlemage Galatea of the Steppe"
+    }, {
+        "id": "5352",
+        "name": "Artificer Arabella of the Steppe"
+    }, {
+        "id": "5353",
+        "name": "Battle Mage Talbot of the Steppe"
+    }, {
+        "id": "5388",
+        "name": "Witch Zolona of the Steppe"
+    }, {
+        "id": "5430",
+        "name": "Arcanist Talbot of the Steppe"
+    }, {
+        "id": "5463",
+        "name": "Magus Jadis of the Steppe"
+    }, {
+        "id": "5536",
+        "name": "Magus Carly of the Steppe"
+    }, {
+        "id": "5669",
+        "name": "Sage Hind of the Steppe"
+    }, {
+        "id": "5724",
+        "name": "Battlemage Daria of the Steppe"
+    }, {
+        "id": "5742",
+        "name": "Witch Liliana of the Steppe"
+    }, {
+        "id": "5763",
+        "name": "Runecaster Cromwell of the Steppe"
+    }, {
+        "id": "5780",
+        "name": "Sage Borak of the Steppe"
+    }, {
+        "id": "5823",
+        "name": "Diabolist Burnside of the Steppe"
+    }, {
+        "id": "5879",
+        "name": "Runecaster Soran of the Steppe"
+    }, {
+        "id": "5885",
+        "name": "Runecaster Huizhong of the Steppe"
+    }, {
+        "id": "5904",
+        "name": "Enchanter Calliope of the Steppe"
+    }, {
+        "id": "5980",
+        "name": "Battle Mage Caligula of the Steppe"
+    }, {
+        "id": "6009",
+        "name": "Archmagus Bayard of the Steppe"
+    }, {
+        "id": "6028",
+        "name": "Alchemist Devon of the Steppe"
+    }, {
+        "id": "6069",
+        "name": "Pyromancer Carly of the Steppe"
+    }, {
+        "id": "6184",
+        "name": "Hedge Wizard Herne of the Steppe"
+    }, {
+        "id": "6189",
+        "name": "Druid Leah of the Steppe"
+    }, {
+        "id": "6267",
+        "name": "Adept Tundror of the Steppe"
+    }, {
+        "id": "6416",
+        "name": "Fortune Teller Fumiko of the Steppe"
+    }, {
+        "id": "6427",
+        "name": "Arcanist Bathsheba of the Steppe"
+    }, {
+        "id": "6487",
+        "name": "Ozohr of the Steppe"
+    }, {
+        "id": "6507",
+        "name": "Hedge Wizard Rixxa of the Steppe"
+    }, {
+        "id": "6541",
+        "name": "Summoner Iprix of the Steppe"
+    }, {
+        "id": "6574",
+        "name": "Magus Alatar of the Steppe"
+    }, {
+        "id": "6629",
+        "name": "Artificer Setsuko of the Steppe"
+    }, {
+        "id": "6682",
+        "name": "Witch Lavinia of the Steppe"
+    }, {
+        "id": "6714",
+        "name": "Pyromancer Khudalf of the Steppe"
+    }, {
+        "id": "6755",
+        "name": "Daphne of the Steppe"
+    }, {
+        "id": "6762",
+        "name": "Archmagus Jerret of the Steppe"
+    }, {
+        "id": "6858",
+        "name": "Hedge Wizard Ariadne of the Steppe"
+    }, {
+        "id": "6864",
+        "name": "Augurer Wolfram of the Steppe"
+    }, {
+        "id": "6944",
+        "name": "Electromancer Shigenjo of the Steppe"
+    }, {
+        "id": "6964",
+        "name": "Alchemist Chyou of the Steppe"
+    }, {
+        "id": "6970",
+        "name": "Sorcerer Zane of the Steppe"
+    }, {
+        "id": "7032",
+        "name": "Arch-Magician Carly of the Steppe"
+    }, {
+        "id": "7035",
+        "name": "Witch Rowena of the Steppe"
+    }, {
+        "id": "7069",
+        "name": "Witch Zelda of the Steppe"
+    }, {
+        "id": "7120",
+        "name": "Hedge Wizard Uur'lok of the Steppe"
+    }, {
+        "id": "7132",
+        "name": "Artificer Kurama of the Steppe"
+    }, {
+        "id": "7137",
+        "name": "Geomancer Luther of the Steppe"
+    }, {
+        "id": "7230",
+        "name": "Artificer Herne of the Steppe"
+    }, {
+        "id": "7267",
+        "name": "Ghost Eater Yumi of the Steppe"
+    }, {
+        "id": "7299",
+        "name": "Sorcerer Mycho of the Steppe"
+    }, {
+        "id": "7336",
+        "name": "Bard Goober of the Steppe"
+    }, {
+        "id": "7365",
+        "name": "Enchanter Lamia of the Steppe"
+    }, {
+        "id": "7384",
+        "name": "Artificer Judas of the Steppe"
+    }, {
+        "id": "7459",
+        "name": "Oberon of the Steppe"
+    }, {
+        "id": "7595",
+        "name": "Archmagus Basil of the Steppe"
+    }, {
+        "id": "7640",
+        "name": "Faye of the Steppe"
+    }, {
+        "id": "7678",
+        "name": "Battle Mage Bayard of the Steppe"
+    }, {
+        "id": "7719",
+        "name": "Hedge Wizard Rowena of the Steppe"
+    }, {
+        "id": "7831",
+        "name": "Enchanter Daphne of the Steppe"
+    }, {
+        "id": "7877",
+        "name": "Archmagus Milo of the Steppe"
+    }, {
+        "id": "7881",
+        "name": "Clairvoyant Devin of the Steppe"
+    }, {
+        "id": "7959",
+        "name": "Aleister of the Steppe"
+    }, {
+        "id": "7969",
+        "name": "Pyromancer Florah of the Steppe"
+    }, {
+        "id": "7997",
+        "name": "Electromancer Alvaro of the Steppe"
+    }, {
+        "id": "8062",
+        "name": "Battle Mage Hansel of the Steppe"
+    }, {
+        "id": "8085",
+        "name": "Cassiopeia of the Steppe"
+    }, {
+        "id": "8201",
+        "name": "Archmagus Jeldor of the Steppe"
+    }, {
+        "id": "8204",
+        "name": "Archmagus Soya of the Steppe"
+    }, {
+        "id": "8206",
+        "name": "Chronomancer Min of the Steppe"
+    }, {
+        "id": "8223",
+        "name": "Alchemist Robert of the Steppe"
+    }, {
+        "id": "8229",
+        "name": "Arch-Magician Calliope of the Steppe"
+    }, {
+        "id": "8299",
+        "name": "Sorcerer Jahid of the Steppe"
+    }, {
+        "id": "8356",
+        "name": "Enchanter Sondra of the Steppe"
+    }, {
+        "id": "8396",
+        "name": "Adept Angus of the Steppe"
+    }, {
+        "id": "8409",
+        "name": "Sage Venga of the Steppe"
+    }, {
+        "id": "8410",
+        "name": "Enchanter Sonja of the Steppe"
+    }, {
+        "id": "8488",
+        "name": "Hedge Wizard Cosmo of the Steppe"
+    }, {
+        "id": "8521",
+        "name": "Sage Celah of the Steppe"
+    }, {
+        "id": "8596",
+        "name": "Arch-Magician Pumlo of the Steppe"
+    }, {
+        "id": "8627",
+        "name": "Jerret of the Steppe"
+    }, {
+        "id": "8640",
+        "name": "Sorcerer Celah of the Steppe"
+    }, {
+        "id": "8658",
+        "name": "Sage Chipper of the Steppe"
+    }, {
+        "id": "8681",
+        "name": "Calliope of the Steppe"
+    }, {
+        "id": "8688",
+        "name": "Shaman Lux of the Steppe"
+    }, {
+        "id": "8839",
+        "name": "Sorcerer Milo of the Steppe"
+    }, {
+        "id": "8843",
+        "name": "Hedge Wizard Xiaobo of the Steppe"
+    }, {
+        "id": "8931",
+        "name": "Archmagus Orpheus of the Steppe"
+    }, {
+        "id": "8940",
+        "name": "Battle Mage Angus of the Steppe"
+    }, {
+        "id": "8954",
+        "name": "Wizard Froggy of the Steppe"
+    }, {
+        "id": "8988",
+        "name": "Battle Mage Durm of the Steppe"
+    }, {
+        "id": "9000",
+        "name": "Geomancer Shivra of the Steppe"
+    }, {
+        "id": "9030",
+        "name": "Alchemist Junko of the Steppe"
+    }, {
+        "id": "9087",
+        "name": "Witch Delilah of the Steppe"
+    }, {
+        "id": "9164",
+        "name": "Augurer Rita of the Steppe"
+    }, {
+        "id": "9186",
+        "name": "Archmagus Zane of the Steppe"
+    }, {
+        "id": "9202",
+        "name": "Enchanter Diana of the Steppe"
+    }, {
+        "id": "9285",
+        "name": "Charmer Calista of the Steppe"
+    }, {
+        "id": "9342",
+        "name": "Magus Leah of the Steppe"
+    }, {
+        "id": "9388",
+        "name": "Shadow Mage Alatar of the Steppe"
+    }, {
+        "id": "9411",
+        "name": "Mystic Faiz of the Steppe"
+    }, {
+        "id": "9445",
+        "name": "Archmagus Davos of the Steppe"
+    }, {
+        "id": "9458",
+        "name": "Archmagus Jerret of the Steppe"
+    }, {
+        "id": "9548",
+        "name": "Hedge Wizard Magpie of the Steppe"
+    }, {
+        "id": "9568",
+        "name": "Oracle David of the Steppe"
+    }, {
+        "id": "9624",
+        "name": "Archmagus Celah of the Steppe"
+    }, {
+        "id": "9677",
+        "name": "Cryptomancer Larissa of the Steppe"
+    }, {
+        "id": "9729",
+        "name": "Fortune Teller Goomer of the Steppe"
+    }, {
+        "id": "9733",
+        "name": "Arch-Magician Gellert of the Steppe"
+    }, {
+        "id": "9785",
+        "name": "Battle Mage Hagar of the Steppe"
+    }, {
+        "id": "9851",
+        "name": "Enchanter Adrienne of the Steppe"
+    }, {
+        "id": "9937",
+        "name": "Clairvoyant Milo of the Steppe"
+    }, {
+        "id": "9956",
+        "name": "Archmagus Chanterelle of the Steppe"
+    }],
+    "Abyss": [{
+        "id": "64",
+        "name": "Amir from the Abyss"
+    }, {
+        "id": "246",
+        "name": "Archmagus Solomon from the Abyss"
+    }, {
+        "id": "658",
+        "name": "Magus Milo from the Abyss"
+    }, {
+        "id": "792",
+        "name": "Pyromancer Flamos from the Abyss"
+    }, {
+        "id": "1289",
+        "name": "Adept Karasu from the Abyss"
+    }, {
+        "id": "1589",
+        "name": "Hex Mage Asmodeus from the Abyss"
+    }, {
+        "id": "1623",
+        "name": "Magus David from the Abyss"
+    }, {
+        "id": "2090",
+        "name": "Holy Monk Chandler from the Abyss"
+    }, {
+        "id": "2352",
+        "name": "Druid Ixar from the Abyss"
+    }, {
+        "id": "2399",
+        "name": "Archmagus Aleister from the Abyss"
+    }, {
+        "id": "2896",
+        "name": "Necromancer Chiron from the Abyss"
+    }, {
+        "id": "3426",
+        "name": "Hydromancer Eggplant from the Abyss"
+    }, {
+        "id": "3637",
+        "name": "Null Mage Jeldor from the Abyss"
+    }, {
+        "id": "3877",
+        "name": "Alchemist Morfran from the Abyss"
+    }, {
+        "id": "4084",
+        "name": "Illusionist Huan from the Abyss"
+    }, {
+        "id": "4348",
+        "name": "Pyromancer Embrose from the Abyss"
+    }, {
+        "id": "4491",
+        "name": "Battle Mage Malthus from the Abyss"
+    }, {
+        "id": "4506",
+        "name": "Druid Angus from the Abyss"
+    }, {
+        "id": "4781",
+        "name": "Druid Morfran from the Abyss"
+    }, {
+        "id": "4841",
+        "name": "Charmer Circe from the Abyss"
+    }, {
+        "id": "5091",
+        "name": "Clairvoyant Nori from the Abyss"
+    }, {
+        "id": "6411",
+        "name": "Necromancer Poppy from the Abyss"
+    }, {
+        "id": "6855",
+        "name": "Evoker Finn from the Abyss"
+    }, {
+        "id": "6979",
+        "name": "Arcanist Hedgie from the Abyss"
+    }, {
+        "id": "6985",
+        "name": "Void Disciple Aleister from the Abyss"
+    }, {
+        "id": "7162",
+        "name": "Necromancer Xerxes from the Abyss"
+    }, {
+        "id": "7163",
+        "name": "Sorcerer Milo from the Abyss"
+    }, {
+        "id": "7260",
+        "name": "Fire Eater from the Abyss"
+    }, {
+        "id": "7329",
+        "name": "Necromancer Seth from the Abyss"
+    }, {
+        "id": "8170",
+        "name": "Mystic Davos from the Abyss"
+    }, {
+        "id": "8226",
+        "name": "Clairvoyant Gary from the Abyss"
+    }, {
+        "id": "8397",
+        "name": "Pyromancer Fire Eater from the Abyss"
+    }, {
+        "id": "8526",
+        "name": "Arcanist Shi from the Abyss"
+    }, {
+        "id": "8662",
+        "name": "Archmagus Salvatore from the Abyss"
+    }, {
+        "id": "8735",
+        "name": "Scorch from the Abyss"
+    }, {
+        "id": "8795",
+        "name": "Sage Akron from the Abyss"
+    }, {
+        "id": "8916",
+        "name": "Thaumaturge Voidoth from the Abyss"
+    }, {
+        "id": "9104",
+        "name": "Allistair from the Abyss"
+    }, {
+        "id": "9455",
+        "name": "Sky Master Magpie from the Abyss"
+    }, {
+        "id": "9678",
+        "name": "Arcanist Gino from the Abyss"
+    }, {
+        "id": "9691",
+        "name": "Shaman Homer from the Abyss"
+    }, {
+        "id": "9805",
+        "name": "Archmagus Merlon from the Abyss"
+    }],
+    "Dunes": [{
+        "id": "73",
+        "name": "Battle Mage Devin of the Dunes"
+    }, {
+        "id": "80",
+        "name": "Void Disciple Zafar of the Dunes"
+    }, {
+        "id": "136",
+        "name": "Sorcerer Basil of the Dunes"
+    }, {
+        "id": "144",
+        "name": "Archmagus Jerret of the Dunes"
+    }, {
+        "id": "276",
+        "name": "Alchemist Isaac of the Dunes"
+    }, {
+        "id": "342",
+        "name": "Shadow Mage Hagar of the Dunes"
+    }, {
+        "id": "378",
+        "name": "Magus Wazir of the Dunes"
+    }, {
+        "id": "396",
+        "name": "Merlon of the Dunes"
+    }, {
+        "id": "449",
+        "name": "Apollo of the Dunes"
+    }, {
+        "id": "521",
+        "name": "Hedge Wizard Alizam of the Dunes"
+    }, {
+        "id": "524",
+        "name": "Battle Mage Finn of the Dunes"
+    }, {
+        "id": "711",
+        "name": "Archmagus Apollo of the Dunes"
+    }, {
+        "id": "910",
+        "name": "Battle Mage Cromwell of the Dunes"
+    }, {
+        "id": "917",
+        "name": "Sorcerer Jerret of the Dunes"
+    }, {
+        "id": "922",
+        "name": "Thaumaturge Anton of the Dunes"
+    }, {
+        "id": "1371",
+        "name": "Cleric Nazim of the Dunes"
+    }, {
+        "id": "1463",
+        "name": "Sorcerer Kamil of the Dunes"
+    }, {
+        "id": "1466",
+        "name": "Voodoo Priest Auguste of the Dunes"
+    }, {
+        "id": "2044",
+        "name": "Battle Mage Axel of the Dunes"
+    }, {
+        "id": "2075",
+        "name": "Electromancer Yumi of the Dunes"
+    }, {
+        "id": "2159",
+        "name": "Battle Mage Angus of the Dunes"
+    }, {
+        "id": "2277",
+        "name": "Druid Chooki of the Dunes"
+    }, {
+        "id": "2291",
+        "name": "Artificer Dante of the Dunes"
+    }, {
+        "id": "2300",
+        "name": "Wild Mage Dante of the Dunes"
+    }, {
+        "id": "2379",
+        "name": "Shaman Darick of the Dunes"
+    }, {
+        "id": "2716",
+        "name": "Voodoo Priest Auguste of the Dunes"
+    }, {
+        "id": "2759",
+        "name": "Alchemist Uday of the Dunes"
+    }, {
+        "id": "2771",
+        "name": "Battle Mage Tundror of the Dunes"
+    }, {
+        "id": "2801",
+        "name": "Magus Ramiz of the Dunes"
+    }, {
+        "id": "2821",
+        "name": "Enchanter Orpheus of the Dunes"
+    }, {
+        "id": "3288",
+        "name": "Shadow Mage Nadeem of the Dunes"
+    }, {
+        "id": "3316",
+        "name": "Holy Monk Crobas of the Dunes"
+    }, {
+        "id": "3440",
+        "name": "Magus Aleister of the Dunes"
+    }, {
+        "id": "3474",
+        "name": "Witch Lilith of the Dunes"
+    }, {
+        "id": "3478",
+        "name": "Arcanist Xiaobo of the Dunes"
+    }, {
+        "id": "3653",
+        "name": "Shaman Hothor of the Dunes"
+    }, {
+        "id": "3692",
+        "name": "Diabolist Lenora of the Dunes"
+    }, {
+        "id": "3728",
+        "name": "Enchanter Nassif of the Dunes"
+    }, {
+        "id": "3730",
+        "name": "Diviner Pezo of the Dunes"
+    }, {
+        "id": "3867",
+        "name": "Sorcerer Merlon of the Dunes"
+    }, {
+        "id": "4485",
+        "name": "Voodoo Priest Jeldor of the Dunes"
+    }, {
+        "id": "4510",
+        "name": "Runecaster Bullock of the Dunes"
+    }, {
+        "id": "4527",
+        "name": "Mystic Ramiz of the Dunes"
+    }, {
+        "id": "4660",
+        "name": "Sorcerer Danny of the Dunes"
+    }, {
+        "id": "4791",
+        "name": "Druid Salvatore of the Dunes"
+    }, {
+        "id": "4962",
+        "name": "Battle Mage Borak of the Dunes"
+    }, {
+        "id": "5054",
+        "name": "Archmagus Zaros of the Dunes"
+    }, {
+        "id": "5346",
+        "name": "Enchanter Sisk of the Dunes"
+    }, {
+        "id": "5520",
+        "name": "Conjurer Davos of the Dunes"
+    }, {
+        "id": "5567",
+        "name": "Augurer Zelroth of the Dunes"
+    }, {
+        "id": "5617",
+        "name": "Battle Mage Bartholomew of the Dunes"
+    }, {
+        "id": "5682",
+        "name": "Allistair of the Dunes"
+    }, {
+        "id": "5831",
+        "name": "Magus Milton of the Dunes"
+    }, {
+        "id": "5964",
+        "name": "Hedge Wizard Alex of the Dunes"
+    }, {
+        "id": "6045",
+        "name": "Archmagus Ixar of the Dunes"
+    }, {
+        "id": "6328",
+        "name": "Druid Lenora of the Dunes"
+    }, {
+        "id": "6494",
+        "name": "Arch-Magician Thor of the Dunes"
+    }, {
+        "id": "6583",
+        "name": "Null Mage Jiang of the Dunes"
+    }, {
+        "id": "6848",
+        "name": "Magus Rafiq of the Dunes"
+    }, {
+        "id": "6919",
+        "name": "Pyromancer Jeldor of the Dunes"
+    }, {
+        "id": "6937",
+        "name": "Alchemist Nolan of the Dunes"
+    }, {
+        "id": "7067",
+        "name": "Aeromancer Gully of the Dunes"
+    }, {
+        "id": "7285",
+        "name": "Alchemist Cassiopeia of the Dunes"
+    }, {
+        "id": "7506",
+        "name": "Sorcerer Faiz of the Dunes"
+    }, {
+        "id": "7565",
+        "name": "Sorcerer Aleister of the Dunes"
+    }, {
+        "id": "7635",
+        "name": "Wild Mage Hothor of the Dunes"
+    }, {
+        "id": "7670",
+        "name": "Transmuter Rook of the Dunes"
+    }, {
+        "id": "7693",
+        "name": "Wild Mage  of the Dunes"
+    }, {
+        "id": "7826",
+        "name": "Runecaster Horace of the Dunes"
+    }, {
+        "id": "7829",
+        "name": "Sage Soran of the Dunes"
+    }, {
+        "id": "7851",
+        "name": "Shaman Jeldor of the Dunes"
+    }, {
+        "id": "7882",
+        "name": "Mystic Caligula of the Dunes"
+    }, {
+        "id": "8108",
+        "name": "Sorcerer Jameel of the Dunes"
+    }, {
+        "id": "8195",
+        "name": "Artificer Pozzik of the Dunes"
+    }, {
+        "id": "8384",
+        "name": "Archmagus Lumos of the Dunes"
+    }, {
+        "id": "8390",
+        "name": "Cleric Zaros of the Dunes"
+    }, {
+        "id": "8482",
+        "name": "Battle Mage Otto of the Dunes"
+    }, {
+        "id": "8483",
+        "name": "Cleric Lumos of the Dunes"
+    }, {
+        "id": "8503",
+        "name": "Archmagus Lumos of the Dunes"
+    }, {
+        "id": "8515",
+        "name": "Archmagus Akron of the Dunes"
+    }, {
+        "id": "8842",
+        "name": "Battle Mage Baird of the Dunes"
+    }, {
+        "id": "8865",
+        "name": "Enchanter Carly of the Dunes"
+    }, {
+        "id": "9026",
+        "name": "Enchanter Lobo of the Dunes"
+    }, {
+        "id": "9112",
+        "name": "Artificer Axel of the Dunes"
+    }, {
+        "id": "9174",
+        "name": "Hydromancer Alessar of the Dunes"
+    }, {
+        "id": "9213",
+        "name": "Enchanter Atlas of the Dunes"
+    }, {
+        "id": "9373",
+        "name": "Thaumaturge Goliath of the Dunes"
+    }, {
+        "id": "9625",
+        "name": "Druid Toka of the Dunes"
+    }, {
+        "id": "9639",
+        "name": "Archmagus Rocco of the Dunes"
+    }, {
+        "id": "9684",
+        "name": "Artificer Udor of the Dunes"
+    }, {
+        "id": "9702",
+        "name": "Witch Alizam of the Dunes"
+    }, {
+        "id": "9865",
+        "name": "Archmagus Onaxx of the Dunes"
+    }, {
+        "id": "9883",
+        "name": "Adept Wolfram of the Dunes"
+    }, {
+        "id": "9926",
+        "name": "Sorcerer Jean Leon of the Dunes"
+    }, {
+        "id": "9973",
+        "name": "Sorcerer Casper of the Dunes"
+    }, {
+        "id": "9996",
+        "name": "Sorcerer Chooki of the Dunes"
+    }],
+    "Thunder": [{
+        "id": "33",
+        "name": "Bringer of Thunder"
+    }],
+    "Plains": [{
+        "id": "40",
+        "name": "Hydromancer Feng of the Plains"
+    }, {
+        "id": "78",
+        "name": "Battle Mage Malthus of the Plains"
+    }, {
+        "id": "159",
+        "name": "Charmer Iris of the Plains"
+    }, {
+        "id": "184",
+        "name": "Sorcerer Iprix of the Plains"
+    }, {
+        "id": "202",
+        "name": "Illusionist Bathsheba of the Plains"
+    }, {
+        "id": "230",
+        "name": "Evoker Jadis of the Plains"
+    }, {
+        "id": "242",
+        "name": "Clairvoyant Nassif of the Plains"
+    }, {
+        "id": "265",
+        "name": "Geomancer Ai of the Plains"
+    }, {
+        "id": "300",
+        "name": "Battle Mage Darick of the Plains"
+    }, {
+        "id": "330",
+        "name": "Hedge Wizard Rita of the Plains"
+    }, {
+        "id": "332",
+        "name": "Witch Sylvia of the Plains"
+    }, {
+        "id": "333",
+        "name": "Druid Eizo of the Plains"
+    }, {
+        "id": "369",
+        "name": "Enchanter Ariadne of the Plains"
+    }, {
+        "id": "404",
+        "name": "Hedge Wizard Imeena of the Plains"
+    }, {
+        "id": "421",
+        "name": "Archmagus Apollo of the Plains"
+    }, {
+        "id": "447",
+        "name": "Leah of the Plains"
+    }, {
+        "id": "483",
+        "name": "Witch Rowena of the Plains"
+    }, {
+        "id": "494",
+        "name": "Mystic Ursula of the Plains"
+    }, {
+        "id": "497",
+        "name": "Sorcerer Lumos of the Plains"
+    }, {
+        "id": "550",
+        "name": "Charmer Daria of the Plains"
+    }, {
+        "id": "649",
+        "name": "Sage Kryll of the Plains"
+    }, {
+        "id": "652",
+        "name": "Alchemist Rita of the Plains"
+    }, {
+        "id": "811",
+        "name": "Cleric Elizabeth of the Plains"
+    }, {
+        "id": "953",
+        "name": "Arch-Magician Artis of the Plains"
+    }, {
+        "id": "974",
+        "name": "Alchemist Daphne of the Plains"
+    }, {
+        "id": "978",
+        "name": "Illusionist Fumiko of the Plains"
+    }, {
+        "id": "1075",
+        "name": "Sorcerer Chooki of the Plains"
+    }, {
+        "id": "1087",
+        "name": "Archmagus Eizo of the Plains"
+    }, {
+        "id": "1219",
+        "name": "Chaos Mage Celeste of the Plains"
+    }, {
+        "id": "1256",
+        "name": "Mystic Qasim of the Plains"
+    }, {
+        "id": "1319",
+        "name": "Alchemist Idris of the Plains"
+    }, {
+        "id": "1387",
+        "name": "Witch Lilith of the Plains"
+    }, {
+        "id": "1421",
+        "name": "Arch-Magician Cromwell of the Plains"
+    }, {
+        "id": "1457",
+        "name": "Archmagus Lux of the Plains"
+    }, {
+        "id": "1489",
+        "name": "Archmagus Isaac of the Plains"
+    }, {
+        "id": "1523",
+        "name": "Archmagus Soya of the Plains"
+    }, {
+        "id": "1631",
+        "name": "Witch Calypso of the Plains"
+    }, {
+        "id": "1658",
+        "name": "Enchanter Althea of the Plains"
+    }, {
+        "id": "1730",
+        "name": "Clairvoyant Aiko of the Plains"
+    }, {
+        "id": "1753",
+        "name": "Ghost Eater Imeena of the Plains"
+    }, {
+        "id": "1788",
+        "name": "Hedge Wizard Fungi of the Plains"
+    }, {
+        "id": "1803",
+        "name": "Archmagus Alatar of the Plains"
+    }, {
+        "id": "1867",
+        "name": "Battle Mage Wolfram of the Plains"
+    }, {
+        "id": "1902",
+        "name": "Witch Drusilla of the Plains"
+    }, {
+        "id": "1926",
+        "name": "Druid Horace of the Plains"
+    }, {
+        "id": "1932",
+        "name": "Archmagus George of the Plains"
+    }, {
+        "id": "1954",
+        "name": "Runecaster Keziah of the Plains"
+    }, {
+        "id": "1974",
+        "name": "Enchanter Arabella of the Plains"
+    }, {
+        "id": "2007",
+        "name": "Geomancer Huan of the Plains"
+    }, {
+        "id": "2049",
+        "name": "Enchanter Bathsheba of the Plains"
+    }, {
+        "id": "2072",
+        "name": "Hedge Wizard Beyna of the Plains"
+    }, {
+        "id": "2120",
+        "name": "Conjurer Mushy of the Plains"
+    }, {
+        "id": "2165",
+        "name": "Thaumaturge Wolfram of the Plains"
+    }, {
+        "id": "2218",
+        "name": "Cryptomancer Ozohr of the Plains"
+    }, {
+        "id": "2244",
+        "name": "Charmer Sondra of the Plains"
+    }, {
+        "id": "2252",
+        "name": "Archmagus Milton of the Plains"
+    }, {
+        "id": "2385",
+        "name": "Archmagus Alessar of the Plains"
+    }, {
+        "id": "2401",
+        "name": "Hedge Wizard Blaise of the Plains"
+    }, {
+        "id": "2438",
+        "name": "Conjurer Ambrosia of the Plains"
+    }, {
+        "id": "2524",
+        "name": "Witch Keziah of the Plains"
+    }, {
+        "id": "2540",
+        "name": "Shaman Axel of the Plains"
+    }, {
+        "id": "2577",
+        "name": "Druid Diana of the Plains"
+    }, {
+        "id": "2612",
+        "name": "Archmagus Eden of the Plains"
+    }, {
+        "id": "2621",
+        "name": "Arcanist Rixxa of the Plains"
+    }, {
+        "id": "2643",
+        "name": "Archmagus Milton of the Plains"
+    }, {
+        "id": "2764",
+        "name": "Enchanter Astrid of the Plains"
+    }, {
+        "id": "2833",
+        "name": "Battle Mage Khudalf of the Plains"
+    }, {
+        "id": "2838",
+        "name": "Artificer Misumi of the Plains"
+    }, {
+        "id": "3018",
+        "name": "Solar Mage Velorina of the Plains"
+    }, {
+        "id": "3140",
+        "name": "Sorcerer Crowley of the Plains"
+    }, {
+        "id": "3143",
+        "name": "Archmagus Ming of the Plains"
+    }, {
+        "id": "3189",
+        "name": "Isaac of the Plains"
+    }, {
+        "id": "3194",
+        "name": "Hydromancer Wolfram of the Plains"
+    }, {
+        "id": "3214",
+        "name": "Arch-Magician Karasu of the Plains"
+    }, {
+        "id": "3266",
+        "name": "Druid Jerret of the Plains"
+    }, {
+        "id": "3378",
+        "name": "Adept Maia of the Plains"
+    }, {
+        "id": "3420",
+        "name": "Archmagus Amir of the Plains"
+    }, {
+        "id": "3595",
+        "name": "Shadow Mage Woomba of the Plains"
+    }, {
+        "id": "3600",
+        "name": "Enchanter Ariadne of the Plains"
+    }, {
+        "id": "3645",
+        "name": "Alchemist Xiuying of the Plains"
+    }, {
+        "id": "3755",
+        "name": "Celeste of the Plains"
+    }, {
+        "id": "3813",
+        "name": "Pyromancer Daria of the Plains"
+    }, {
+        "id": "3838",
+        "name": "Illusionist Hadrien of the Plains"
+    }, {
+        "id": "3855",
+        "name": "Geomancer Fungi of the Plains"
+    }, {
+        "id": "3881",
+        "name": "Hedge Wizard Magnus of the Plains"
+    }, {
+        "id": "3919",
+        "name": "Alchemist Baozhai of the Plains"
+    }, {
+        "id": "3943",
+        "name": "Sage Zelda of the Plains"
+    }, {
+        "id": "3979",
+        "name": "Conjurer Drusilla of the Plains"
+    }, {
+        "id": "3996",
+        "name": "Arch-Magician Cromwell of the Plains"
+    }, {
+        "id": "4007",
+        "name": "Arch-Magician Hugo of the Plains"
+    }, {
+        "id": "4029",
+        "name": "Aleister of the Plains"
+    }, {
+        "id": "4378",
+        "name": "Archmagus Crowley of the Plains"
+    }, {
+        "id": "4389",
+        "name": "Enchanter Lamia of the Plains"
+    }, {
+        "id": "4390",
+        "name": "Witch Ambrosia of the Plains"
+    }, {
+        "id": "4449",
+        "name": "Witch Darick of the Plains"
+    }, {
+        "id": "4459",
+        "name": "Battle Mage Baird of the Plains"
+    }, {
+        "id": "4478",
+        "name": "Sage Cromwell of the Plains"
+    }, {
+        "id": "4577",
+        "name": "Hex Mage Ulysse of the Plains"
+    }, {
+        "id": "4631",
+        "name": "Sage Gorgana of the Plains"
+    }, {
+        "id": "4639",
+        "name": "Magus Baird of the Plains"
+    }, {
+        "id": "4646",
+        "name": "Battle Mage Ethan of the Plains"
+    }, {
+        "id": "4685",
+        "name": "Hydromancer Enigma of the Plains"
+    }, {
+        "id": "4695",
+        "name": "Witch Lenora of the Plains"
+    }, {
+        "id": "4765",
+        "name": "Sage Asmodeus of the Plains"
+    }, {
+        "id": "4834",
+        "name": "Cassiopeia of the Plains"
+    }, {
+        "id": "4858",
+        "name": "Battle Mage Nicolas of the Plains"
+    }, {
+        "id": "4871",
+        "name": "Witch Juniper of the Plains"
+    }, {
+        "id": "4872",
+        "name": "Runecaster Faye of the Plains"
+    }, {
+        "id": "4879",
+        "name": "Aeromancer Sylvia of the Plains"
+    }, {
+        "id": "4929",
+        "name": "Alchemist Faiz of the Plains"
+    }, {
+        "id": "4932",
+        "name": "Witch Sabina of the Plains"
+    }, {
+        "id": "5033",
+        "name": "Shaman Silas of the Plains"
+    }, {
+        "id": "5036",
+        "name": "Alchemist Calista of the Plains"
+    }, {
+        "id": "5071",
+        "name": "Hedge Wizard Armstrong of the Plains"
+    }, {
+        "id": "5192",
+        "name": "Hex Mage Epher of the Plains"
+    }, {
+        "id": "5234",
+        "name": "Arcanist George of the Plains"
+    }, {
+        "id": "5246",
+        "name": "Transmuter Konoha of the Plains"
+    }, {
+        "id": "5253",
+        "name": "Cryptomancer Asphodel of the Plains"
+    }, {
+        "id": "5259",
+        "name": "Battle Mage Homer of the Plains"
+    }, {
+        "id": "5484",
+        "name": "Lunar Mage Ofaris of the Plains"
+    }, {
+        "id": "5588",
+        "name": "Maia of the Plains"
+    }, {
+        "id": "5660",
+        "name": "Archmagus Milo of the Plains"
+    }, {
+        "id": "5711",
+        "name": "Conjurer Yumi of the Plains"
+    }, {
+        "id": "5741",
+        "name": "Artificer Lux of the Plains"
+    }, {
+        "id": "5754",
+        "name": "Archmagus Pumlo of the Plains"
+    }, {
+        "id": "5760",
+        "name": "Chaos Mage Shub of the Plains"
+    }, {
+        "id": "5843",
+        "name": "Charmer Devon of the Plains"
+    }, {
+        "id": "5892",
+        "name": "Druid Dutorn of the Plains"
+    }, {
+        "id": "6040",
+        "name": "Battle Mage Ratko of the Plains"
+    }, {
+        "id": "6143",
+        "name": "Druid Sturgis of the Plains"
+    }, {
+        "id": "6220",
+        "name": "Enchanter Astrid of the Plains"
+    }, {
+        "id": "6241",
+        "name": "Battle Mage Nolan of the Plains"
+    }, {
+        "id": "6253",
+        "name": "Adrienne of the Plains"
+    }, {
+        "id": "6254",
+        "name": "Archmagus Apollo of the Plains"
+    }, {
+        "id": "6333",
+        "name": "Enchanter Willow of the Plains"
+    }, {
+        "id": "6334",
+        "name": "Althea of the Plains"
+    }, {
+        "id": "6502",
+        "name": "Holy Monk Edge of the Plains"
+    }, {
+        "id": "6545",
+        "name": "Druid Alizam of the Plains"
+    }, {
+        "id": "6585",
+        "name": "Calliope of the Plains"
+    }, {
+        "id": "6592",
+        "name": "Alchemist Tengu of the Plains"
+    }, {
+        "id": "6616",
+        "name": "Alchemist Angus of the Plains"
+    }, {
+        "id": "6657",
+        "name": "Void Disciple Godfrey of the Plains"
+    }, {
+        "id": "6719",
+        "name": "Arcanist Qasim of the Plains"
+    }, {
+        "id": "6934",
+        "name": "Enchanter Leah of the Plains"
+    }, {
+        "id": "7006",
+        "name": "Runecaster Tundror of the Plains"
+    }, {
+        "id": "7015",
+        "name": "Battle Mage Rodolfo of the Plains"
+    }, {
+        "id": "7018",
+        "name": "Basil of the Plains"
+    }, {
+        "id": "7070",
+        "name": "Druid Ratko of the Plains"
+    }, {
+        "id": "7361",
+        "name": "Alchemist Chu Hua of the Plains"
+    }, {
+        "id": "7383",
+        "name": "Sorcerer Alatar of the Plains"
+    }, {
+        "id": "7480",
+        "name": "Archmagus Azahl of the Plains"
+    }, {
+        "id": "7563",
+        "name": "Thaumaturge Izible of the Plains"
+    }, {
+        "id": "7694",
+        "name": "Geomancer Hothor of the Plains"
+    }, {
+        "id": "7705",
+        "name": "Alchemist Liliana of the Plains"
+    }, {
+        "id": "7809",
+        "name": "Adept Uvlius of the Plains"
+    }, {
+        "id": "7816",
+        "name": "Magus Alizam of the Plains"
+    }, {
+        "id": "8003",
+        "name": "Sage Horace of the Plains"
+    }, {
+        "id": "8073",
+        "name": "Enchanter Daria of the Plains"
+    }, {
+        "id": "8127",
+        "name": "Cleric Argus of the Plains"
+    }, {
+        "id": "8189",
+        "name": "Sorcerer Impy of the Plains"
+    }, {
+        "id": "8211",
+        "name": "Sage Lin of the Plains"
+    }, {
+        "id": "8235",
+        "name": "Arch-Magician Rodolfo of the Plains"
+    }, {
+        "id": "8316",
+        "name": "Geomancer Pepo of the Plains"
+    }, {
+        "id": "8361",
+        "name": "Shaman Soya of the Plains"
+    }, {
+        "id": "8412",
+        "name": "Cosmic Mage Dante of the Plains"
+    }, {
+        "id": "8514",
+        "name": "Hex Mage Milton of the Plains"
+    }, {
+        "id": "8653",
+        "name": "Clairvoyant Baird of the Plains"
+    }, {
+        "id": "8671",
+        "name": "Mystic Angus of the Plains"
+    }, {
+        "id": "8796",
+        "name": "Alchemist Konoha of the Plains"
+    }, {
+        "id": "8835",
+        "name": "Shaman Carly of the Plains"
+    }, {
+        "id": "8838",
+        "name": "Charmer Althea of the Plains"
+    }, {
+        "id": "8881",
+        "name": "Arcanist Hagatha of the Plains"
+    }, {
+        "id": "9095",
+        "name": "Ghost Eater Salah of the Plains"
+    }, {
+        "id": "9098",
+        "name": "Enchanter Beyna of the Plains"
+    }, {
+        "id": "9206",
+        "name": "Witch Ambrosia of the Plains"
+    }, {
+        "id": "9230",
+        "name": "Oracle Gwendolin of the Plains"
+    }, {
+        "id": "9255",
+        "name": "Thaumaturge Finn of the Plains"
+    }, {
+        "id": "9311",
+        "name": "Alchemist Zane of the Plains"
+    }, {
+        "id": "9378",
+        "name": "Magus Daphne of the Plains"
+    }, {
+        "id": "9390",
+        "name": "Battle Mage Hagar of the Plains"
+    }, {
+        "id": "9419",
+        "name": "Witch Velorina of the Plains"
+    }, {
+        "id": "9466",
+        "name": "Chronomancer Nazim of the Plains"
+    }, {
+        "id": "9474",
+        "name": "Lunar Mage Durm of the Plains"
+    }, {
+        "id": "9484",
+        "name": "Necromancer Zhan of the Plains"
+    }, {
+        "id": "9675",
+        "name": "Adept Aldo of the Plains"
+    }, {
+        "id": "9707",
+        "name": "Shadow Mage Kalo of the Plains"
+    }, {
+        "id": "9730",
+        "name": "Alchemist Konoha of the Plains"
+    }, {
+        "id": "9866",
+        "name": "Magus David of the Plains"
+    }, {
+        "id": "9890",
+        "name": "Druid Rowena of the Plains"
+    }, {
+        "id": "9896",
+        "name": "Enchanter Victoria of the Plains"
+    }, {
+        "id": "9914",
+        "name": "Charmer Astrid of the Plains"
+    }, {
+        "id": "9923",
+        "name": "Geomancer Hagar of the Plains"
+    }, {
+        "id": "9980",
+        "name": "Battle Mage Samuel of the Plains"
+    }],
+    "Crypt": [{
+        "id": "4927",
+        "name": "Aeromancer Apollo of the Crypt"
+    }],
+    "Circle": [{
+        "id": "36",
+        "name": "Chronomancer Gunthor of the Circle"
+    }, {
+        "id": "235",
+        "name": "Summoner Uur'lok of the Circle"
+    }, {
+        "id": "354",
+        "name": "Druid Larissa of the Circle"
+    }, {
+        "id": "576",
+        "name": "Augurer Eden of the Circle"
+    }, {
+        "id": "857",
+        "name": "Archmagus Alessar of the Circle"
+    }, {
+        "id": "1139",
+        "name": "Summoner Purple Boy of the Circle"
+    }, {
+        "id": "1369",
+        "name": "Sorcerer Gunthor of the Circle"
+    }, {
+        "id": "1706",
+        "name": "Archmagus Amir of the Circle"
+    }, {
+        "id": "1735",
+        "name": "Adept Toby of the Circle"
+    }, {
+        "id": "2116",
+        "name": "Pyromancer Buttons of the Circle"
+    }, {
+        "id": "2173",
+        "name": "Hedge Wizard Ratko of the Circle"
+    }, {
+        "id": "2449",
+        "name": "Runecaster Marius of the Circle"
+    }, {
+        "id": "2545",
+        "name": "Sorcerer Kazem of the Circle"
+    }, {
+        "id": "2636",
+        "name": "Pyromancer Rita of the Circle"
+    }, {
+        "id": "3207",
+        "name": "Enchanter Rita of the Circle"
+    }, {
+        "id": "3242",
+        "name": "Alchemist Carly of the Circle"
+    }, {
+        "id": "3290",
+        "name": "Druid Leah of the Circle"
+    }, {
+        "id": "3315",
+        "name": "Cosmic Mage Amir of the Circle"
+    }, {
+        "id": "3909",
+        "name": "Archmagus Alessar of the Circle"
+    }, {
+        "id": "4332",
+        "name": "Enchanter Celeste of the Circle"
+    }, {
+        "id": "4369",
+        "name": "Enchanter Daria of the Circle"
+    }, {
+        "id": "5131",
+        "name": "Artificer Fredo of the Circle"
+    }, {
+        "id": "5297",
+        "name": "Diviner Borak of the Circle"
+    }, {
+        "id": "5705",
+        "name": "Enchanter Althea of the Circle"
+    }, {
+        "id": "5785",
+        "name": "Iprix of the Circle"
+    }, {
+        "id": "6709",
+        "name": "Conjurer Daria of the Circle"
+    }, {
+        "id": "6877",
+        "name": "Arcanist Luther of the Circle"
+    }, {
+        "id": "7186",
+        "name": "Ofaris of the Circle"
+    }, {
+        "id": "7279",
+        "name": "Illusionist Khudalf of the Circle"
+    }, {
+        "id": "7360",
+        "name": "Conjurer Soran of the Circle"
+    }, {
+        "id": "8293",
+        "name": "Augurer Moka of the Circle"
+    }, {
+        "id": "8334",
+        "name": "Medium Cassiopeia of the Circle"
+    }, {
+        "id": "8637",
+        "name": "Alchemist Alizam of the Circle"
+    }, {
+        "id": "8778",
+        "name": "Sorcerer David of the Circle"
+    }],
+    "El Dorado": [{
+        "id": "6",
+        "name": "Wild Mage Rowena of El Dorado"
+    }, {
+        "id": "129",
+        "name": "Sage Uur'lok of El Dorado"
+    }, {
+        "id": "241",
+        "name": "Fortune Teller Argus of El Dorado"
+    }, {
+        "id": "345",
+        "name": "Archmagus Milo of El Dorado"
+    }, {
+        "id": "1039",
+        "name": "Enchanter Lamia of El Dorado"
+    }, {
+        "id": "1052",
+        "name": "Battle Mage Cromwell of El Dorado"
+    }, {
+        "id": "1350",
+        "name": "Bard Helix of El Dorado"
+    }, {
+        "id": "1446",
+        "name": "Druid Rixxa of El Dorado"
+    }, {
+        "id": "1677",
+        "name": "Shaman Galatea of El Dorado"
+    }, {
+        "id": "1696",
+        "name": "Battle Mage Danny of El Dorado"
+    }, {
+        "id": "1711",
+        "name": "Magus Koop of El Dorado"
+    }, {
+        "id": "1855",
+        "name": "Cleric Iprix of El Dorado"
+    }, {
+        "id": "1915",
+        "name": "Archmagus Ixar of El Dorado"
+    }, {
+        "id": "1922",
+        "name": "Shaman Louis of El Dorado"
+    }, {
+        "id": "2178",
+        "name": "Sorcerer Ixar of El Dorado"
+    }, {
+        "id": "2324",
+        "name": "Diviner Requiem of El Dorado"
+    }, {
+        "id": "2443",
+        "name": "Diabolist Khudalf of El Dorado"
+    }, {
+        "id": "2517",
+        "name": "Archmagus Casper of El Dorado"
+    }, {
+        "id": "2554",
+        "name": "Cleric Nicolas of El Dorado"
+    }, {
+        "id": "2565",
+        "name": "Hadrien of El Dorado"
+    }, {
+        "id": "2586",
+        "name": "Magus Samuel of El Dorado"
+    }, {
+        "id": "2611",
+        "name": "Bard Bolin of El Dorado"
+    }, {
+        "id": "2635",
+        "name": "Chaos Mage Giuseppe of El Dorado"
+    }, {
+        "id": "2763",
+        "name": "Battle Mage Danny of El Dorado"
+    }, {
+        "id": "2772",
+        "name": "Clairvoyant Bao of El Dorado"
+    }, {
+        "id": "2922",
+        "name": "Shaman Jay of El Dorado"
+    }, {
+        "id": "3372",
+        "name": "Arcanist Lin of El Dorado"
+    }, {
+        "id": "3597",
+        "name": "Artificer Numpty of El Dorado"
+    }, {
+        "id": "3781",
+        "name": "Hedge Wizard Victoria of El Dorado"
+    }, {
+        "id": "3804",
+        "name": "Scryer Voidoth of El Dorado"
+    }, {
+        "id": "3849",
+        "name": "Sage Ixar of El Dorado"
+    }, {
+        "id": "4049",
+        "name": "Enchanter Giacomo of El Dorado"
+    }, {
+        "id": "4093",
+        "name": "Archmagus  of El Dorado"
+    }, {
+        "id": "4139",
+        "name": "Archmagus Willow of El Dorado"
+    }, {
+        "id": "4213",
+        "name": "Carly of El Dorado"
+    }, {
+        "id": "4217",
+        "name": "Thaumaturge Miyo of El Dorado"
+    }, {
+        "id": "4249",
+        "name": "Mystic Ofaris of El Dorado"
+    }, {
+        "id": "4320",
+        "name": "Sage Xiuying of El Dorado"
+    }, {
+        "id": "4340",
+        "name": "Cleric Baptiste of El Dorado"
+    }, {
+        "id": "4381",
+        "name": "Druid Faye of El Dorado"
+    }, {
+        "id": "4410",
+        "name": "Druid Celeste of El Dorado"
+    }, {
+        "id": "4428",
+        "name": "Archmagus Eronin of El Dorado"
+    }, {
+        "id": "4604",
+        "name": "Archmagus Sturgis of El Dorado"
+    }, {
+        "id": "4654",
+        "name": "Druid Udor of El Dorado"
+    }, {
+        "id": "4671",
+        "name": "Battle Mage Homer of El Dorado"
+    }, {
+        "id": "4769",
+        "name": "Magus Impy of El Dorado"
+    }, {
+        "id": "4889",
+        "name": "Necromancer Brown Cow of El Dorado"
+    }, {
+        "id": "4944",
+        "name": "Archmagus Iprix of El Dorado"
+    }, {
+        "id": "5006",
+        "name": "Artificer Zaros of El Dorado"
+    }, {
+        "id": "5023",
+        "name": "Sage Remus of El Dorado"
+    }, {
+        "id": "5148",
+        "name": "Battle Mage Baird of El Dorado"
+    }, {
+        "id": "5153",
+        "name": "Archmagus Casper of El Dorado"
+    }, {
+        "id": "5226",
+        "name": "Nikolas of El Dorado"
+    }, {
+        "id": "5404",
+        "name": "Magus Dario of El Dorado"
+    }, {
+        "id": "5522",
+        "name": "Archmagus Soya of El Dorado"
+    }, {
+        "id": "5589",
+        "name": "Hedge Wizard Behemoth of El Dorado"
+    }, {
+        "id": "5644",
+        "name": "Druid Aldo of El Dorado"
+    }, {
+        "id": "5681",
+        "name": "Druid Ozohr of El Dorado"
+    }, {
+        "id": "5951",
+        "name": "Arcanist Soya of El Dorado"
+    }, {
+        "id": "6203",
+        "name": "Bard Amir of El Dorado"
+    }, {
+        "id": "6260",
+        "name": "Summoner Raul of El Dorado"
+    }, {
+        "id": "6324",
+        "name": "Enchanter Amir of El Dorado"
+    }, {
+        "id": "6340",
+        "name": "Wild Mage Moloch of El Dorado"
+    }, {
+        "id": "6371",
+        "name": "Archmagus Tengu of El Dorado"
+    }, {
+        "id": "6447",
+        "name": "Archmagus Alessar of El Dorado"
+    }, {
+        "id": "6575",
+        "name": "Archmagus Silas of El Dorado"
+    }, {
+        "id": "6747",
+        "name": "Sorcerer Aleister of El Dorado"
+    }, {
+        "id": "7054",
+        "name": "Sorcerer Nazim of El Dorado"
+    }, {
+        "id": "7155",
+        "name": "Archmagus Salvatore of El Dorado"
+    }, {
+        "id": "7176",
+        "name": "Sage Nikolas of El Dorado"
+    }, {
+        "id": "7248",
+        "name": "Shaman Rita of El Dorado"
+    }, {
+        "id": "7288",
+        "name": "Hedge Wizard Norix of El Dorado"
+    }, {
+        "id": "7345",
+        "name": "Ixar of El Dorado"
+    }, {
+        "id": "7457",
+        "name": "Battle Mage Otto of El Dorado"
+    }, {
+        "id": "7466",
+        "name": "Evoker Alessar of El Dorado"
+    }, {
+        "id": "7549",
+        "name": "Alchemist Ethan of El Dorado"
+    }, {
+        "id": "7562",
+        "name": "Pyromancer Aleister of El Dorado"
+    }, {
+        "id": "7578",
+        "name": "Aeromancer Hagar of El Dorado"
+    }, {
+        "id": "7769",
+        "name": "Artificer Silas of El Dorado"
+    }, {
+        "id": "7892",
+        "name": "Sorcerer Eric of El Dorado"
+    }, {
+        "id": "8015",
+        "name": "Archmagus Ofaris of El Dorado"
+    }, {
+        "id": "8182",
+        "name": "Enchanter Cybele of El Dorado"
+    }, {
+        "id": "8224",
+        "name": "Arcanist Milton of El Dorado"
+    }, {
+        "id": "8260",
+        "name": "Wild Mage Seth of El Dorado"
+    }, {
+        "id": "8532",
+        "name": "Necromancer Bolin of El Dorado"
+    }, {
+        "id": "8533",
+        "name": "Archmagus Aleister of El Dorado"
+    }, {
+        "id": "8544",
+        "name": "Milton of El Dorado"
+    }, {
+        "id": "8657",
+        "name": "Arcanist Lumos of El Dorado"
+    }, {
+        "id": "8868",
+        "name": "Hedge Wizard Porto of El Dorado"
+    }, {
+        "id": "8987",
+        "name": "Hedge Wizard Bartholomew of El Dorado"
+    }, {
+        "id": "8991",
+        "name": "Evil Arcanist Nick of El Dorado"
+    }, {
+        "id": "9015",
+        "name": "Medium Shizu of El Dorado"
+    }, {
+        "id": "9205",
+        "name": "Mystic Sisk of El Dorado"
+    }, {
+        "id": "9240",
+        "name": "Archmagus Ixar of El Dorado"
+    }, {
+        "id": "9508",
+        "name": "Oracle Calista of El Dorado"
+    }, {
+        "id": "9651",
+        "name": "Solomon of El Dorado"
+    }, {
+        "id": "9674",
+        "name": "Archmagus Apollo of El Dorado"
+    }, {
+        "id": "9710",
+        "name": "Arcanist Ethan of El Dorado"
+    }, {
+        "id": "9820",
+        "name": "Geomancer Impy of El Dorado"
+    }],
+    "Secret Fire": [{
+        "id": "290",
+        "name": "Archmagus Merlon of the Secret Fire"
+    }, {
+        "id": "337",
+        "name": "Sorcerer Ming of the Secret Fire"
+    }, {
+        "id": "615",
+        "name": "Archmagus Crowley of the Secret Fire"
+    }, {
+        "id": "706",
+        "name": "Enchanter Magnus of the Secret Fire"
+    }, {
+        "id": "930",
+        "name": "Voodoo Priest Armstrong of the Secret Fire"
+    }, {
+        "id": "1770",
+        "name": "Cosmic Mage Asmodeus of the Secret Fire"
+    }, {
+        "id": "2027",
+        "name": "Archmagus Zelroth of the Secret Fire"
+    }, {
+        "id": "2326",
+        "name": "Arch-Magician Nicolas of the Secret Fire"
+    }, {
+        "id": "3338",
+        "name": "Archmagus Hadrien of the Secret Fire"
+    }, {
+        "id": "3791",
+        "name": "Cryptomancer Jay of the Secret Fire"
+    }, {
+        "id": "4595",
+        "name": "Azahl of the Secret Fire"
+    }, {
+        "id": "4755",
+        "name": "Ghost Eater Anton of the Secret Fire"
+    }, {
+        "id": "4965",
+        "name": "Archmagus Udor of the Secret Fire"
+    }, {
+        "id": "5196",
+        "name": "Runecaster Twitch of the Secret Fire"
+    }, {
+        "id": "5624",
+        "name": "Clairvoyant Lumos of the Secret Fire"
+    }, {
+        "id": "5744",
+        "name": "Magus Ixar of the Secret Fire"
+    }, {
+        "id": "6365",
+        "name": "Battlemage Thoth of the Secret Fire"
+    }, {
+        "id": "7136",
+        "name": "Mystic Angus of the Secret Fire"
+    }, {
+        "id": "7202",
+        "name": "Archmagus Hadrien of the Secret Fire"
+    }, {
+        "id": "7419",
+        "name": "Enchanter Crowley of the Secret Fire"
+    }, {
+        "id": "8049",
+        "name": "Sage Ilyas of the Secret Fire"
+    }, {
+        "id": "8442",
+        "name": "Sorcerer Lumos of the Secret Fire"
+    }, {
+        "id": "8465",
+        "name": "Witch Sylvia of the Secret Fire"
+    }, {
+        "id": "8760",
+        "name": "Summoner Zelda of the Secret Fire"
+    }, {
+        "id": "9471",
+        "name": "Sorcerer Azahl of the Secret Fire"
+    }, {
+        "id": "9482",
+        "name": "Witch Marceline of the Secret Fire"
+    }, {
+        "id": "9491",
+        "name": "Bard Lumos of the Secret Fire"
+    }, {
+        "id": "9515",
+        "name": "Shaman Pumlo of the Secret Fire"
+    }, {
+        "id": "9767",
+        "name": "Magus Aldus of the Secret Fire"
+    }],
+    "Palms": [{
+        "id": "41",
+        "name": "Arcanist Atlanta of the Palms"
+    }, {
+        "id": "161",
+        "name": "Archmagus Aleister of the Palms"
+    }, {
+        "id": "287",
+        "name": "Enchanter Aldus of the Palms"
+    }, {
+        "id": "351",
+        "name": "Shaman Embrose of the Palms"
+    }, {
+        "id": "542",
+        "name": "Augurer Hagar of the Palms"
+    }, {
+        "id": "597",
+        "name": "Arcanist Twitch of the Palms"
+    }, {
+        "id": "829",
+        "name": "Alchemist Hagar of the Palms"
+    }, {
+        "id": "894",
+        "name": "Magus Faiz of the Palms"
+    }, {
+        "id": "908",
+        "name": "Pyromancer Nolan of the Palms"
+    }, {
+        "id": "946",
+        "name": "Magus Jaffer of the Palms"
+    }, {
+        "id": "1065",
+        "name": "Adept Marius of the Palms"
+    }, {
+        "id": "1089",
+        "name": "Geomancer Devin of the Palms"
+    }, {
+        "id": "1275",
+        "name": "Clairvoyant Basil of the Palms"
+    }, {
+        "id": "1281",
+        "name": "Conjurer Duzzle of the Palms"
+    }, {
+        "id": "1303",
+        "name": "Archmagus Cromwell of the Palms"
+    }, {
+        "id": "1309",
+        "name": "Sorcerer Kazem of the Palms"
+    }, {
+        "id": "1485",
+        "name": "Shaman Angus of the Palms"
+    }, {
+        "id": "1569",
+        "name": "Shaman Cairon of the Palms"
+    }, {
+        "id": "1582",
+        "name": "Sorcerer Kazem of the Palms"
+    }, {
+        "id": "1728",
+        "name": "Clairvoyant Nadeem of the Palms"
+    }, {
+        "id": "2060",
+        "name": "Chaos Mage Chooki of the Palms"
+    }, {
+        "id": "2069",
+        "name": "Thaumaturge Sharx of the Palms"
+    }, {
+        "id": "2153",
+        "name": "Magus Huan of the Palms"
+    }, {
+        "id": "2192",
+        "name": "Aeromancer Basil of the Palms"
+    }, {
+        "id": "2323",
+        "name": "Ghost Eater Cairon of the Palms"
+    }, {
+        "id": "2432",
+        "name": "Battle Mage Cromwell of the Palms"
+    }, {
+        "id": "2544",
+        "name": "Druid Jabir of the Palms"
+    }, {
+        "id": "2701",
+        "name": "Battlemage Nassif of the Palms"
+    }, {
+        "id": "2705",
+        "name": "Artificer Rumpleskin of the Palms"
+    }, {
+        "id": "2856",
+        "name": "Alchemist Tundror of the Palms"
+    }, {
+        "id": "2902",
+        "name": "Archmagus Aleister of the Palms"
+    }, {
+        "id": "2916",
+        "name": "Magus Baird of the Palms"
+    }, {
+        "id": "3141",
+        "name": "Shaman Durm of the Palms"
+    }, {
+        "id": "3434",
+        "name": "Artificer Taqi of the Palms"
+    }, {
+        "id": "3445",
+        "name": "Oracle Jasper of the Palms"
+    }, {
+        "id": "3472",
+        "name": "Shaman Rodolfo of the Palms"
+    }, {
+        "id": "3678",
+        "name": "Druid Setsuko of the Palms"
+    }, {
+        "id": "3716",
+        "name": "Conjurer Zubin of the Palms"
+    }, {
+        "id": "3834",
+        "name": "Sorcerer Iprix of the Palms"
+    }, {
+        "id": "3954",
+        "name": "Witch Calypso of the Palms"
+    }, {
+        "id": "4120",
+        "name": "Battle Mage Magnus of the Palms"
+    }, {
+        "id": "4143",
+        "name": "Wild Mage Idris of the Palms"
+    }, {
+        "id": "4186",
+        "name": "Sorcerer Reza of the Palms"
+    }, {
+        "id": "4209",
+        "name": "Runecaster Luther of the Palms"
+    }, {
+        "id": "4573",
+        "name": "Sorcerer Davos of the Palms"
+    }, {
+        "id": "4580",
+        "name": "Magus Louis of the Palms"
+    }, {
+        "id": "4672",
+        "name": "Druid Cromwell of the Palms"
+    }, {
+        "id": "4754",
+        "name": "Runecaster Casper of the Palms"
+    }, {
+        "id": "4786",
+        "name": "Arcanist Zelda of the Palms"
+    }, {
+        "id": "4804",
+        "name": "Battle Mage Angus of the Palms"
+    }, {
+        "id": "4844",
+        "name": "Hedge Wizard Dante of the Palms"
+    }, {
+        "id": "4851",
+        "name": "Archmagus Crobas of the Palms"
+    }, {
+        "id": "4867",
+        "name": "Wild Mage Danny of the Palms"
+    }, {
+        "id": "4891",
+        "name": "Aleister of the Palms"
+    }, {
+        "id": "5007",
+        "name": "Hex Mage Lumos of the Palms"
+    }, {
+        "id": "5103",
+        "name": "Artis of the Palms"
+    }, {
+        "id": "5106",
+        "name": "Cryptomancer Toka of the Palms"
+    }, {
+        "id": "5114",
+        "name": "Archmagus Lumos of the Palms"
+    }, {
+        "id": "5171",
+        "name": "Enchanter Thor of the Palms"
+    }, {
+        "id": "5249",
+        "name": "Archmagus Amir of the Palms"
+    }, {
+        "id": "5279",
+        "name": "Holy Monk Mace of the Palms"
+    }, {
+        "id": "5428",
+        "name": "Illusionist Beyna of the Palms"
+    }, {
+        "id": "5499",
+        "name": "Archmagus Azahl of the Palms"
+    }, {
+        "id": "5562",
+        "name": "Shaman Rafiq of the Palms"
+    }, {
+        "id": "5568",
+        "name": "Archmagus Merlon of the Palms"
+    }, {
+        "id": "5665",
+        "name": "Wild Mage Zaros of the Palms"
+    }, {
+        "id": "5718",
+        "name": "Archmagus Jeldor of the Palms"
+    }, {
+        "id": "5963",
+        "name": "Arch-Magician Edge of the Palms"
+    }, {
+        "id": "5982",
+        "name": "Mystic Angus of the Palms"
+    }, {
+        "id": "6052",
+        "name": "Clairvoyant Silas of the Palms"
+    }, {
+        "id": "6078",
+        "name": "Cryptomancer Voidoth of the Palms"
+    }, {
+        "id": "6099",
+        "name": "Ghost Eater Malcom of the Palms"
+    }, {
+        "id": "6262",
+        "name": "Voodoo Priest Pierre of the Palms"
+    }, {
+        "id": "6367",
+        "name": "Hydromancer Dante of the Palms"
+    }, {
+        "id": "6373",
+        "name": "Archmagus Salah of the Palms"
+    }, {
+        "id": "6432",
+        "name": "Alchemist Trollin of the Palms"
+    }, {
+        "id": "6466",
+        "name": "Daphne of the Palms"
+    }, {
+        "id": "6757",
+        "name": "Adept Ixar of the Palms"
+    }, {
+        "id": "6915",
+        "name": "Charmer Sondra of the Palms"
+    }, {
+        "id": "7021",
+        "name": "Druid Ozohr of the Palms"
+    }, {
+        "id": "7063",
+        "name": "Arcanist Solomon of the Palms"
+    }, {
+        "id": "7073",
+        "name": "Thaumaturge Talbot of the Palms"
+    }, {
+        "id": "7093",
+        "name": "Magus Finn of the Palms"
+    }, {
+        "id": "7399",
+        "name": "Voodoo Priest Requiem of the Palms"
+    }, {
+        "id": "7453",
+        "name": "Evoker Nicolas of the Palms"
+    }, {
+        "id": "7608",
+        "name": "Archmagus Aden of the Palms"
+    }, {
+        "id": "7655",
+        "name": "Archmagus Apollo of the Palms"
+    }, {
+        "id": "7747",
+        "name": "Archmagus Aldus of the Palms"
+    }, {
+        "id": "7777",
+        "name": "Summoner Nixie of the Palms"
+    }, {
+        "id": "7873",
+        "name": "Electromancer Bayard of the Palms"
+    }, {
+        "id": "8320",
+        "name": "Artificer Ulysse of the Palms"
+    }, {
+        "id": "8510",
+        "name": "Diabolist Huizhong of the Palms"
+    }, {
+        "id": "8587",
+        "name": "David of the Palms"
+    }, {
+        "id": "8822",
+        "name": "Sorcerer Zaros of the Palms"
+    }, {
+        "id": "8894",
+        "name": "Light Mage Illuminus of the Palms"
+    }, {
+        "id": "9021",
+        "name": "Thaumaturge Aleister of the Palms"
+    }, {
+        "id": "9265",
+        "name": "David of the Palms"
+    }, {
+        "id": "9283",
+        "name": "Geomancer Darick of the Palms"
+    }, {
+        "id": "9362",
+        "name": "Sorcerer Eizo of the Palms"
+    }, {
+        "id": "9414",
+        "name": "Alchemist Amir of the Palms"
+    }, {
+        "id": "9454",
+        "name": "Archmagus Remus of the Palms"
+    }, {
+        "id": "9468",
+        "name": "Enchanter Maia of the Palms"
+    }, {
+        "id": "9480",
+        "name": "Holy Monk Akron of the Palms"
+    }, {
+        "id": "9590",
+        "name": "Diviner Misumi of the Palms"
+    }, {
+        "id": "9705",
+        "name": "Battle Mage Thor of the Palms"
+    }, {
+        "id": "9795",
+        "name": "Diviner Isaac of the Palms"
+    }, {
+        "id": "9834",
+        "name": "Wild Mage Durm of the Palms"
+    }, {
+        "id": "9919",
+        "name": "Arch-Magician Nadeem of the Palms"
+    }, {
+        "id": "9961",
+        "name": "Mystic Tundror of the Palms"
+    }],
+    "7 Hues": [{
+        "id": "8701",
+        "name": "Alchemist Toby of the 7 Hues"
+    }],
+    "Tundra": [{
+        "id": "147",
+        "name": "Ghost Eater Vossler of the Tundra"
+    }, {
+        "id": "1128",
+        "name": "Sorcerer Jabir of the Tundra"
+    }, {
+        "id": "1147",
+        "name": "Ice Mage Soya of the Tundra"
+    }, {
+        "id": "1671",
+        "name": "Artificer Twitch of the Tundra"
+    }, {
+        "id": "1736",
+        "name": "Shaman Otto of the Tundra"
+    }, {
+        "id": "1737",
+        "name": "Bard Azahl of the Tundra"
+    }, {
+        "id": "1872",
+        "name": "Sorcerer Naoki of the Tundra"
+    }, {
+        "id": "2560",
+        "name": "Druid Samuel of the Tundra"
+    }, {
+        "id": "2762",
+        "name": "Ice Mage Moloch of the Tundra"
+    }, {
+        "id": "2840",
+        "name": "Pyromancer  of the Tundra"
+    }, {
+        "id": "3275",
+        "name": "Ice Mage Milo of the Tundra"
+    }, {
+        "id": "3381",
+        "name": "Electromancer Uvlius of the Tundra"
+    }, {
+        "id": "3874",
+        "name": "Sorcerer Ixar of the Tundra"
+    }, {
+        "id": "4150",
+        "name": "Ice Mage Uur'lok of the Tundra"
+    }, {
+        "id": "4531",
+        "name": "Ice Mage Dutorn of the Tundra"
+    }, {
+        "id": "4681",
+        "name": "Ice Mage Crowley of the Tundra"
+    }, {
+        "id": "4883",
+        "name": "Druid Epher of the Tundra"
+    }, {
+        "id": "5566",
+        "name": "Ice Mage Purple Boy of the Tundra"
+    }, {
+        "id": "6248",
+        "name": "Ice Mage Solomon of the Tundra"
+    }, {
+        "id": "6780",
+        "name": "Ice Mage Aleister of the Tundra"
+    }, {
+        "id": "6816",
+        "name": "Sorcerer Solomon of the Tundra"
+    }, {
+        "id": "7878",
+        "name": "Sage Wolfram of the Tundra"
+    }, {
+        "id": "8082",
+        "name": "Witch Shivra of the Tundra"
+    }, {
+        "id": "8171",
+        "name": "Mystic Damien of the Tundra"
+    }, {
+        "id": "8598",
+        "name": "Alchemist Hu of the Tundra"
+    }, {
+        "id": "8997",
+        "name": "Arcanist Angus of the Tundra"
+    }, {
+        "id": "9066",
+        "name": "Archmagus Ixar of the Tundra"
+    }, {
+        "id": "9293",
+        "name": "Conjurer Twitch of the Tundra"
+    }, {
+        "id": "9297",
+        "name": "Hedge Wizard Aleister of the Tundra"
+    }, {
+        "id": "9316",
+        "name": "Summoner Oberon of the Tundra"
+    }, {
+        "id": "9354",
+        "name": "Artificer Dutorn of the Tundra"
+    }],
+    "Berg": [{
+        "id": "88",
+        "name": "Shaman Lamia of the Berg"
+    }, {
+        "id": "2957",
+        "name": "Evoker Mushy of the Berg"
+    }, {
+        "id": "2983",
+        "name": "Sorcerer Jeldor of the Berg"
+    }, {
+        "id": "3077",
+        "name": "Mystic Huizhong of the Berg"
+    }, {
+        "id": "3319",
+        "name": "Enchanter Taqi of the Berg"
+    }, {
+        "id": "3377",
+        "name": "Magus Setsuko of the Berg"
+    }, {
+        "id": "3668",
+        "name": "Geomancer Milo of the Berg"
+    }, {
+        "id": "4380",
+        "name": "Runecaster Tundror of the Berg"
+    }, {
+        "id": "4598",
+        "name": "Ice Mage Durm of the Berg"
+    }, {
+        "id": "4878",
+        "name": "Oracle Taqi of the Berg"
+    }, {
+        "id": "4926",
+        "name": "Sorcerer Milton of the Berg"
+    }, {
+        "id": "4935",
+        "name": "Shaman Silas of the Berg"
+    }, {
+        "id": "5140",
+        "name": "Sorcerer Basil of the Berg"
+    }, {
+        "id": "5180",
+        "name": "Ice Mage Gaspard of the Berg"
+    }, {
+        "id": "5661",
+        "name": "Magus Angus of the Berg"
+    }, {
+        "id": "6512",
+        "name": "Enchanter Willow of the Berg"
+    }, {
+        "id": "6726",
+        "name": "Ice Mage Merlon of the Berg"
+    }, {
+        "id": "6831",
+        "name": "Ghost Eater Abaddon of the Berg"
+    }, {
+        "id": "7914",
+        "name": "Ice Mage Armstrong of the Berg"
+    }, {
+        "id": "8198",
+        "name": "Ice Mage Zelroth of the Berg"
+    }, {
+        "id": "8780",
+        "name": "Sorcerer Hadrien of the Berg"
+    }, {
+        "id": "9272",
+        "name": "Ice Mage Elmo of the Berg"
+    }, {
+        "id": "9357",
+        "name": "Ice Mage Sarah of the Berg"
+    }, {
+        "id": "9503",
+        "name": "Ice Mage Khudalf of the Berg"
+    }],
+    "Light": [{
+        "id": "453",
+        "name": "Ghost Eater Aleister of the Light"
+    }, {
+        "id": "527",
+        "name": "Arch-Magician Udor of the Light"
+    }, {
+        "id": "617",
+        "name": "Thaumaturge Aldo of the Light"
+    }, {
+        "id": "638",
+        "name": "Archmagus Ravana of the Light"
+    }, {
+        "id": "645",
+        "name": "Sage Solomon of the Light"
+    }, {
+        "id": "687",
+        "name": "Artificer Solomon of the Light"
+    }, {
+        "id": "692",
+        "name": "Hedge Wizard Marceau of the Light"
+    }, {
+        "id": "996",
+        "name": "Spellsinger Remus of the Light"
+    }, {
+        "id": "1057",
+        "name": "Pyromancer Flamos of the Light"
+    }, {
+        "id": "1124",
+        "name": "Evoker Remus of the Light"
+    }, {
+        "id": "1154",
+        "name": "Augurer Cairon of the Light"
+    }, {
+        "id": "1317",
+        "name": "Hydromancer Alessar of the Light"
+    }, {
+        "id": "1505",
+        "name": "Chaos Mage Norix of the Light"
+    }, {
+        "id": "1562",
+        "name": "Null Mage Charlord of the Light"
+    }, {
+        "id": "1629",
+        "name": "Witch Keziah of the Light"
+    }, {
+        "id": "1987",
+        "name": "Summoner Crowley of the Light"
+    }, {
+        "id": "2158",
+        "name": "Arcanist Finn of the Light"
+    }, {
+        "id": "2235",
+        "name": "Battle Mage Goliath of the Light"
+    }, {
+        "id": "2315",
+        "name": "Sorcerer Basil of the Light"
+    }, {
+        "id": "2431",
+        "name": "Archmagus Milton of the Light"
+    }, {
+        "id": "2990",
+        "name": "Cosmic Mage Tundror of the Light"
+    }, {
+        "id": "3009",
+        "name": "Conjurer Drusilla of the Light"
+    }, {
+        "id": "3293",
+        "name": "Fortune Teller Ozohr of the Light"
+    }, {
+        "id": "3371",
+        "name": "Geomancer Angus of the Light"
+    }, {
+        "id": "3435",
+        "name": "Evoker Finch of the Light"
+    }, {
+        "id": "3463",
+        "name": "Conjurer Marceline of the Light"
+    }, {
+        "id": "3650",
+        "name": "Artificer Moka of the Light"
+    }, {
+        "id": "3704",
+        "name": "Void Disciple Nazim of the Light"
+    }, {
+        "id": "3801",
+        "name": "Arcanist Vossler of the Light"
+    }, {
+        "id": "3825",
+        "name": "Thaumaturge Aleister of the Light"
+    }, {
+        "id": "4119",
+        "name": "Summoner Bartholomew of the Light"
+    }, {
+        "id": "4194",
+        "name": "Spellsinger Eronin of the Light"
+    }, {
+        "id": "4894",
+        "name": "Magus Carly of the Light"
+    }, {
+        "id": "4918",
+        "name": "Sky Master Magpie of the Light"
+    }, {
+        "id": "4928",
+        "name": "Fortune Teller Cosmo of the Light"
+    }, {
+        "id": "4980",
+        "name": "Archmagus Alessar of the Light"
+    }, {
+        "id": "5287",
+        "name": "Null Mage Ixar of the Light"
+    }, {
+        "id": "5371",
+        "name": "Pyromancer Aleister of the Light"
+    }, {
+        "id": "5548",
+        "name": "Magus Daria of the Light"
+    }, {
+        "id": "5656",
+        "name": "Battlemage Hansel of the Light"
+    }, {
+        "id": "5728",
+        "name": "Electromancer Ozohr of the Light"
+    }, {
+        "id": "5944",
+        "name": "Scryer Bartholomew of the Light"
+    }, {
+        "id": "6027",
+        "name": "Eizo of the Light"
+    }, {
+        "id": "6088",
+        "name": "Arcanist Lumos of the Light"
+    }, {
+        "id": "6124",
+        "name": "Pyromancer Lumos of the Light"
+    }, {
+        "id": "6146",
+        "name": "Druid Eden of the Light"
+    }, {
+        "id": "6185",
+        "name": "Cryptomancer Carly of the Light"
+    }, {
+        "id": "6345",
+        "name": "Archmagus Zubin of the Light"
+    }, {
+        "id": "6348",
+        "name": "Battle Mage Axel of the Light"
+    }, {
+        "id": "6354",
+        "name": "Alchemist Isaac of the Light"
+    }, {
+        "id": "6399",
+        "name": "Archmagus Milo of the Light"
+    }, {
+        "id": "6403",
+        "name": "Battle Mage Danny of the Light"
+    }, {
+        "id": "6543",
+        "name": "Adept Durm of the Light"
+    }, {
+        "id": "6544",
+        "name": "Archmagus Oberon of the Light"
+    }, {
+        "id": "6802",
+        "name": "Shaman Sondra of the Light"
+    }, {
+        "id": "7551",
+        "name": "Lumos of the Light"
+    }, {
+        "id": "7588",
+        "name": "Sorcerer Eizo of the Light"
+    }, {
+        "id": "7923",
+        "name": "Witch Esme of the Light"
+    }, {
+        "id": "8307",
+        "name": "Sorcerer Zorko of the Light"
+    }, {
+        "id": "8576",
+        "name": "Ghost Eater Seth of the Light"
+    }, {
+        "id": "8578",
+        "name": "Hydromancer David of the Light"
+    }, {
+        "id": "8785",
+        "name": "Archmagus Crowley of the Light"
+    }, {
+        "id": "8794",
+        "name": "Charmer Asphodel of the Light"
+    }, {
+        "id": "8827",
+        "name": "Ghost Eater Norix of the Light"
+    }, {
+        "id": "8935",
+        "name": "Solar Mage Fire Eater of the Light"
+    }, {
+        "id": "9071",
+        "name": "Druid Cassius of the Light"
+    }, {
+        "id": "9242",
+        "name": "Artificer Poppy of the Light"
+    }, {
+        "id": "9300",
+        "name": "Shadow Mage Imeena of the Light"
+    }, {
+        "id": "9481",
+        "name": "Pyromancer Huizhong of the Light"
+    }, {
+        "id": "9671",
+        "name": "Artificer Nikolas of the Light"
+    }, {
+        "id": "9697",
+        "name": "Necromancer Aamon of the Light"
+    }, {
+        "id": "9798",
+        "name": "Druid Norix of the Light"
+    }],
+    "Astral Plane": [{
+        "id": "213",
+        "name": "Pyromancer Soya of the Astral Plane"
+    }, {
+        "id": "292",
+        "name": "Magus Basil of the Astral Plane"
+    }, {
+        "id": "584",
+        "name": "Enchanter Uvlius of the Astral Plane"
+    }, {
+        "id": "626",
+        "name": "Medium Solomon of the Astral Plane"
+    }, {
+        "id": "772",
+        "name": "Pyromancer Ixar of the Astral Plane"
+    }, {
+        "id": "1184",
+        "name": "Battlemage Cassius of the Astral Plane"
+    }, {
+        "id": "1206",
+        "name": "Enchanter Daria of the Astral Plane"
+    }, {
+        "id": "1207",
+        "name": "Necromancer Billy of the Astral Plane"
+    }, {
+        "id": "1278",
+        "name": "Mystic Impy of the Astral Plane"
+    }, {
+        "id": "1515",
+        "name": "Alchemist Pumlo of the Astral Plane"
+    }, {
+        "id": "1535",
+        "name": "Sage JackDaw of the Astral Plane"
+    }, {
+        "id": "1560",
+        "name": "Ghost Eater Ali of the Astral Plane"
+    }, {
+        "id": "1564",
+        "name": "Druid Danny of the Astral Plane"
+    }, {
+        "id": "1595",
+        "name": "Sorcerer Aldus of the Astral Plane"
+    }, {
+        "id": "1611",
+        "name": "Sorcerer Qaid of the Astral Plane"
+    }, {
+        "id": "1613",
+        "name": "Fortune Teller Jiang of the Astral Plane"
+    }, {
+        "id": "1641",
+        "name": "Hedge Wizard Eizo of the Astral Plane"
+    }, {
+        "id": "1744",
+        "name": "Scryer Nikolas of the Astral Plane"
+    }, {
+        "id": "1756",
+        "name": "Sorcerer Cairon of the Astral Plane"
+    }, {
+        "id": "2031",
+        "name": "Diana of the Astral Plane"
+    }, {
+        "id": "2121",
+        "name": "Aleister of the Astral Plane"
+    }, {
+        "id": "2236",
+        "name": "Sorcerer Ramiz of the Astral Plane"
+    }, {
+        "id": "2575",
+        "name": "Arch-Magician Yaggdytha of the Astral Plane"
+    }, {
+        "id": "2659",
+        "name": "Pyromancer Scorch of the Astral Plane"
+    }, {
+        "id": "2684",
+        "name": "Pyromancer Aslan of the Astral Plane"
+    }, {
+        "id": "2888",
+        "name": "Archmagus Jastor of the Astral Plane"
+    }, {
+        "id": "3091",
+        "name": "Pyromancer Milo of the Astral Plane"
+    }, {
+        "id": "3227",
+        "name": "Archmagus Gellert of the Astral Plane"
+    }, {
+        "id": "3258",
+        "name": "Clairvoyant Aiko of the Astral Plane"
+    }, {
+        "id": "3356",
+        "name": "Ozohr of the Astral Plane"
+    }, {
+        "id": "3561",
+        "name": "Hedge Wizard Caligari of the Astral Plane"
+    }, {
+        "id": "3859",
+        "name": "Archmagus Iprix of the Astral Plane"
+    }, {
+        "id": "3869",
+        "name": "Magus Gellert of the Astral Plane"
+    }, {
+        "id": "3908",
+        "name": "Alchemist Pix of the Astral Plane"
+    }, {
+        "id": "4436",
+        "name": "Archmagus Basil of the Astral Plane"
+    }, {
+        "id": "4493",
+        "name": "Enchanter Iprix of the Astral Plane"
+    }, {
+        "id": "4607",
+        "name": "Voodoo Priest Uvlius of the Astral Plane"
+    }, {
+        "id": "4729",
+        "name": "Witch Lamia of the Astral Plane"
+    }, {
+        "id": "4835",
+        "name": "Magus Hecate of the Astral Plane"
+    }, {
+        "id": "4862",
+        "name": "Crowley of the Astral Plane"
+    }, {
+        "id": "4938",
+        "name": "Mystic Jastor of the Astral Plane"
+    }, {
+        "id": "4959",
+        "name": "Transmuter Hanataka of the Astral Plane"
+    }, {
+        "id": "4981",
+        "name": "Necromancer Chiron of the Astral Plane"
+    }, {
+        "id": "4990",
+        "name": "Sorcerer Milton of the Astral Plane"
+    }, {
+        "id": "5395",
+        "name": "Witch Properpine of the Astral Plane"
+    }, {
+        "id": "5400",
+        "name": "Archmagus Dario of the Astral Plane"
+    }, {
+        "id": "5758",
+        "name": "Uvlius of the Astral Plane"
+    }, {
+        "id": "5796",
+        "name": "Shadow Mage Isaac of the Astral Plane"
+    }, {
+        "id": "5817",
+        "name": "Cleric Adium of the Astral Plane"
+    }, {
+        "id": "5841",
+        "name": "Diabolist Ghorhoth of the Astral Plane"
+    }, {
+        "id": "5914",
+        "name": "Bard Brutus of the Astral Plane"
+    }, {
+        "id": "5946",
+        "name": "Shaman Aldus of the Astral Plane"
+    }, {
+        "id": "5953",
+        "name": "Enchanter Daria of the Astral Plane"
+    }, {
+        "id": "6042",
+        "name": "Chronomancer Bao of the Astral Plane"
+    }, {
+        "id": "6165",
+        "name": "Diabolist Alizam of the Astral Plane"
+    }, {
+        "id": "6183",
+        "name": "Pyromancer Damien of the Astral Plane"
+    }, {
+        "id": "6506",
+        "name": "Sorcerer Hadrien of the Astral Plane"
+    }, {
+        "id": "6560",
+        "name": "Sorcerer Aleister of the Astral Plane"
+    }, {
+        "id": "6584",
+        "name": "Hex Mage Asmodeus of the Astral Plane"
+    }, {
+        "id": "6716",
+        "name": "Witch Cassandra of the Astral Plane"
+    }, {
+        "id": "6823",
+        "name": "Necromancer Aiko of the Astral Plane"
+    }, {
+        "id": "7084",
+        "name": "Aldus of the Astral Plane"
+    }, {
+        "id": "7166",
+        "name": "Battle Mage Gary of the Astral Plane"
+    }, {
+        "id": "7397",
+        "name": "Cleric Oiq of the Astral Plane"
+    }, {
+        "id": "7416",
+        "name": "Magus Jabir of the Astral Plane"
+    }, {
+        "id": "7599",
+        "name": "Thaumaturge Elena of the Astral Plane"
+    }, {
+        "id": "7626",
+        "name": "Sky Master Hank of the Astral Plane"
+    }, {
+        "id": "7662",
+        "name": "Sorcerer Ilyas of the Astral Plane"
+    }, {
+        "id": "7718",
+        "name": "Shaman Azazel of the Astral Plane"
+    }, {
+        "id": "7780",
+        "name": "Sorcerer Ifran of the Astral Plane"
+    }, {
+        "id": "7907",
+        "name": "Sorcerer Apollo of the Astral Plane"
+    }, {
+        "id": "7978",
+        "name": "Enchanter Sonja of the Astral Plane"
+    }, {
+        "id": "8038",
+        "name": "Shaman Alessar of the Astral Plane"
+    }, {
+        "id": "8237",
+        "name": "Hedge Wizard Darby of the Astral Plane"
+    }, {
+        "id": "8305",
+        "name": "Archmagus Drokore of the Astral Plane"
+    }, {
+        "id": "8439",
+        "name": "Battle Mage Blaise of the Astral Plane"
+    }, {
+        "id": "8511",
+        "name": "Sorcerer Soya of the Astral Plane"
+    }, {
+        "id": "8551",
+        "name": "Pyromancer Isaac of the Astral Plane"
+    }, {
+        "id": "8797",
+        "name": "Scryer Bane of the Astral Plane"
+    }, {
+        "id": "8813",
+        "name": "Arcanist Angus of the Astral Plane"
+    }, {
+        "id": "8840",
+        "name": "Chronomancer Takao of the Astral Plane"
+    }, {
+        "id": "8965",
+        "name": "Enchanter Uvlius of the Astral Plane"
+    }, {
+        "id": "9054",
+        "name": "Hedge Wizard Xiuying of the Astral Plane"
+    }, {
+        "id": "9173",
+        "name": "Hedge Wizard Fungi of the Astral Plane"
+    }, {
+        "id": "9215",
+        "name": "Archmagus Lumos of the Astral Plane"
+    }, {
+        "id": "9223",
+        "name": "Battle Mage Ethan of the Astral Plane"
+    }, {
+        "id": "9228",
+        "name": "Enchanter Hanataka of the Astral Plane"
+    }, {
+        "id": "9264",
+        "name": "Arch-Magician Alatar of the Astral Plane"
+    }, {
+        "id": "9273",
+        "name": "Witch Lamia of the Astral Plane"
+    }, {
+        "id": "9294",
+        "name": "Ghost Eater Iprix of the Astral Plane"
+    }, {
+        "id": "9429",
+        "name": "Chronomancer Merlon of the Astral Plane"
+    }, {
+        "id": "9439",
+        "name": "Alchemist Kazem of the Astral Plane"
+    }, {
+        "id": "9546",
+        "name": "Shaman Bayard of the Astral Plane"
+    }, {
+        "id": "9547",
+        "name": "Archmagus Jeldor of the Astral Plane"
+    }, {
+        "id": "9640",
+        "name": "Alchemist Hothor of the Astral Plane"
+    }, {
+        "id": "9709",
+        "name": "Runecaster Shanyuan of the Astral Plane"
+    }, {
+        "id": "9875",
+        "name": "Archmagus Merlon of the Astral Plane"
+    }],
+    "Grave": [{
+        "id": "2816",
+        "name": "Adept Milo of the Grave"
+    }, {
+        "id": "4855",
+        "name": "Enchanter Mad Apple of the Grave"
+    }],
+    "Arcadia": [{
+        "id": "110",
+        "name": "Arch-Magician Jasper of Arcadia"
+    }, {
+        "id": "452",
+        "name": "Archmagus Remus of Arcadia"
+    }, {
+        "id": "466",
+        "name": "Druid Faiz of Arcadia"
+    }, {
+        "id": "578",
+        "name": "Archmagus Alessar of Arcadia"
+    }, {
+        "id": "798",
+        "name": "Oracle Cosmo of Arcadia"
+    }, {
+        "id": "877",
+        "name": "Arch-Magician Goliath of Arcadia"
+    }, {
+        "id": "1152",
+        "name": "Archmagus Crobas of Arcadia"
+    }, {
+        "id": "1173",
+        "name": "Hedge Wizard Godfrey of Arcadia"
+    }, {
+        "id": "1197",
+        "name": "Battle Mage Borak of Arcadia"
+    }, {
+        "id": "1236",
+        "name": "Mystic Carmilla of Arcadia"
+    }, {
+        "id": "1363",
+        "name": "Sorcerer Alatar of Arcadia"
+    }, {
+        "id": "1445",
+        "name": "Diviner Robert of Arcadia"
+    }, {
+        "id": "1483",
+        "name": "Necromancer Malcom of Arcadia"
+    }, {
+        "id": "1598",
+        "name": "Witch Rita of Arcadia"
+    }, {
+        "id": "1615",
+        "name": "Archmagus George of Arcadia"
+    }, {
+        "id": "1791",
+        "name": "Witch Elena of Arcadia"
+    }, {
+        "id": "1804",
+        "name": "Bard Titania of Arcadia"
+    }, {
+        "id": "1805",
+        "name": "Aeromancer Ming of Arcadia"
+    }, {
+        "id": "1823",
+        "name": "Alchemist Solomon of Arcadia"
+    }, {
+        "id": "1894",
+        "name": "Shaman Ofaris of Arcadia"
+    }, {
+        "id": "2029",
+        "name": "Archmagus Apollo of Arcadia"
+    }, {
+        "id": "2144",
+        "name": "Stellar Mage Iris of Arcadia"
+    }, {
+        "id": "2280",
+        "name": "Sorcerer Casper of Arcadia"
+    }, {
+        "id": "2286",
+        "name": "Shaman Ulysse of Arcadia"
+    }, {
+        "id": "2313",
+        "name": "Archmagus Ofaris of Arcadia"
+    }, {
+        "id": "2440",
+        "name": "Arcanist Hothor of Arcadia"
+    }, {
+        "id": "2450",
+        "name": "Magus Pumlo of Arcadia"
+    }, {
+        "id": "2487",
+        "name": "Druid Eyolf of Arcadia"
+    }, {
+        "id": "2805",
+        "name": "Hedge Wizard Hedgie of Arcadia"
+    }, {
+        "id": "2807",
+        "name": "Ghost Eater Mina of Arcadia"
+    }, {
+        "id": "2903",
+        "name": "Archmagus Soya of Arcadia"
+    }, {
+        "id": "3308",
+        "name": "Archmagus Solomon of Arcadia"
+    }, {
+        "id": "3336",
+        "name": "Shadow Mage Nazim of Arcadia"
+    }, {
+        "id": "3462",
+        "name": "Hedge Wizard Aldus of Arcadia"
+    }, {
+        "id": "3591",
+        "name": "Diviner Calliope of Arcadia"
+    }, {
+        "id": "3729",
+        "name": "Charmer Circe of Arcadia"
+    }, {
+        "id": "4114",
+        "name": "Battle Mage Hagar of Arcadia"
+    }, {
+        "id": "4134",
+        "name": "Diabolist Imeena of Arcadia"
+    }, {
+        "id": "4152",
+        "name": "Sorcerer Nazim of Arcadia"
+    }, {
+        "id": "4195",
+        "name": "Summoner Aleister of Arcadia"
+    }, {
+        "id": "4247",
+        "name": "Allistair of Arcadia"
+    }, {
+        "id": "4266",
+        "name": "Diabolist Sondra of Arcadia"
+    }, {
+        "id": "4277",
+        "name": "Witch Properpine of Arcadia"
+    }, {
+        "id": "4294",
+        "name": "Arcanist Leah of Arcadia"
+    }, {
+        "id": "4310",
+        "name": "Aeromancer Lenora of Arcadia"
+    }, {
+        "id": "4318",
+        "name": "Alchemist Ariadne of Arcadia"
+    }, {
+        "id": "4338",
+        "name": "Aeromancer Esme of Arcadia"
+    }, {
+        "id": "4371",
+        "name": "Enchanter Layla of Arcadia"
+    }, {
+        "id": "4388",
+        "name": "Enchanter Sonja of Arcadia"
+    }, {
+        "id": "4496",
+        "name": "Hydromancer Meloogen of Arcadia"
+    }, {
+        "id": "4658",
+        "name": "Battle Mage Gary of Arcadia"
+    }, {
+        "id": "4697",
+        "name": "Battle Mage Nolan of Arcadia"
+    }, {
+        "id": "4746",
+        "name": "Magus Daria of Arcadia"
+    }, {
+        "id": "4865",
+        "name": "Battle Mage Aslan of Arcadia"
+    }, {
+        "id": "4869",
+        "name": "Mina of Arcadia"
+    }, {
+        "id": "4930",
+        "name": "Alchemist Behemoth of Arcadia"
+    }, {
+        "id": "5102",
+        "name": "Magus Caligula of Arcadia"
+    }, {
+        "id": "5149",
+        "name": "Diabolist Daria of Arcadia"
+    }, {
+        "id": "5165",
+        "name": "Runecaster Cassiopeia of Arcadia"
+    }, {
+        "id": "5239",
+        "name": "Sorcerer Soya of Arcadia"
+    }, {
+        "id": "5261",
+        "name": "Witch Velorina of Arcadia"
+    }, {
+        "id": "5483",
+        "name": "Enchanter Daria of Arcadia"
+    }, {
+        "id": "5756",
+        "name": "Shaman Tundror of Arcadia"
+    }, {
+        "id": "6005",
+        "name": "Pyromancer Zolona of Arcadia"
+    }, {
+        "id": "6360",
+        "name": "Battle Mage Brutus of Arcadia"
+    }, {
+        "id": "6383",
+        "name": "Shaman Chandler of Arcadia"
+    }, {
+        "id": "6405",
+        "name": "Adept Atlanta of Arcadia"
+    }, {
+        "id": "6426",
+        "name": "Arcanist Lenora of Arcadia"
+    }, {
+        "id": "6461",
+        "name": "Aeromancer Delilah of Arcadia"
+    }, {
+        "id": "6529",
+        "name": "Battle Mage Blaise of Arcadia"
+    }, {
+        "id": "6615",
+        "name": "Alchemist Alessar of Arcadia"
+    }, {
+        "id": "6632",
+        "name": "Adept David of Arcadia"
+    }, {
+        "id": "6688",
+        "name": "Artificer Gwendolin of Arcadia"
+    }, {
+        "id": "6734",
+        "name": "Witch Delilah of Arcadia"
+    }, {
+        "id": "6754",
+        "name": "Alchemist Hagatha of Arcadia"
+    }, {
+        "id": "6789",
+        "name": "Shaman C'thalpa of Arcadia"
+    }, {
+        "id": "6794",
+        "name": "Hex Mage Tundror of Arcadia"
+    }, {
+        "id": "6842",
+        "name": "Illusionist Wolfram of Arcadia"
+    }, {
+        "id": "6912",
+        "name": "Silas of Arcadia"
+    }, {
+        "id": "7172",
+        "name": "Sky Master Crowley of Arcadia"
+    }, {
+        "id": "7444",
+        "name": "Battle Mage Goliath of Arcadia"
+    }, {
+        "id": "7446",
+        "name": "Archmagus Celah of Arcadia"
+    }, {
+        "id": "7447",
+        "name": "Magus Maia of Arcadia"
+    }, {
+        "id": "7538",
+        "name": "Runecaster Atlanta of Arcadia"
+    }, {
+        "id": "7589",
+        "name": "Hedge Wizard Pepo of Arcadia"
+    }, {
+        "id": "7639",
+        "name": "Sage Iluzor of Arcadia"
+    }, {
+        "id": "7789",
+        "name": "Pyromancer Lumos of Arcadia"
+    }, {
+        "id": "7839",
+        "name": "Archmagus Soran of Arcadia"
+    }, {
+        "id": "8133",
+        "name": "Alchemist Soran of Arcadia"
+    }, {
+        "id": "8280",
+        "name": "Sage Sondra of Arcadia"
+    }, {
+        "id": "8577",
+        "name": "Magus Kazem of Arcadia"
+    }, {
+        "id": "8723",
+        "name": "Diabolist Impy of Arcadia"
+    }, {
+        "id": "9136",
+        "name": "Sorcerer Ozohr of Arcadia"
+    }, {
+        "id": "9154",
+        "name": "Aeromancer Karasu of Arcadia"
+    }, {
+        "id": "9219",
+        "name": "Enchanter Daphne of Arcadia"
+    }, {
+        "id": "9355",
+        "name": "Hedge Wizard Lenora of Arcadia"
+    }, {
+        "id": "9619",
+        "name": "Shaman Velorina of Arcadia"
+    }, {
+        "id": "9692",
+        "name": "Magus  of Arcadia"
+    }, {
+        "id": "9787",
+        "name": "Hedge Wizard Liliana of Arcadia"
+    }, {
+        "id": "9791",
+        "name": "Arch-Magician Lucinda of Arcadia"
+    }, {
+        "id": "9891",
+        "name": "Necromancer Judas of Arcadia"
+    }, {
+        "id": "9970",
+        "name": "Shadow Mage Fark of Arcadia"
+    }],
+    "Woodlands": [{
+        "id": "200",
+        "name": "Summoner Silas of the Woodlands"
+    }, {
+        "id": "774",
+        "name": "Battle Mage Hagar of the Woodlands"
+    }, {
+        "id": "1013",
+        "name": "Archmagus Yookoo of the Woodlands"
+    }, {
+        "id": "1202",
+        "name": "Sage Ifran of the Woodlands"
+    }, {
+        "id": "1738",
+        "name": "Diabolist Borak of the Woodlands"
+    }, {
+        "id": "2221",
+        "name": "Battle Mage Robert of the Woodlands"
+    }, {
+        "id": "2233",
+        "name": "Pyromancer Remus of the Woodlands"
+    }, {
+        "id": "2278",
+        "name": "Archmagus Uur'lok of the Woodlands"
+    }, {
+        "id": "2344",
+        "name": "Ghost Eater Gino of the Woodlands"
+    }, {
+        "id": "2346",
+        "name": "Chronomancer Lumos of the Woodlands"
+    }, {
+        "id": "2788",
+        "name": "Witch Velorina of the Woodlands"
+    }, {
+        "id": "3608",
+        "name": "Geomancer Nixie of the Woodlands"
+    }, {
+        "id": "3863",
+        "name": "Magus Chipper of the Woodlands"
+    }, {
+        "id": "4342",
+        "name": "Alchemist Aubergine of the Woodlands"
+    }, {
+        "id": "4454",
+        "name": "Archmagus Uvlius of the Woodlands"
+    }, {
+        "id": "4711",
+        "name": "Arcanist Purple Boy of the Woodlands"
+    }, {
+        "id": "5303",
+        "name": "Battle Mage Magnus of the Woodlands"
+    }, {
+        "id": "5355",
+        "name": "Aeromancer Prisma of the Woodlands"
+    }, {
+        "id": "5867",
+        "name": "Battle Mage Blaise of the Woodlands"
+    }, {
+        "id": "5886",
+        "name": "Battle Mage Homer of the Woodlands"
+    }, {
+        "id": "6168",
+        "name": "Mystic Azazel of the Woodlands"
+    }, {
+        "id": "6498",
+        "name": "Runecaster Merlon of the Woodlands"
+    }, {
+        "id": "7094",
+        "name": "Bard Pix of the Woodlands"
+    }, {
+        "id": "7152",
+        "name": "Magus Daria of the Woodlands"
+    }, {
+        "id": "7214",
+        "name": "Adept Yookoo of the Woodlands"
+    }, {
+        "id": "9387",
+        "name": "Zane of the Woodlands"
+    }, {
+        "id": "9493",
+        "name": "Arcanist Toka of the Woodlands"
+    }, {
+        "id": "9638",
+        "name": "Hedge Wizard Blaise of the Woodlands"
+    }],
+    "Technochrome": [{
+        "id": "55",
+        "name": "Ghost Eater Kobold of the Technochrome"
+    }, {
+        "id": "2756",
+        "name": "Ghost Eater Corky of the Technochrome"
+    }, {
+        "id": "9383",
+        "name": "Arch-Magician Poppy of the Technochrome"
+    }],
+    "Riviera": [{
+        "id": "50",
+        "name": "Shaman Alizam of the Riviera"
+    }, {
+        "id": "185",
+        "name": "Sage Caligula of the Riviera"
+    }, {
+        "id": "338",
+        "name": "Sorcerer Chooki of the Riviera"
+    }, {
+        "id": "459",
+        "name": "Summoner Aldo of the Riviera"
+    }, {
+        "id": "478",
+        "name": "Battle Mage Nicolas of the Riviera"
+    }, {
+        "id": "641",
+        "name": "Arch-Magician Ethan of the Riviera"
+    }, {
+        "id": "697",
+        "name": "Adept Sabina of the Riviera"
+    }, {
+        "id": "746",
+        "name": "Cleric Magnus of the Riviera"
+    }, {
+        "id": "760",
+        "name": "Druid Ulysse of the Riviera"
+    }, {
+        "id": "906",
+        "name": "Geomancer Aleister of the Riviera"
+    }, {
+        "id": "1169",
+        "name": "Archmagus Brutus of the Riviera"
+    }, {
+        "id": "1263",
+        "name": "Battlemage Qasim of the Riviera"
+    }, {
+        "id": "1268",
+        "name": "Alchemist David of the Riviera"
+    }, {
+        "id": "1283",
+        "name": "Diabolist Rita of the Riviera"
+    }, {
+        "id": "1661",
+        "name": "Enchanter Layla of the Riviera"
+    }, {
+        "id": "1747",
+        "name": "Enchanter Sondra of the Riviera"
+    }, {
+        "id": "1797",
+        "name": "Arch-Magician Hansel of the Riviera"
+    }, {
+        "id": "1836",
+        "name": "Witch Sylvia of the Riviera"
+    }, {
+        "id": "1917",
+        "name": "Arcanist Gino of the Riviera"
+    }, {
+        "id": "1941",
+        "name": "Witch Ivy of the Riviera"
+    }, {
+        "id": "1966",
+        "name": "Sorcerer Jahid of the Riviera"
+    }, {
+        "id": "2180",
+        "name": "Shadow Mage Wolfram of the Riviera"
+    }, {
+        "id": "2270",
+        "name": "Enchanter Jadis of the Riviera"
+    }, {
+        "id": "2496",
+        "name": "Holy Monk Ravana of the Riviera"
+    }, {
+        "id": "2538",
+        "name": "Arcanist Ekmira of the Riviera"
+    }, {
+        "id": "2547",
+        "name": "Chronomancer Eden of the Riviera"
+    }, {
+        "id": "2761",
+        "name": "Druid Molek of the Riviera"
+    }, {
+        "id": "2882",
+        "name": "Illusionist Layla of the Riviera"
+    }, {
+        "id": "3142",
+        "name": "Archmagus David of the Riviera"
+    }, {
+        "id": "3224",
+        "name": "Aldus of the Riviera"
+    }, {
+        "id": "3318",
+        "name": "Witch Caligula of the Riviera"
+    }, {
+        "id": "3345",
+        "name": "Sorcerer Apollo of the Riviera"
+    }, {
+        "id": "3405",
+        "name": "Necromancer Gully of the Riviera"
+    }, {
+        "id": "3458",
+        "name": "Witch Alessar of the Riviera"
+    }, {
+        "id": "3467",
+        "name": "Shadow Mage Nixie of the Riviera"
+    }, {
+        "id": "3510",
+        "name": "Runecaster Rowena of the Riviera"
+    }, {
+        "id": "3660",
+        "name": "Archmagus Aleister of the Riviera"
+    }, {
+        "id": "3810",
+        "name": "Beyna of the Riviera"
+    }, {
+        "id": "4030",
+        "name": "Shaman Zubin of the Riviera"
+    }, {
+        "id": "4058",
+        "name": "Atlanta of the Riviera"
+    }, {
+        "id": "4068",
+        "name": "Conjurer Elena of the Riviera"
+    }, {
+        "id": "4075",
+        "name": "Shaman Armstrong of the Riviera"
+    }, {
+        "id": "4256",
+        "name": "Battle Mage Homer of the Riviera"
+    }, {
+        "id": "4265",
+        "name": "Alchemist Lamia of the Riviera"
+    }, {
+        "id": "4370",
+        "name": "Apollo of the Riviera"
+    }, {
+        "id": "4376",
+        "name": "Archmagus  of the Riviera"
+    }, {
+        "id": "4414",
+        "name": "Archmagus Remus of the Riviera"
+    }, {
+        "id": "4434",
+        "name": "Witch Drusilla of the Riviera"
+    }, {
+        "id": "4444",
+        "name": "Cleric Lumos of the Riviera"
+    }, {
+        "id": "4716",
+        "name": "Enchanter Layla of the Riviera"
+    }, {
+        "id": "4825",
+        "name": "Charmer Iris of the Riviera"
+    }, {
+        "id": "4840",
+        "name": "Illusionist Jig of the Riviera"
+    }, {
+        "id": "4845",
+        "name": "Battle Mage Dante of the Riviera"
+    }, {
+        "id": "4954",
+        "name": "Cleric Arabella of the Riviera"
+    }, {
+        "id": "5099",
+        "name": "Artificer Eden of the Riviera"
+    }, {
+        "id": "5179",
+        "name": "Pyromancer Fire Eater of the Riviera"
+    }, {
+        "id": "5322",
+        "name": "Sage Eric of the Riviera"
+    }, {
+        "id": "5438",
+        "name": "Archmagus Alatar of the Riviera"
+    }, {
+        "id": "5546",
+        "name": "Shaman Aiko of the Riviera"
+    }, {
+        "id": "5604",
+        "name": "Necromancer Aamon of the Riviera"
+    }, {
+        "id": "5615",
+        "name": "Battle Mage Rodolfo of the Riviera"
+    }, {
+        "id": "5670",
+        "name": "Archmagus Beyna of the Riviera"
+    }, {
+        "id": "5899",
+        "name": "Davos of the Riviera"
+    }, {
+        "id": "5910",
+        "name": "Enchanter Layla of the Riviera"
+    }, {
+        "id": "5940",
+        "name": "Archmagus Casper of the Riviera"
+    }, {
+        "id": "6053",
+        "name": "Lamia of the Riviera"
+    }, {
+        "id": "6140",
+        "name": "Arch-Magician Caligula of the Riviera"
+    }, {
+        "id": "6194",
+        "name": "Sage Hansel of the Riviera"
+    }, {
+        "id": "6237",
+        "name": "Archmagus Amanita of the Riviera"
+    }, {
+        "id": "6312",
+        "name": "Magus Axis of the Riviera"
+    }, {
+        "id": "6366",
+        "name": "Wild Mage Azahl of the Riviera"
+    }, {
+        "id": "6435",
+        "name": "Necromancer Asmodeus of the Riviera"
+    }, {
+        "id": "6478",
+        "name": "Sorcerer Pix of the Riviera"
+    }, {
+        "id": "6610",
+        "name": "Druid Darick of the Riviera"
+    }, {
+        "id": "6772",
+        "name": "Conjurer Hanataka of the Riviera"
+    }, {
+        "id": "6806",
+        "name": "Null Mage Eric of the Riviera"
+    }, {
+        "id": "7280",
+        "name": "Battle Mage Cromwell of the Riviera"
+    }, {
+        "id": "7351",
+        "name": "Sage Silas of the Riviera"
+    }, {
+        "id": "7375",
+        "name": "Enchanter Esme of the Riviera"
+    }, {
+        "id": "7376",
+        "name": "Alchemist  of the Riviera"
+    }, {
+        "id": "7464",
+        "name": "Lunar Mage Circe of the Riviera"
+    }, {
+        "id": "7468",
+        "name": "Enchanter Thana of the Riviera"
+    }, {
+        "id": "7481",
+        "name": "Alchemist Properpine of the Riviera"
+    }, {
+        "id": "7560",
+        "name": "Magus Qasim of the Riviera"
+    }, {
+        "id": "7592",
+        "name": "Shaman Keziah of the Riviera"
+    }, {
+        "id": "7790",
+        "name": "Battle Mage Hothor of the Riviera"
+    }, {
+        "id": "8167",
+        "name": "Magus Nolan of the Riviera"
+    }, {
+        "id": "8197",
+        "name": "Druid Bullock of the Riviera"
+    }, {
+        "id": "8259",
+        "name": "Thaumaturge Wolfram of the Riviera"
+    }, {
+        "id": "8288",
+        "name": "Battle Mage Nicolas of the Riviera"
+    }, {
+        "id": "8338",
+        "name": "Hedge Wizard Min of the Riviera"
+    }, {
+        "id": "8358",
+        "name": "Druid Tundror of the Riviera"
+    }, {
+        "id": "8391",
+        "name": "Wild Mage Beyna of the Riviera"
+    }, {
+        "id": "8545",
+        "name": "Shaman Talon of the Riviera"
+    }, {
+        "id": "8592",
+        "name": "Enchanter Calista of the Riviera"
+    }, {
+        "id": "8725",
+        "name": "Cleric Lenora of the Riviera"
+    }, {
+        "id": "8963",
+        "name": "Cosmic Mage Crowley of the Riviera"
+    }, {
+        "id": "8995",
+        "name": "Shaman Thana of the Riviera"
+    }, {
+        "id": "9128",
+        "name": "Enchanter Circe of the Riviera"
+    }, {
+        "id": "9129",
+        "name": "Electromancer Orpheus of the Riviera"
+    }, {
+        "id": "9177",
+        "name": "Archmagus Soran of the Riviera"
+    }, {
+        "id": "9226",
+        "name": "Archmagus Leah of the Riviera"
+    }, {
+        "id": "9352",
+        "name": "Diabolist Impy of the Riviera"
+    }, {
+        "id": "9450",
+        "name": "Oracle Bucky of the Riviera"
+    }, {
+        "id": "9553",
+        "name": "Druid Spore Boy of the Riviera"
+    }, {
+        "id": "9594",
+        "name": "Victoria of the Riviera"
+    }, {
+        "id": "9749",
+        "name": "Battle Mage Borak of the Riviera"
+    }, {
+        "id": "9776",
+        "name": "Hex Mage Pandora of the Riviera"
+    }],
+    "Mu": [{
+        "id": "5",
+        "name": "Runecaster Hadrien of Mu"
+    }, {
+        "id": "150",
+        "name": "Arch-Magician Alessar of Mu"
+    }, {
+        "id": "177",
+        "name": "Shaman Crowley of Mu"
+    }, {
+        "id": "231",
+        "name": "Artificer Apollo of Mu"
+    }, {
+        "id": "362",
+        "name": "Alchemist Celah of Mu"
+    }, {
+        "id": "715",
+        "name": "Evoker Kingsley of Mu"
+    }, {
+        "id": "732",
+        "name": "Shadow Mage Robert of Mu"
+    }, {
+        "id": "773",
+        "name": "Sage Eronin of Mu"
+    }, {
+        "id": "793",
+        "name": "Battlemage Lei of Mu"
+    }, {
+        "id": "808",
+        "name": "Null Mage Voidoth of Mu"
+    }, {
+        "id": "898",
+        "name": "Arcanist Artis of Mu"
+    }, {
+        "id": "944",
+        "name": "Archmagus  of Mu"
+    }, {
+        "id": "1043",
+        "name": "Archmagus Pumlo of Mu"
+    }, {
+        "id": "1136",
+        "name": "Alchemist Qaid of Mu"
+    }, {
+        "id": "1223",
+        "name": "Magus Jahid of Mu"
+    }, {
+        "id": "1379",
+        "name": "Illusionist Uday of Mu"
+    }, {
+        "id": "1400",
+        "name": "Hedge Wizard Eden of Mu"
+    }, {
+        "id": "1436",
+        "name": "Battle Mage Luther of Mu"
+    }, {
+        "id": "1441",
+        "name": "Druid Rodolfo of Mu"
+    }, {
+        "id": "1468",
+        "name": "Alchemist Argus of Mu"
+    }, {
+        "id": "1626",
+        "name": "Hedge Wizard Jiggs of Mu"
+    }, {
+        "id": "1868",
+        "name": "Sorcerer Crowley of Mu"
+    }, {
+        "id": "2105",
+        "name": "Conjurer Zelroth of Mu"
+    }, {
+        "id": "2241",
+        "name": "Battle Mage Angus of Mu"
+    }, {
+        "id": "2267",
+        "name": "Sky Master JackDaw of Mu"
+    }, {
+        "id": "2501",
+        "name": "Archmagus Merlon of Mu"
+    }, {
+        "id": "2676",
+        "name": "Archmagus George of Mu"
+    }, {
+        "id": "2694",
+        "name": "Spellsinger Winter Squash of Mu"
+    }, {
+        "id": "2702",
+        "name": "Thaumaturge George of Mu"
+    }, {
+        "id": "2746",
+        "name": "Archmagus Lux of Mu"
+    }, {
+        "id": "2827",
+        "name": "Lumos of Mu"
+    }, {
+        "id": "2865",
+        "name": "David of Mu"
+    }, {
+        "id": "3177",
+        "name": "Arcanist Alvaro of Mu"
+    }, {
+        "id": "3191",
+        "name": "Hedge Wizard Alessar of Mu"
+    }, {
+        "id": "3485",
+        "name": "Ghost Eater Artis of Mu"
+    }, {
+        "id": "3544",
+        "name": "Alchemist Azahl of Mu"
+    }, {
+        "id": "3915",
+        "name": "Spellsinger Konoha of Mu"
+    }, {
+        "id": "4448",
+        "name": "Necromancer Voidoth of Mu"
+    }, {
+        "id": "4648",
+        "name": "Archmagus Damien of Mu"
+    }, {
+        "id": "4708",
+        "name": "Spellsinger Adium of Mu"
+    }, {
+        "id": "4839",
+        "name": "Galatea of Mu"
+    }, {
+        "id": "4920",
+        "name": "Diabolist Rita of Mu"
+    }, {
+        "id": "4997",
+        "name": "Hedge Wizard Pozzik of Mu"
+    }, {
+        "id": "5207",
+        "name": "Druid Crackerjack of Mu"
+    }, {
+        "id": "5233",
+        "name": "Battle Mage Caligula of Mu"
+    }, {
+        "id": "5374",
+        "name": "Cryptomancer Atlanta of Mu"
+    }, {
+        "id": "5441",
+        "name": "Mystic Digby of Mu"
+    }, {
+        "id": "5500",
+        "name": "Void Disciple Zeromus of Mu"
+    }, {
+        "id": "5519",
+        "name": "Archmagus Ixar of Mu"
+    }, {
+        "id": "5599",
+        "name": "Magus Merlon of Mu"
+    }, {
+        "id": "5702",
+        "name": "Battlemage Burnside of Mu"
+    }, {
+        "id": "5828",
+        "name": "Artificer Imeena of Mu"
+    }, {
+        "id": "6232",
+        "name": "Battle Mage Brutus of Mu"
+    }, {
+        "id": "6335",
+        "name": "Hedge Wizard Duzzle of Mu"
+    }, {
+        "id": "6395",
+        "name": "Shadow Mage Rafiq of Mu"
+    }, {
+        "id": "6550",
+        "name": "Summoner Oxnard of Mu"
+    }, {
+        "id": "6600",
+        "name": "Pyromancer Aldus of Mu"
+    }, {
+        "id": "6724",
+        "name": "Clairvoyant Hothor of Mu"
+    }, {
+        "id": "6909",
+        "name": "Augurer Brown Cow of Mu"
+    }, {
+        "id": "7013",
+        "name": "Hedge Wizard Uvlius of Mu"
+    }, {
+        "id": "7043",
+        "name": "Mystic Jeldor of Mu"
+    }, {
+        "id": "7169",
+        "name": "Sky Master Crackerjack of Mu"
+    }, {
+        "id": "7315",
+        "name": "Sorcerer Amir of Mu"
+    }, {
+        "id": "7450",
+        "name": "Magus Bobbin of Mu"
+    }, {
+        "id": "7699",
+        "name": "Soran of Mu"
+    }, {
+        "id": "7763",
+        "name": "Geomancer Davos of Mu"
+    }, {
+        "id": "7985",
+        "name": "Augurer Devon of Mu"
+    }, {
+        "id": "8089",
+        "name": "Archmagus Jeldor of Mu"
+    }, {
+        "id": "8329",
+        "name": "Chronomancer Ramiz of Mu"
+    }, {
+        "id": "8343",
+        "name": "Archmagus Iprix of Mu"
+    }, {
+        "id": "8462",
+        "name": "Sage Zubin of Mu"
+    }, {
+        "id": "8699",
+        "name": "Necromancer Astrid of Mu"
+    }, {
+        "id": "9032",
+        "name": "Enchanter Diana of Mu"
+    }, {
+        "id": "9703",
+        "name": "Diabolist Gourdon of Mu"
+    }, {
+        "id": "9913",
+        "name": "Lumos of Mu"
+    }],
+    "Rock": [{
+        "id": "106",
+        "name": "Zubin of the Rock"
+    }, {
+        "id": "361",
+        "name": "Illusionist Gunthor of the Rock"
+    }, {
+        "id": "439",
+        "name": "Aeromancer Kobold of the Rock"
+    }, {
+        "id": "530",
+        "name": "Cryptomancer Demos of the Rock"
+    }, {
+        "id": "1108",
+        "name": "Hedge Wizard Celeste of the Rock"
+    }, {
+        "id": "1144",
+        "name": "Adept Hadrien of the Rock"
+    }, {
+        "id": "1229",
+        "name": "Sage Bartholomew of the Rock"
+    }, {
+        "id": "1534",
+        "name": "Adept Cassius of the Rock"
+    }, {
+        "id": "1557",
+        "name": "Sage Soran of the Rock"
+    }, {
+        "id": "1597",
+        "name": "Uvlius of the Rock"
+    }, {
+        "id": "1599",
+        "name": "Alchemist Purple Boy of the Rock"
+    }, {
+        "id": "1609",
+        "name": "Clairvoyant Celeste of the Rock"
+    }, {
+        "id": "1801",
+        "name": "Hedge Wizard Behemoth of the Rock"
+    }, {
+        "id": "1848",
+        "name": "Geomancer Le Blanc of the Rock"
+    }, {
+        "id": "1976",
+        "name": "Alchemist Tenguyama of the Rock"
+    }, {
+        "id": "2164",
+        "name": "Aeromancer Jianyu of the Rock"
+    }, {
+        "id": "2322",
+        "name": "Alchemist Oberon of the Rock"
+    }, {
+        "id": "2363",
+        "name": "Bard Aldo of the Rock"
+    }, {
+        "id": "2402",
+        "name": "Pyromancer Artis of the Rock"
+    }, {
+        "id": "2416",
+        "name": "Null Mage Salah of the Rock"
+    }, {
+        "id": "2433",
+        "name": "Alchemist Alizam of the Rock"
+    }, {
+        "id": "2623",
+        "name": "Sorcerer Celah of the Rock"
+    }, {
+        "id": "3024",
+        "name": "Voodoo Priest Eliphas of the Rock"
+    }, {
+        "id": "3033",
+        "name": "Geomancer Goomer of the Rock"
+    }, {
+        "id": "3061",
+        "name": "Witch Elena of the Rock"
+    }, {
+        "id": "3067",
+        "name": "Battle Mage Tundror of the Rock"
+    }, {
+        "id": "3092",
+        "name": "Archmagus Jasper of the Rock"
+    }, {
+        "id": "3267",
+        "name": "Hedge Wizard Bolin of the Rock"
+    }, {
+        "id": "3305",
+        "name": "Battle Mage Cromwell of the Rock"
+    }, {
+        "id": "3418",
+        "name": "Voodoo Priest Gallo of the Rock"
+    }, {
+        "id": "3543",
+        "name": "Charmer Mina of the Rock"
+    }, {
+        "id": "3575",
+        "name": "Soya of the Rock"
+    }, {
+        "id": "3614",
+        "name": "Sorcerer Milo of the Rock"
+    }, {
+        "id": "3633",
+        "name": "Magus Pumlo of the Rock"
+    }, {
+        "id": "3634",
+        "name": "Archmagus Lumos of the Rock"
+    }, {
+        "id": "3931",
+        "name": "Shadow Mage Chipper of the Rock"
+    }, {
+        "id": "3972",
+        "name": "Magus Daphne of the Rock"
+    }, {
+        "id": "4014",
+        "name": "Battle Mage Bartholomew of the Rock"
+    }, {
+        "id": "4051",
+        "name": "Artificer Jean Leon of the Rock"
+    }, {
+        "id": "4398",
+        "name": "Sorcerer Milo of the Rock"
+    }, {
+        "id": "4411",
+        "name": "Hedge Wizard Uvlius of the Rock"
+    }, {
+        "id": "4720",
+        "name": "Battle Mage Cassius of the Rock"
+    }, {
+        "id": "4968",
+        "name": "Sage Marius of the Rock"
+    }, {
+        "id": "5020",
+        "name": "Sage Charlord of the Rock"
+    }, {
+        "id": "5709",
+        "name": "Battle Mage Brutus of the Rock"
+    }, {
+        "id": "5833",
+        "name": "Arcanist Gil of the Rock"
+    }, {
+        "id": "5845",
+        "name": "Illusionist Hobbs of the Rock"
+    }, {
+        "id": "5875",
+        "name": "Archmagus Ofaris of the Rock"
+    }, {
+        "id": "5877",
+        "name": "Archmagus Casper of the Rock"
+    }, {
+        "id": "5996",
+        "name": "Alchemist Uday of the Rock"
+    }, {
+        "id": "6080",
+        "name": "Artificer Aleister of the Rock"
+    }, {
+        "id": "6111",
+        "name": "Archmagus Hadrien of the Rock"
+    }, {
+        "id": "6213",
+        "name": "Archmagus  of the Rock"
+    }, {
+        "id": "6296",
+        "name": "Archmagus Davos of the Rock"
+    }, {
+        "id": "6306",
+        "name": "Battle Mage Horace of the Rock"
+    }, {
+        "id": "6320",
+        "name": "Enchanter Ali of the Rock"
+    }, {
+        "id": "6503",
+        "name": "Geomancer Nixie of the Rock"
+    }, {
+        "id": "6618",
+        "name": "Archmagus Khudalf of the Rock"
+    }, {
+        "id": "6650",
+        "name": "Druid Jeldor of the Rock"
+    }, {
+        "id": "6712",
+        "name": "Druid Dante of the Rock"
+    }, {
+        "id": "6717",
+        "name": "Shaman Milo of the Rock"
+    }, {
+        "id": "6883",
+        "name": "Wild Mage Zaim of the Rock"
+    }, {
+        "id": "6896",
+        "name": "Druid Cybele of the Rock"
+    }, {
+        "id": "6994",
+        "name": "Archmagus Alex of the Rock"
+    }, {
+        "id": "7102",
+        "name": "Spellsinger Dante of the Rock"
+    }, {
+        "id": "7156",
+        "name": "Arch-Magician Casper of the Rock"
+    }, {
+        "id": "7225",
+        "name": "Alchemist Remus of the Rock"
+    }, {
+        "id": "7311",
+        "name": "Runecaster Fidget of the Rock"
+    }, {
+        "id": "7313",
+        "name": "Conjurer Quddus of the Rock"
+    }, {
+        "id": "7400",
+        "name": "Shaman Zubin of the Rock"
+    }, {
+        "id": "7417",
+        "name": "Battle Mage Danny of the Rock"
+    }, {
+        "id": "7543",
+        "name": "Archmagus Sisk of the Rock"
+    }, {
+        "id": "7575",
+        "name": "Electromancer Liu of the Rock"
+    }, {
+        "id": "7683",
+        "name": "Sage Angus of the Rock"
+    }, {
+        "id": "7751",
+        "name": "Druid Baird of the Rock"
+    }, {
+        "id": "7759",
+        "name": "Alchemist Shizu of the Rock"
+    }, {
+        "id": "7761",
+        "name": "Hedge Wizard Jerret of the Rock"
+    }, {
+        "id": "7773",
+        "name": "Mystic Hashim of the Rock"
+    }, {
+        "id": "7825",
+        "name": "Clairvoyant Celah of the Rock"
+    }, {
+        "id": "8194",
+        "name": "Archmagus Aldus of the Rock"
+    }, {
+        "id": "8252",
+        "name": "Alchemist Angus of the Rock"
+    }, {
+        "id": "8634",
+        "name": "Adept Duzzle of the Rock"
+    }, {
+        "id": "8744",
+        "name": "Geomancer Samuel of the Rock"
+    }, {
+        "id": "8748",
+        "name": "Alchemist Remus of the Rock"
+    }, {
+        "id": "9320",
+        "name": "Sorcerer Kazem of the Rock"
+    }, {
+        "id": "9632",
+        "name": "Shadow Mage Ramiz of the Rock"
+    }, {
+        "id": "9701",
+        "name": "Evoker Jahid of the Rock"
+    }],
+    "Event Horizon": [{
+        "id": "471",
+        "name": "Eden of the Event Horizon"
+    }, {
+        "id": "669",
+        "name": "Archmagus Eden of the Event Horizon"
+    }, {
+        "id": "680",
+        "name": "Arcanist Aden of the Event Horizon"
+    }, {
+        "id": "736",
+        "name": "Thaumaturge Celah of the Event Horizon"
+    }, {
+        "id": "743",
+        "name": "Necromancer Black Goat of the Event Horizon"
+    }, {
+        "id": "800",
+        "name": "Adept Beyna of the Event Horizon"
+    }, {
+        "id": "1077",
+        "name": "Enchanter Silas of the Event Horizon"
+    }, {
+        "id": "1196",
+        "name": "Archmagus Lux of the Event Horizon"
+    }, {
+        "id": "1328",
+        "name": "Medium Bathsheba of the Event Horizon"
+    }, {
+        "id": "1382",
+        "name": "Thaumaturge Alessar of the Event Horizon"
+    }, {
+        "id": "1429",
+        "name": "Mystic Nicolas of the Event Horizon"
+    }, {
+        "id": "1731",
+        "name": "Witch Sabina of the Event Horizon"
+    }, {
+        "id": "1864",
+        "name": "Runecaster Ekmira of the Event Horizon"
+    }, {
+        "id": "2285",
+        "name": "Archmagus Aleister of the Event Horizon"
+    }, {
+        "id": "2372",
+        "name": "Adept Voidoth of the Event Horizon"
+    }, {
+        "id": "2516",
+        "name": "Adept Soya of the Event Horizon"
+    }, {
+        "id": "2537",
+        "name": "Archmagus Alessar of the Event Horizon"
+    }, {
+        "id": "2724",
+        "name": "Artificer Corvin of the Event Horizon"
+    }, {
+        "id": "2900",
+        "name": "Merlon of the Event Horizon"
+    }, {
+        "id": "2934",
+        "name": "Mystic Jeldor of the Event Horizon"
+    }, {
+        "id": "2941",
+        "name": "Shaman David of the Event Horizon"
+    }, {
+        "id": "2965",
+        "name": "Sorcerer Ilyas of the Event Horizon"
+    }, {
+        "id": "3032",
+        "name": "Apollo of the Event Horizon"
+    }, {
+        "id": "3066",
+        "name": "Electromancer Flynn of the Event Horizon"
+    }, {
+        "id": "3164",
+        "name": "Archmagus Pumlo of the Event Horizon"
+    }, {
+        "id": "3235",
+        "name": "Archmagus Eizo of the Event Horizon"
+    }, {
+        "id": "3297",
+        "name": "Battle Mage Angus of the Event Horizon"
+    }, {
+        "id": "3332",
+        "name": "George of the Event Horizon"
+    }, {
+        "id": "3388",
+        "name": "Archmagus Apollo of the Event Horizon"
+    }, {
+        "id": "3412",
+        "name": "Bard Liu of the Event Horizon"
+    }, {
+        "id": "4048",
+        "name": "Bard Silas of the Event Horizon"
+    }, {
+        "id": "4611",
+        "name": "Alchemist Goober of the Event Horizon"
+    }, {
+        "id": "4785",
+        "name": "Diabolist Oliver of the Event Horizon"
+    }, {
+        "id": "5043",
+        "name": "Pyromancer Samuel of the Event Horizon"
+    }, {
+        "id": "5097",
+        "name": "Runecaster Qianfan of the Event Horizon"
+    }, {
+        "id": "5138",
+        "name": "Sorcerer Casper of the Event Horizon"
+    }, {
+        "id": "5178",
+        "name": "Witch Carmilla of the Event Horizon"
+    }, {
+        "id": "5341",
+        "name": "Alchemist David of the Event Horizon"
+    }, {
+        "id": "5586",
+        "name": "Archmagus Silas of the Event Horizon"
+    }, {
+        "id": "5641",
+        "name": "Artificer Hothor of the Event Horizon"
+    }, {
+        "id": "5683",
+        "name": "Astrid of the Event Horizon"
+    }, {
+        "id": "5727",
+        "name": "Cosmic Mage Jeldor of the Event Horizon"
+    }, {
+        "id": "5811",
+        "name": "Sorcerer Alizam of the Event Horizon"
+    }, {
+        "id": "5935",
+        "name": "Electromancer Crobas of the Event Horizon"
+    }, {
+        "id": "5942",
+        "name": "Sorcerer Zane of the Event Horizon"
+    }, {
+        "id": "6103",
+        "name": "Illusionist  of the Event Horizon"
+    }, {
+        "id": "6175",
+        "name": "Enchanter Devon of the Event Horizon"
+    }, {
+        "id": "6247",
+        "name": "Mystic Milton of the Event Horizon"
+    }, {
+        "id": "6256",
+        "name": "Hedge Wizard Simon of the Event Horizon"
+    }, {
+        "id": "6370",
+        "name": "Magus Faiz of the Event Horizon"
+    }, {
+        "id": "6442",
+        "name": "Cartomancer Jaffer of the Event Horizon"
+    }, {
+        "id": "6744",
+        "name": "Hedge Wizard Oberon of the Event Horizon"
+    }, {
+        "id": "6830",
+        "name": "Arch-Magician Shigenjo of the Event Horizon"
+    }, {
+        "id": "6837",
+        "name": "Shaman Crowley of the Event Horizon"
+    }, {
+        "id": "6992",
+        "name": "Sage Yumi of the Event Horizon"
+    }, {
+        "id": "7079",
+        "name": "Sorcerer Gogol of the Event Horizon"
+    }, {
+        "id": "7199",
+        "name": "Summoner Bolin of the Event Horizon"
+    }, {
+        "id": "7337",
+        "name": "Archmagus Hans of the Event Horizon"
+    }, {
+        "id": "7512",
+        "name": "Shaman Gwendolin of the Event Horizon"
+    }, {
+        "id": "7908",
+        "name": "Shaman Eric of the Event Horizon"
+    }, {
+        "id": "7943",
+        "name": "Hedge Wizard Goober of the Event Horizon"
+    }, {
+        "id": "8290",
+        "name": "Archmagus Uvlius of the Event Horizon"
+    }, {
+        "id": "8302",
+        "name": "Hedge Wizard Nicolas of the Event Horizon"
+    }, {
+        "id": "8368",
+        "name": "Lunar Mage Rumpleskin of the Event Horizon"
+    }, {
+        "id": "8431",
+        "name": "Summoner Finch of the Event Horizon"
+    }, {
+        "id": "8504",
+        "name": "Archmagus Allistair of the Event Horizon"
+    }, {
+        "id": "8732",
+        "name": "Cosmic Mage Seth of the Event Horizon"
+    }, {
+        "id": "8806",
+        "name": "Astrid of the Event Horizon"
+    }, {
+        "id": "8837",
+        "name": "Artificer Pino of the Event Horizon"
+    }, {
+        "id": "8917",
+        "name": "Pyromancer Eliphas of the Event Horizon"
+    }, {
+        "id": "9052",
+        "name": "Shadow Mage Voidoth of the Event Horizon"
+    }, {
+        "id": "9747",
+        "name": "Alchemist Salvatore of the Event Horizon"
+    }, {
+        "id": "9901",
+        "name": "Davos of the Event Horizon"
+    }, {
+        "id": "9968",
+        "name": "Sorcerer Merlon of the Event Horizon"
+    }],
+    "Cosmos": [{
+        "id": "23",
+        "name": "Alien Arcanist Marlo of the Cosmos"
+    }, {
+        "id": "45",
+        "name": "Runecaster Ratko of the Cosmos"
+    }, {
+        "id": "119",
+        "name": "Bard Alizam of the Cosmos"
+    }, {
+        "id": "130",
+        "name": "Archmagus Oberon of the Cosmos"
+    }, {
+        "id": "141",
+        "name": "Scryer Arabella of the Cosmos"
+    }, {
+        "id": "181",
+        "name": "Void Disciple Voidoth of the Cosmos"
+    }, {
+        "id": "263",
+        "name": "Battle Mage Axel of the Cosmos"
+    }, {
+        "id": "308",
+        "name": "Druid Alessar of the Cosmos"
+    }, {
+        "id": "375",
+        "name": "Artificer Daria of the Cosmos"
+    }, {
+        "id": "463",
+        "name": "Adept Caligula of the Cosmos"
+    }, {
+        "id": "484",
+        "name": "Battle Mage Luther of the Cosmos"
+    }, {
+        "id": "516",
+        "name": "Lumos of the Cosmos"
+    }, {
+        "id": "608",
+        "name": "Alchemist Adium of the Cosmos"
+    }, {
+        "id": "637",
+        "name": "George of the Cosmos"
+    }, {
+        "id": "655",
+        "name": "Hedge Wizard Borak of the Cosmos"
+    }, {
+        "id": "716",
+        "name": "Archmagus Aleister of the Cosmos"
+    }, {
+        "id": "742",
+        "name": "Archmagus Aden of the Cosmos"
+    }, {
+        "id": "920",
+        "name": "Void Disciple Reza of the Cosmos"
+    }, {
+        "id": "1019",
+        "name": "Charmer Thana of the Cosmos"
+    }, {
+        "id": "1041",
+        "name": "Arch-Magician Remus of the Cosmos"
+    }, {
+        "id": "1068",
+        "name": "Enchanter Diana of the Cosmos"
+    }, {
+        "id": "1114",
+        "name": "Scryer Huizhong of the Cosmos"
+    }, {
+        "id": "1129",
+        "name": "Alchemist Leah of the Cosmos"
+    }, {
+        "id": "1199",
+        "name": "Archmagus Basil of the Cosmos"
+    }, {
+        "id": "1208",
+        "name": "Thaumaturge Hagatha of the Cosmos"
+    }, {
+        "id": "1217",
+        "name": "Pyromancer Zixin of the Cosmos"
+    }, {
+        "id": "1259",
+        "name": "Spellsinger Tenguyama of the Cosmos"
+    }, {
+        "id": "1284",
+        "name": "Sorcerer Azahl of the Cosmos"
+    }, {
+        "id": "1346",
+        "name": "Battlemage Merlon of the Cosmos"
+    }, {
+        "id": "1431",
+        "name": "Electromancer David of the Cosmos"
+    }, {
+        "id": "1488",
+        "name": "Artificer Jaffer of the Cosmos"
+    }, {
+        "id": "1555",
+        "name": "Mystic Azahl of the Cosmos"
+    }, {
+        "id": "1580",
+        "name": "Necromancer Judas of the Cosmos"
+    }, {
+        "id": "1600",
+        "name": "Evoker Soya of the Cosmos"
+    }, {
+        "id": "1647",
+        "name": "Shaman Liliana of the Cosmos"
+    }, {
+        "id": "1698",
+        "name": "Enchanter Faye of the Cosmos"
+    }, {
+        "id": "1760",
+        "name": "Shadow Mage Soya of the Cosmos"
+    }, {
+        "id": "1773",
+        "name": "Druid Aleister of the Cosmos"
+    }, {
+        "id": "1860",
+        "name": "Battle Mage Nolan of the Cosmos"
+    }, {
+        "id": "1938",
+        "name": "Cleric Jabir of the Cosmos"
+    }, {
+        "id": "1958",
+        "name": "Enchanter Bathsheba of the Cosmos"
+    }, {
+        "id": "1961",
+        "name": "Arch-Magician Gully of the Cosmos"
+    }, {
+        "id": "1995",
+        "name": "Wild Mage Umber of the Cosmos"
+    }, {
+        "id": "2130",
+        "name": "Summoner Thoth of the Cosmos"
+    }, {
+        "id": "2140",
+        "name": "Archmagus George of the Cosmos"
+    }, {
+        "id": "2169",
+        "name": "Necromancer Morrow of the Cosmos"
+    }, {
+        "id": "2211",
+        "name": "Charmer Daria of the Cosmos"
+    }, {
+        "id": "2268",
+        "name": "Hedge Wizard Aleister of the Cosmos"
+    }, {
+        "id": "2388",
+        "name": "Alessar of the Cosmos"
+    }, {
+        "id": "2595",
+        "name": "Adept Voidoth of the Cosmos"
+    }, {
+        "id": "2631",
+        "name": "Diabolist Rita of the Cosmos"
+    }, {
+        "id": "2819",
+        "name": "Alchemist Argus of the Cosmos"
+    }, {
+        "id": "2841",
+        "name": "Druid Ratko of the Cosmos"
+    }, {
+        "id": "2866",
+        "name": "Archmagus Zelroth of the Cosmos"
+    }, {
+        "id": "2883",
+        "name": "Wild Mage Shanyuan of the Cosmos"
+    }, {
+        "id": "2954",
+        "name": "Druid Tengu of the Cosmos"
+    }, {
+        "id": "2994",
+        "name": "Udor of the Cosmos"
+    }, {
+        "id": "3014",
+        "name": "Alchemist Bartholomew of the Cosmos"
+    }, {
+        "id": "3146",
+        "name": "Charmer Lamia of the Cosmos"
+    }, {
+        "id": "3477",
+        "name": "Alatar of the Cosmos"
+    }, {
+        "id": "3484",
+        "name": "Sage Allistair of the Cosmos"
+    }, {
+        "id": "3486",
+        "name": "Battle Mage Magnus of the Cosmos"
+    }, {
+        "id": "3551",
+        "name": "Ghost Eater Arcus of the Cosmos"
+    }, {
+        "id": "3571",
+        "name": "Cleric Ofaris of the Cosmos"
+    }, {
+        "id": "3609",
+        "name": "Sorcerer Apollo of the Cosmos"
+    }, {
+        "id": "3623",
+        "name": "Sorcerer Jeldor of the Cosmos"
+    }, {
+        "id": "3627",
+        "name": "Magus Fire Eater of the Cosmos"
+    }, {
+        "id": "3659",
+        "name": "Magus George of the Cosmos"
+    }, {
+        "id": "3713",
+        "name": "Sorcerer Apollo of the Cosmos"
+    }, {
+        "id": "3725",
+        "name": "Magus Pino of the Cosmos"
+    }, {
+        "id": "3731",
+        "name": "Hex Mage Ivy of the Cosmos"
+    }, {
+        "id": "3752",
+        "name": "Necromancer Vossler of the Cosmos"
+    }, {
+        "id": "3769",
+        "name": "Pyromancer Thoth of the Cosmos"
+    }, {
+        "id": "3779",
+        "name": "Enchanter Atlanta of the Cosmos"
+    }, {
+        "id": "3807",
+        "name": "Alchemist Axis of the Cosmos"
+    }, {
+        "id": "3893",
+        "name": "Magus Isaac of the Cosmos"
+    }, {
+        "id": "3895",
+        "name": "Thaumaturge Anton of the Cosmos"
+    }, {
+        "id": "3965",
+        "name": "Arcanist Jeldor of the Cosmos"
+    }, {
+        "id": "3970",
+        "name": "Summoner Ofaris of the Cosmos"
+    }, {
+        "id": "4078",
+        "name": "Aeromancer Zixin of the Cosmos"
+    }, {
+        "id": "4098",
+        "name": "Hedge Wizard Peppy of the Cosmos"
+    }, {
+        "id": "4245",
+        "name": "Archmagus Alessar of the Cosmos"
+    }, {
+        "id": "4412",
+        "name": "Sorcerer Abbadon of the Cosmos"
+    }, {
+        "id": "4429",
+        "name": "Chronomancer Lei of the Cosmos"
+    }, {
+        "id": "4438",
+        "name": "Arch-Magician Arabella of the Cosmos"
+    }, {
+        "id": "4469",
+        "name": "Artificer Samael of the Cosmos"
+    }, {
+        "id": "4512",
+        "name": "Enchanter Merlon of the Cosmos"
+    }, {
+        "id": "4526",
+        "name": "Archmagus Hadrien of the Cosmos"
+    }, {
+        "id": "4582",
+        "name": "Sorcerer Jahid of the Cosmos"
+    }, {
+        "id": "4647",
+        "name": "Alchemist Behemoth of the Cosmos"
+    }, {
+        "id": "4742",
+        "name": "Adept Crackerjack of the Cosmos"
+    }, {
+        "id": "4792",
+        "name": "Necromancer Seth of the Cosmos"
+    }, {
+        "id": "4813",
+        "name": "Druid Duzzle of the Cosmos"
+    }, {
+        "id": "4830",
+        "name": "Enchanter Beyna of the Cosmos"
+    }, {
+        "id": "4947",
+        "name": "Artificer Alessar of the Cosmos"
+    }, {
+        "id": "4991",
+        "name": "Arch-Magician Iprix of the Cosmos"
+    }, {
+        "id": "5008",
+        "name": "Archmagus Isaac of the Cosmos"
+    }, {
+        "id": "5057",
+        "name": "Magus Remus of the Cosmos"
+    }, {
+        "id": "5169",
+        "name": "Archmagus Allistair of the Cosmos"
+    }, {
+        "id": "5186",
+        "name": "Alchemist Ozohr of the Cosmos"
+    }, {
+        "id": "5199",
+        "name": "Arcanist Kang of the Cosmos"
+    }, {
+        "id": "5219",
+        "name": "Archmagus Eronin of the Cosmos"
+    }, {
+        "id": "5412",
+        "name": "Archmagus Lumos of the Cosmos"
+    }, {
+        "id": "5421",
+        "name": "Battlemage Homer of the Cosmos"
+    }, {
+        "id": "5440",
+        "name": "Adept Rita of the Cosmos"
+    }, {
+        "id": "5466",
+        "name": "Magus Duzzle of the Cosmos"
+    }, {
+        "id": "5468",
+        "name": "Aeromancer Tengu of the Cosmos"
+    }, {
+        "id": "5591",
+        "name": "Archmagus Oberon of the Cosmos"
+    }, {
+        "id": "5620",
+        "name": "Arch-Magician Apollo of the Cosmos"
+    }, {
+        "id": "5765",
+        "name": "Augurer Ozohr of the Cosmos"
+    }, {
+        "id": "5793",
+        "name": "Alchemist Hagatha of the Cosmos"
+    }, {
+        "id": "5869",
+        "name": "Hex Mage Hansel of the Cosmos"
+    }, {
+        "id": "5889",
+        "name": "Witch Ivy of the Cosmos"
+    }, {
+        "id": "5915",
+        "name": "Archmagus Onaxx of the Cosmos"
+    }, {
+        "id": "6024",
+        "name": "Arcanist Elizabeth of the Cosmos"
+    }, {
+        "id": "6058",
+        "name": "Cosmic Mage JackDaw of the Cosmos"
+    }, {
+        "id": "6271",
+        "name": "Clairvoyant Woomba of the Cosmos"
+    }, {
+        "id": "6308",
+        "name": "Sorcerer Eden of the Cosmos"
+    }, {
+        "id": "6387",
+        "name": "Sorcerer Zorko of the Cosmos"
+    }, {
+        "id": "6422",
+        "name": "Chronomancer Angus of the Cosmos"
+    }, {
+        "id": "6430",
+        "name": "Summoner Axel of the Cosmos"
+    }, {
+        "id": "6433",
+        "name": "Sorcerer Jabir of the Cosmos"
+    }, {
+        "id": "6614",
+        "name": "Pyromancer Scorch of the Cosmos"
+    }, {
+        "id": "6628",
+        "name": "Sorcerer Nassif of the Cosmos"
+    }, {
+        "id": "6637",
+        "name": "Sorcerer Idris of the Cosmos"
+    }, {
+        "id": "6648",
+        "name": "Hedge Wizard Calypso of the Cosmos"
+    }, {
+        "id": "6654",
+        "name": "Necromancer Soya of the Cosmos"
+    }, {
+        "id": "6677",
+        "name": "Hedge Wizard Carly of the Cosmos"
+    }, {
+        "id": "6771",
+        "name": "Shaman Black Goat of the Cosmos"
+    }, {
+        "id": "6853",
+        "name": "Summoner Wazir of the Cosmos"
+    }, {
+        "id": "6954",
+        "name": "Alchemist  of the Cosmos"
+    }, {
+        "id": "6962",
+        "name": "Wild Mage Jiang of the Cosmos"
+    }, {
+        "id": "7050",
+        "name": "Chronomancer Rodolfo of the Cosmos"
+    }, {
+        "id": "7075",
+        "name": "Enchanter Aleister of the Cosmos"
+    }, {
+        "id": "7124",
+        "name": "Fortune Teller Lamia of the Cosmos"
+    }, {
+        "id": "7191",
+        "name": "Aleister of the Cosmos"
+    }, {
+        "id": "7235",
+        "name": "Battle Mage Ulysse of the Cosmos"
+    }, {
+        "id": "7271",
+        "name": "Augurer Merlon of the Cosmos"
+    }, {
+        "id": "7292",
+        "name": "Artificer Lumos of the Cosmos"
+    }, {
+        "id": "7309",
+        "name": "Adept Aldo of the Cosmos"
+    }, {
+        "id": "7346",
+        "name": "Battle Mage Homer of the Cosmos"
+    }, {
+        "id": "7371",
+        "name": "Wild Mage Nick of the Cosmos"
+    }, {
+        "id": "7431",
+        "name": "Magus Milo of the Cosmos"
+    }, {
+        "id": "7454",
+        "name": "Archmagus Celah of the Cosmos"
+    }, {
+        "id": "7671",
+        "name": "Shaman Pezo of the Cosmos"
+    }, {
+        "id": "7695",
+        "name": "Archmagus Eden of the Cosmos"
+    }, {
+        "id": "7717",
+        "name": "Alchemist Cromwell of the Cosmos"
+    }, {
+        "id": "7725",
+        "name": "Cleric Bayard of the Cosmos"
+    }, {
+        "id": "7805",
+        "name": "Archmagus Yookoo of the Cosmos"
+    }, {
+        "id": "7812",
+        "name": "Chaos Mage Daria of the Cosmos"
+    }, {
+        "id": "7852",
+        "name": "Illusionist Bao of the Cosmos"
+    }, {
+        "id": "7970",
+        "name": "Shadow Mage Ramiz of the Cosmos"
+    }, {
+        "id": "8072",
+        "name": "Druid Hansel of the Cosmos"
+    }, {
+        "id": "8146",
+        "name": "Sorcerer Cairon of the Cosmos"
+    }, {
+        "id": "8213",
+        "name": "Alchemist Bayard of the Cosmos"
+    }, {
+        "id": "8272",
+        "name": "Enchanter Lamia of the Cosmos"
+    }, {
+        "id": "8294",
+        "name": "Witch Ekmira of the Cosmos"
+    }, {
+        "id": "8297",
+        "name": "Battle Mage Eric of the Cosmos"
+    }, {
+        "id": "8318",
+        "name": "Druid Alessar of the Cosmos"
+    }, {
+        "id": "8366",
+        "name": "Artificer Iprix of the Cosmos"
+    }, {
+        "id": "8535",
+        "name": "Artificer Mace of the Cosmos"
+    }, {
+        "id": "8572",
+        "name": "Archmagus Alessar of the Cosmos"
+    }, {
+        "id": "8621",
+        "name": "Sorcerer Angus of the Cosmos"
+    }, {
+        "id": "8747",
+        "name": "Alchemist Chanterelle of the Cosmos"
+    }, {
+        "id": "8771",
+        "name": "Voodoo Priest Baptiste of the Cosmos"
+    }, {
+        "id": "8826",
+        "name": "Druid Hishoken of the Cosmos"
+    }, {
+        "id": "8849",
+        "name": "Arcanist Zane of the Cosmos"
+    }, {
+        "id": "8895",
+        "name": "Scryer Ilu of the Cosmos"
+    }, {
+        "id": "8936",
+        "name": "Adept Casper of the Cosmos"
+    }, {
+        "id": "8969",
+        "name": "Battle Mage Nicolas of the Cosmos"
+    }, {
+        "id": "8992",
+        "name": "Enchanter Amir of the Cosmos"
+    }, {
+        "id": "9003",
+        "name": "Charmer Willow of the Cosmos"
+    }, {
+        "id": "9045",
+        "name": "Cosmic Mage Ofaris of the Cosmos"
+    }, {
+        "id": "9061",
+        "name": "Arcanist Sabina of the Cosmos"
+    }, {
+        "id": "9169",
+        "name": "Archmagus Casper of the Cosmos"
+    }, {
+        "id": "9211",
+        "name": "Summoner Oxnard of the Cosmos"
+    }, {
+        "id": "9217",
+        "name": "Ghost Eater Flamos of the Cosmos"
+    }, {
+        "id": "9284",
+        "name": "Runecaster Bayard of the Cosmos"
+    }, {
+        "id": "9339",
+        "name": "Remus of the Cosmos"
+    }, {
+        "id": "9353",
+        "name": "Druid Bao of the Cosmos"
+    }, {
+        "id": "9361",
+        "name": "Battlemage Konoha of the Cosmos"
+    }, {
+        "id": "9418",
+        "name": "Witch Imeena of the Cosmos"
+    }, {
+        "id": "9555",
+        "name": "Chronomancer Eden of the Cosmos"
+    }, {
+        "id": "9669",
+        "name": "Thaumaturge Orlando of the Cosmos"
+    }, {
+        "id": "9746",
+        "name": "Arcanist Nadeem of the Cosmos"
+    }, {
+        "id": "9846",
+        "name": "Medium Apollo of the Cosmos"
+    }, {
+        "id": "9922",
+        "name": "Alchemist Goomer of the Cosmos"
+    }, {
+        "id": "9933",
+        "name": "Archmagus Aleister of the Cosmos"
+    }],
+    "Havens": [{
+        "id": "114",
+        "name": "Sage Eden of the Havens"
+    }, {
+        "id": "121",
+        "name": "Sorcerer Zafar of the Havens"
+    }, {
+        "id": "223",
+        "name": "Thaumaturge George of the Havens"
+    }, {
+        "id": "245",
+        "name": "Archmagus Alessar of the Havens"
+    }, {
+        "id": "255",
+        "name": "Hedge Wizard Poppy of the Havens"
+    }, {
+        "id": "280",
+        "name": "Sorcerer Udor of the Havens"
+    }, {
+        "id": "325",
+        "name": "Druid Anton of the Havens"
+    }, {
+        "id": "347",
+        "name": "Magus Pumlo of the Havens"
+    }, {
+        "id": "389",
+        "name": "Lumos of the Havens"
+    }, {
+        "id": "475",
+        "name": "Archmagus Alatar of the Havens"
+    }, {
+        "id": "481",
+        "name": "Arcanist Lumos of the Havens"
+    }, {
+        "id": "522",
+        "name": "Archmagus Solomon of the Havens"
+    }, {
+        "id": "596",
+        "name": "Lux of the Havens"
+    }, {
+        "id": "634",
+        "name": "Arch-Magician Patch of the Havens"
+    }, {
+        "id": "653",
+        "name": "Hedge Wizard Kalo of the Havens"
+    }, {
+        "id": "801",
+        "name": "Zane of the Havens"
+    }, {
+        "id": "836",
+        "name": "Sage Dante of the Havens"
+    }, {
+        "id": "842",
+        "name": "Archmagus Alessar of the Havens"
+    }, {
+        "id": "919",
+        "name": "Battle Mage Rodolfo of the Havens"
+    }, {
+        "id": "932",
+        "name": "Shaman Purple Boy of the Havens"
+    }, {
+        "id": "993",
+        "name": "Magus Zelroth of the Havens"
+    }, {
+        "id": "1014",
+        "name": "Battle Mage Ratko of the Havens"
+    }, {
+        "id": "1036",
+        "name": "Artificer Chiron of the Havens"
+    }, {
+        "id": "1061",
+        "name": "Ghost Eater Fire Eater of the Havens"
+    }, {
+        "id": "1109",
+        "name": "Soya of the Havens"
+    }, {
+        "id": "1198",
+        "name": "Battle Mage Ulysse of the Havens"
+    }, {
+        "id": "1233",
+        "name": "Battlemage Burnside of the Havens"
+    }, {
+        "id": "1240",
+        "name": "Mystic Ambrosia of the Havens"
+    }, {
+        "id": "1397",
+        "name": "Hedge Wizard Cromwell of the Havens"
+    }, {
+        "id": "1410",
+        "name": "Hydromancer Jaffer of the Havens"
+    }, {
+        "id": "1492",
+        "name": "Sorcerer Merlon of the Havens"
+    }, {
+        "id": "1533",
+        "name": "Aleister of the Havens"
+    }, {
+        "id": "1536",
+        "name": "Archmagus Ofaris of the Havens"
+    }, {
+        "id": "1568",
+        "name": "Sorcerer Eizo of the Havens"
+    }, {
+        "id": "1578",
+        "name": "Battle Mage Sturgis of the Havens"
+    }, {
+        "id": "1681",
+        "name": "Archmagus Zubin of the Havens"
+    }, {
+        "id": "1692",
+        "name": "Archmagus Uday of the Havens"
+    }, {
+        "id": "1710",
+        "name": "Shaman Hellspawn of the Havens"
+    }, {
+        "id": "1807",
+        "name": "Sorcerer Bartholomew of the Havens"
+    }, {
+        "id": "1819",
+        "name": "Archmagus Basil of the Havens"
+    }, {
+        "id": "2004",
+        "name": "Artificer Corky of the Havens"
+    }, {
+        "id": "2058",
+        "name": "Sorcerer Faiz of the Havens"
+    }, {
+        "id": "2113",
+        "name": "Archmagus Raul of the Havens"
+    }, {
+        "id": "2152",
+        "name": "Holy Magus Iluzor of the Havens"
+    }, {
+        "id": "2187",
+        "name": "Witch Ivy of the Havens"
+    }, {
+        "id": "2239",
+        "name": "Hedge Wizard Eden of the Havens"
+    }, {
+        "id": "2389",
+        "name": "Druid Azahl of the Havens"
+    }, {
+        "id": "2444",
+        "name": "Shadow Mage Ratko of the Havens"
+    }, {
+        "id": "2483",
+        "name": "Mystic Jerret of the Havens"
+    }, {
+        "id": "2505",
+        "name": "Hex Mage Borak of the Havens"
+    }, {
+        "id": "2682",
+        "name": "Ghost Eater Impy of the Havens"
+    }, {
+        "id": "2979",
+        "name": "Archmagus George of the Havens"
+    }, {
+        "id": "3015",
+        "name": "Arch-Magician Angus of the Havens"
+    }, {
+        "id": "3173",
+        "name": "Scryer Rocco of the Havens"
+    }, {
+        "id": "3200",
+        "name": "Shadow Mage Izible of the Havens"
+    }, {
+        "id": "3206",
+        "name": "Summoner Milo of the Havens"
+    }, {
+        "id": "3217",
+        "name": "Sage Finn of the Havens"
+    }, {
+        "id": "3234",
+        "name": "Archmagus Milo of the Havens"
+    }, {
+        "id": "3262",
+        "name": "Sky Master Rook of the Havens"
+    }, {
+        "id": "3277",
+        "name": "Archmagus Davos of the Havens"
+    }, {
+        "id": "3284",
+        "name": "Stellar Mage Bolin of the Havens"
+    }, {
+        "id": "3311",
+        "name": "Magus Alessar of the Havens"
+    }, {
+        "id": "3366",
+        "name": "Battlemage Eden of the Havens"
+    }, {
+        "id": "3473",
+        "name": "Alchemist Larissa of the Havens"
+    }, {
+        "id": "3523",
+        "name": "Enchanter Faye of the Havens"
+    }, {
+        "id": "3590",
+        "name": "Shadow Mage Goliath of the Havens"
+    }, {
+        "id": "3638",
+        "name": "Sorcerer Lumos of the Havens"
+    }, {
+        "id": "3654",
+        "name": "Sage Aleister of the Havens"
+    }, {
+        "id": "3671",
+        "name": "Arcanist Remus of the Havens"
+    }, {
+        "id": "3784",
+        "name": "Druid Solomon of the Havens"
+    }, {
+        "id": "3904",
+        "name": "Archmagus Soya of the Havens"
+    }, {
+        "id": "3911",
+        "name": "Hedge Wizard Goliath of the Havens"
+    }, {
+        "id": "4059",
+        "name": "Chronomancer George of the Havens"
+    }, {
+        "id": "4102",
+        "name": "Archmagus George of the Havens"
+    }, {
+        "id": "4196",
+        "name": "Battlemage Zelda of the Havens"
+    }, {
+        "id": "4325",
+        "name": "Necromancer Malcom of the Havens"
+    }, {
+        "id": "4359",
+        "name": "Archmagus Pumlo of the Havens"
+    }, {
+        "id": "4442",
+        "name": "Illusionist Astrid of the Havens"
+    }, {
+        "id": "4667",
+        "name": "Enchanter Alatar of the Havens"
+    }, {
+        "id": "4734",
+        "name": "Magus Danny of the Havens"
+    }, {
+        "id": "4739",
+        "name": "Sorcerer Azahl of the Havens"
+    }, {
+        "id": "4773",
+        "name": "Archmagus Molek of the Havens"
+    }, {
+        "id": "4847",
+        "name": "Arch-Magician Hongo of the Havens"
+    }, {
+        "id": "4866",
+        "name": "Sorcerer Aleister of the Havens"
+    }, {
+        "id": "4870",
+        "name": "Sage Nikolas of the Havens"
+    }, {
+        "id": "4901",
+        "name": "Vampyre Damien of the Havens"
+    }, {
+        "id": "5031",
+        "name": "Magus Alatar of the Havens"
+    }, {
+        "id": "5053",
+        "name": "Magus Aldus of the Havens"
+    }, {
+        "id": "5063",
+        "name": "Hedge Wizard Shivra of the Havens"
+    }, {
+        "id": "5067",
+        "name": "Electromancer Milo of the Havens"
+    }, {
+        "id": "5156",
+        "name": "Void Disciple Malcom of the Havens"
+    }, {
+        "id": "5216",
+        "name": "Runecaster Bathsheba of the Havens"
+    }, {
+        "id": "5281",
+        "name": "Sage Dante of the Havens"
+    }, {
+        "id": "5356",
+        "name": "Sorcerer Nazim of the Havens"
+    }, {
+        "id": "5397",
+        "name": "Arcanist  of the Havens"
+    }, {
+        "id": "5610",
+        "name": "Archmagus Eden of the Havens"
+    }, {
+        "id": "5663",
+        "name": "Transmuter Onaxx of the Havens"
+    }, {
+        "id": "5941",
+        "name": "Aeromancer Hu of the Havens"
+    }, {
+        "id": "6043",
+        "name": "Druid Khudalf of the Havens"
+    }, {
+        "id": "6079",
+        "name": "Necromancer Seth of the Havens"
+    }, {
+        "id": "6207",
+        "name": "Sorcerer Udor of the Havens"
+    }, {
+        "id": "6218",
+        "name": "Battle Mage Nicolas of the Havens"
+    }, {
+        "id": "6272",
+        "name": "Shadow Mage Aleister of the Havens"
+    }, {
+        "id": "6300",
+        "name": "David of the Havens"
+    }, {
+        "id": "6476",
+        "name": "Medium Malthus of the Havens"
+    }, {
+        "id": "6651",
+        "name": "Thaumaturge Apollo of the Havens"
+    }, {
+        "id": "6846",
+        "name": "Alchemist Merlon of the Havens"
+    }, {
+        "id": "6929",
+        "name": "Artificer Axel of the Havens"
+    }, {
+        "id": "6940",
+        "name": "Arch-Magician Davos of the Havens"
+    }, {
+        "id": "6961",
+        "name": "Transmuter Soran of the Havens"
+    }, {
+        "id": "6971",
+        "name": "Sorcerer Alessar of the Havens"
+    }, {
+        "id": "7106",
+        "name": "Runecaster Amir of the Havens"
+    }, {
+        "id": "7154",
+        "name": "Evoker Kazem of the Havens"
+    }, {
+        "id": "7319",
+        "name": "Illusionist Cairon of the Havens"
+    }, {
+        "id": "7415",
+        "name": "Druid Fark of the Havens"
+    }, {
+        "id": "7485",
+        "name": "Archmagus Diabolos of the Havens"
+    }, {
+        "id": "7732",
+        "name": "Davos of the Havens"
+    }, {
+        "id": "7951",
+        "name": "Adept Solomon of the Havens"
+    }, {
+        "id": "8083",
+        "name": "Druid Angus of the Havens"
+    }, {
+        "id": "8086",
+        "name": "Archmagus Soya of the Havens"
+    }, {
+        "id": "8188",
+        "name": "Voodoo Priest Marius of the Havens"
+    }, {
+        "id": "8402",
+        "name": "Artificer Nadeem of the Havens"
+    }, {
+        "id": "8406",
+        "name": "Hydromancer Kamil of the Havens"
+    }, {
+        "id": "8417",
+        "name": "Druid Dutorn of the Havens"
+    }, {
+        "id": "8471",
+        "name": "Enchanter Calliope of the Havens"
+    }, {
+        "id": "8491",
+        "name": "Sorcerer Hashim of the Havens"
+    }, {
+        "id": "8570",
+        "name": "Artificer Pino of the Havens"
+    }, {
+        "id": "8585",
+        "name": "Sorcerer Orpheus of the Havens"
+    }, {
+        "id": "8641",
+        "name": "Evoker Davos of the Havens"
+    }, {
+        "id": "8661",
+        "name": "Archmagus Alatar of the Havens"
+    }, {
+        "id": "8720",
+        "name": "Hedge Wizard Ofaris of the Havens"
+    }, {
+        "id": "8787",
+        "name": "Electromancer Ixar of the Havens"
+    }, {
+        "id": "8910",
+        "name": "Spellsinger Hagar of the Havens"
+    }, {
+        "id": "9050",
+        "name": "Chronomancer Froggy of the Havens"
+    }, {
+        "id": "9073",
+        "name": "Cosmic Mage Magnus of the Havens"
+    }, {
+        "id": "9085",
+        "name": "Archmagus Argus of the Havens"
+    }, {
+        "id": "9115",
+        "name": "Magus Iprix of the Havens"
+    }, {
+        "id": "9224",
+        "name": "Aeromancer Rook of the Havens"
+    }, {
+        "id": "9227",
+        "name": "Necromancer Aamon of the Havens"
+    }, {
+        "id": "9263",
+        "name": "Sorcerer Soran of the Havens"
+    }, {
+        "id": "9279",
+        "name": "Artificer Bucky of the Havens"
+    }, {
+        "id": "9344",
+        "name": "Sorcerer Jerret of the Havens"
+    }, {
+        "id": "9346",
+        "name": "Battle Mage Robert of the Havens"
+    }, {
+        "id": "9350",
+        "name": "Alchemist Katherine of the Havens"
+    }, {
+        "id": "9392",
+        "name": "Thaumaturge Zaros of the Havens"
+    }, {
+        "id": "9425",
+        "name": "Archmagus Aleister of the Havens"
+    }, {
+        "id": "9560",
+        "name": "Sorcerer Azahl of the Havens"
+    }, {
+        "id": "9601",
+        "name": "Archmagus Aleister of the Havens"
+    }, {
+        "id": "9630",
+        "name": "Battle Mage Armstrong of the Havens"
+    }, {
+        "id": "9655",
+        "name": "Hedge Wizard Salah of the Havens"
+    }, {
+        "id": "9657",
+        "name": "Alchemist  of the Havens"
+    }, {
+        "id": "9660",
+        "name": "Battle Mage Hothor of the Havens"
+    }, {
+        "id": "9665",
+        "name": "Archmagus David of the Havens"
+    }, {
+        "id": "9724",
+        "name": "Electromancer Optimus of the Havens"
+    }, {
+        "id": "9817",
+        "name": "Shaman George of the Havens"
+    }, {
+        "id": "9869",
+        "name": "Archmagus Gellert of the Havens"
+    }, {
+        "id": "9975",
+        "name": "Conjurer Dante of the Havens"
+    }],
+    "Grotto": [{
+        "id": "126",
+        "name": "Arch-Magician Asphodel of the Grotto"
+    }, {
+        "id": "191",
+        "name": "Hedge Wizard Suki of the Grotto"
+    }, {
+        "id": "217",
+        "name": "Enchanter Asphodel of the Grotto"
+    }, {
+        "id": "219",
+        "name": "Holy Magus Illuminus of the Grotto"
+    }, {
+        "id": "257",
+        "name": "Witch Lenora of the Grotto"
+    }, {
+        "id": "273",
+        "name": "Druid Quddus of the Grotto"
+    }, {
+        "id": "288",
+        "name": "Artificer Daria of the Grotto"
+    }, {
+        "id": "323",
+        "name": "Alchemist Shivra of the Grotto"
+    }, {
+        "id": "573",
+        "name": "Magus Bathsheba of the Grotto"
+    }, {
+        "id": "591",
+        "name": "Enchanter Layla of the Grotto"
+    }, {
+        "id": "673",
+        "name": "Sorcerer Salah of the Grotto"
+    }, {
+        "id": "821",
+        "name": "Arch-Magician Sonja of the Grotto"
+    }, {
+        "id": "969",
+        "name": "Charmer Arabella of the Grotto"
+    }, {
+        "id": "999",
+        "name": "Enchanter Lamia of the Grotto"
+    }, {
+        "id": "1025",
+        "name": "Hydromancer Homer of the Grotto"
+    }, {
+        "id": "1037",
+        "name": "Spellsinger Lamia of the Grotto"
+    }, {
+        "id": "1099",
+        "name": "Udor of the Grotto"
+    }, {
+        "id": "1100",
+        "name": "Archmagus Soya of the Grotto"
+    }, {
+        "id": "1182",
+        "name": "Battle Mage Eric of the Grotto"
+    }, {
+        "id": "1190",
+        "name": "Archmagus Lux of the Grotto"
+    }, {
+        "id": "1224",
+        "name": "Druid Maia of the Grotto"
+    }, {
+        "id": "1241",
+        "name": "Hedge Wizard Cairon of the Grotto"
+    }, {
+        "id": "1351",
+        "name": "Alchemist Flynn of the Grotto"
+    }, {
+        "id": "1427",
+        "name": "Witch Rita of the Grotto"
+    }, {
+        "id": "1547",
+        "name": "Runecaster Hansel of the Grotto"
+    }, {
+        "id": "1612",
+        "name": "Clairvoyant Mina of the Grotto"
+    }, {
+        "id": "1638",
+        "name": "Charmer Bathsheba of the Grotto"
+    }, {
+        "id": "1663",
+        "name": "Witch Liliana of the Grotto"
+    }, {
+        "id": "1679",
+        "name": "Shaman Corky of the Grotto"
+    }, {
+        "id": "1742",
+        "name": "Druid Soya of the Grotto"
+    }, {
+        "id": "1761",
+        "name": "Evoker Nemo of the Grotto"
+    }, {
+        "id": "1769",
+        "name": "Druid Axis of the Grotto"
+    }, {
+        "id": "1835",
+        "name": "Archmagus Robert of the Grotto"
+    }, {
+        "id": "1845",
+        "name": "Archmagus Jeldor of the Grotto"
+    }, {
+        "id": "1861",
+        "name": "Geomancer Axis of the Grotto"
+    }, {
+        "id": "1862",
+        "name": "Daria of the Grotto"
+    }, {
+        "id": "1965",
+        "name": "Enchanter Bathsheba of the Grotto"
+    }, {
+        "id": "2012",
+        "name": "Magus Aden of the Grotto"
+    }, {
+        "id": "2099",
+        "name": "Layla of the Grotto"
+    }, {
+        "id": "2170",
+        "name": "Magus Carmilla of the Grotto"
+    }, {
+        "id": "2299",
+        "name": "Magus Atlanta of the Grotto"
+    }, {
+        "id": "2464",
+        "name": "Arcanist Asphodel of the Grotto"
+    }, {
+        "id": "2511",
+        "name": "Arch-Magician Cromwell of the Grotto"
+    }, {
+        "id": "2594",
+        "name": "Druid Aiko of the Grotto"
+    }, {
+        "id": "2615",
+        "name": "Hydromancer Aslan of the Grotto"
+    }, {
+        "id": "2630",
+        "name": "Chronomancer Impy of the Grotto"
+    }, {
+        "id": "2782",
+        "name": "Cleric Gunthor of the Grotto"
+    }, {
+        "id": "2828",
+        "name": "Hadrien of the Grotto"
+    }, {
+        "id": "2944",
+        "name": "Shaman Nicolas of the Grotto"
+    }, {
+        "id": "2972",
+        "name": "Charmer Artis of the Grotto"
+    }, {
+        "id": "3030",
+        "name": "Battle Mage Brutus of the Grotto"
+    }, {
+        "id": "3037",
+        "name": "Enchanter Larissa of the Grotto"
+    }, {
+        "id": "3064",
+        "name": "Shadow Mage Lilith of the Grotto"
+    }, {
+        "id": "3085",
+        "name": "Arcanist Cybele of the Grotto"
+    }, {
+        "id": "3116",
+        "name": "Druid Bullock of the Grotto"
+    }, {
+        "id": "3126",
+        "name": "Charmer Sondra of the Grotto"
+    }, {
+        "id": "3204",
+        "name": "Shadow Mage Marceline of the Grotto"
+    }, {
+        "id": "3263",
+        "name": "Arcanist Alizam of the Grotto"
+    }, {
+        "id": "3279",
+        "name": "Battle Mage Tundror of the Grotto"
+    }, {
+        "id": "3353",
+        "name": "Archmagus Ixar of the Grotto"
+    }, {
+        "id": "3438",
+        "name": "Arcanist Brutus of the Grotto"
+    }, {
+        "id": "3448",
+        "name": "Druid Fugh of the Grotto"
+    }, {
+        "id": "3450",
+        "name": "Illusionist Marceline of the Grotto"
+    }, {
+        "id": "3513",
+        "name": "Mystic Lin of the Grotto"
+    }, {
+        "id": "3557",
+        "name": "Hedge Wizard Darby of the Grotto"
+    }, {
+        "id": "3665",
+        "name": "Celah of the Grotto"
+    }, {
+        "id": "3776",
+        "name": "Enchanter Devon of the Grotto"
+    }, {
+        "id": "3798",
+        "name": "Battle Mage Talon of the Grotto"
+    }, {
+        "id": "3814",
+        "name": "Battle Mage Cassius of the Grotto"
+    }, {
+        "id": "3823",
+        "name": "Hedge Wizard Leah of the Grotto"
+    }, {
+        "id": "3848",
+        "name": "Calliope of the Grotto"
+    }, {
+        "id": "3952",
+        "name": "Druid Jahid of the Grotto"
+    }, {
+        "id": "3992",
+        "name": "Arcanist Salty of the Grotto"
+    }, {
+        "id": "4137",
+        "name": "Archmagus Cairon of the Grotto"
+    }, {
+        "id": "4157",
+        "name": "Magus Shizu of the Grotto"
+    }, {
+        "id": "4246",
+        "name": "Electromancer Atlanta of the Grotto"
+    }, {
+        "id": "4275",
+        "name": "Sage Astrid of the Grotto"
+    }, {
+        "id": "4299",
+        "name": "Katherine of the Grotto"
+    }, {
+        "id": "4385",
+        "name": "Sorcerer Eden of the Grotto"
+    }, {
+        "id": "4584",
+        "name": "Artificer Twitch of the Grotto"
+    }, {
+        "id": "4596",
+        "name": "Archmagus Aleister of the Grotto"
+    }, {
+        "id": "4651",
+        "name": "Necromancer Calista of the Grotto"
+    }, {
+        "id": "4736",
+        "name": "Witch Ivy of the Grotto"
+    }, {
+        "id": "4737",
+        "name": "Artificer Chipper of the Grotto"
+    }, {
+        "id": "4829",
+        "name": "Solomon of the Grotto"
+    }, {
+        "id": "4836",
+        "name": "Archmagus Jerret of the Grotto"
+    }, {
+        "id": "4838",
+        "name": "Ghost Eater Asphodel of the Grotto"
+    }, {
+        "id": "4896",
+        "name": "Battle Mage Darick of the Grotto"
+    }, {
+        "id": "4913",
+        "name": "Charmer Daria of the Grotto"
+    }, {
+        "id": "4931",
+        "name": "Alchemist Alizam of the Grotto"
+    }, {
+        "id": "5047",
+        "name": "Archmagus Larissa of the Grotto"
+    }, {
+        "id": "5066",
+        "name": "Sage Keziah of the Grotto"
+    }, {
+        "id": "5085",
+        "name": "Battle Mage Samuel of the Grotto"
+    }, {
+        "id": "5096",
+        "name": "Charmer Larissa of the Grotto"
+    }, {
+        "id": "5123",
+        "name": "Artificer Fallow of the Grotto"
+    }, {
+        "id": "5300",
+        "name": "Crowley of the Grotto"
+    }, {
+        "id": "5447",
+        "name": "Enchanter Victoria of the Grotto"
+    }, {
+        "id": "5509",
+        "name": "Conjurer Cybele of the Grotto"
+    }, {
+        "id": "5529",
+        "name": "Adept Dante of the Grotto"
+    }, {
+        "id": "5552",
+        "name": "Isaac of the Grotto"
+    }, {
+        "id": "5695",
+        "name": "Archmagus Aleister of the Grotto"
+    }, {
+        "id": "5723",
+        "name": "Archmagus Duzzle of the Grotto"
+    }, {
+        "id": "5750",
+        "name": "Circe of the Grotto"
+    }, {
+        "id": "5761",
+        "name": "Archmagus Iprix of the Grotto"
+    }, {
+        "id": "5791",
+        "name": "Artificer Ariadne of the Grotto"
+    }, {
+        "id": "5812",
+        "name": "Runecaster Hagar of the Grotto"
+    }, {
+        "id": "5835",
+        "name": "Alchemist Chiyo of the Grotto"
+    }, {
+        "id": "5847",
+        "name": "Archmagus Salvatore of the Grotto"
+    }, {
+        "id": "5894",
+        "name": "Adept Robert of the Grotto"
+    }, {
+        "id": "5921",
+        "name": "Enchanter Beyna of the Grotto"
+    }, {
+        "id": "5924",
+        "name": "Shaman Ulysse of the Grotto"
+    }, {
+        "id": "6023",
+        "name": "Adept Rowena of the Grotto"
+    }, {
+        "id": "6082",
+        "name": "Magus Gorgana of the Grotto"
+    }, {
+        "id": "6138",
+        "name": "Hydromancer Reza of the Grotto"
+    }, {
+        "id": "6147",
+        "name": "Necromancer Rowena of the Grotto"
+    }, {
+        "id": "6179",
+        "name": "Sorcerer Crowley of the Grotto"
+    }, {
+        "id": "6431",
+        "name": "Witch Lilith of the Grotto"
+    }, {
+        "id": "6453",
+        "name": "Oberon of the Grotto"
+    }, {
+        "id": "6468",
+        "name": "Apollo of the Grotto"
+    }, {
+        "id": "6486",
+        "name": "Summoner Goliath of the Grotto"
+    }, {
+        "id": "6524",
+        "name": "Archmagus Isaac of the Grotto"
+    }, {
+        "id": "6681",
+        "name": "Arcanist Misumi of the Grotto"
+    }, {
+        "id": "6733",
+        "name": "Runecaster Fugh of the Grotto"
+    }, {
+        "id": "6804",
+        "name": "Archmagus Lumos of the Grotto"
+    }, {
+        "id": "6972",
+        "name": "Diabolist Chiyo of the Grotto"
+    }, {
+        "id": "7056",
+        "name": "Battle Mage Finn of the Grotto"
+    }, {
+        "id": "7074",
+        "name": "Enchanter Daria of the Grotto"
+    }, {
+        "id": "7081",
+        "name": "Witch Rita of the Grotto"
+    }, {
+        "id": "7165",
+        "name": "Magus Malthus of the Grotto"
+    }, {
+        "id": "7259",
+        "name": "Larissa of the Grotto"
+    }, {
+        "id": "7278",
+        "name": "Archmagus Larissa of the Grotto"
+    }, {
+        "id": "7284",
+        "name": "Adept Shukri of the Grotto"
+    }, {
+        "id": "7479",
+        "name": "Artificer Hagar of the Grotto"
+    }, {
+        "id": "7508",
+        "name": "Evoker Carmilla of the Grotto"
+    }, {
+        "id": "7519",
+        "name": "Pyromancer Godfrey of the Grotto"
+    }, {
+        "id": "7579",
+        "name": "Lunar Mage Cassius of the Grotto"
+    }, {
+        "id": "7634",
+        "name": "Witch Ivy of the Grotto"
+    }, {
+        "id": "7638",
+        "name": "Arcanist Talon of the Grotto"
+    }, {
+        "id": "7696",
+        "name": "Oracle Cromwell of the Grotto"
+    }, {
+        "id": "7729",
+        "name": "Runecaster Voidoth of the Grotto"
+    }, {
+        "id": "7749",
+        "name": "Enchanter Circe of the Grotto"
+    }, {
+        "id": "7856",
+        "name": "Hedge Wizard Jeldor of the Grotto"
+    }, {
+        "id": "7904",
+        "name": "Hedge Wizard Galatea of the Grotto"
+    }, {
+        "id": "7906",
+        "name": "Enchanter Iris of the Grotto"
+    }, {
+        "id": "8114",
+        "name": "Archmagus Jerret of the Grotto"
+    }, {
+        "id": "8300",
+        "name": "Sage Eden of the Grotto"
+    }, {
+        "id": "8311",
+        "name": "Adept Aldus of the Grotto"
+    }, {
+        "id": "8339",
+        "name": "Magus Tumbaj of the Grotto"
+    }, {
+        "id": "8378",
+        "name": "Cleric Udor of the Grotto"
+    }, {
+        "id": "8411",
+        "name": "Adept Katherine of the Grotto"
+    }, {
+        "id": "8487",
+        "name": "Cleric Sylvia of the Grotto"
+    }, {
+        "id": "8565",
+        "name": "Artificer Carly of the Grotto"
+    }, {
+        "id": "8623",
+        "name": "Alchemist Finn of the Grotto"
+    }, {
+        "id": "8639",
+        "name": "Enchanter Carly of the Grotto"
+    }, {
+        "id": "8706",
+        "name": "Electromancer Zhan of the Grotto"
+    }, {
+        "id": "8741",
+        "name": "Illusionist Iris of the Grotto"
+    }, {
+        "id": "8828",
+        "name": "Arcanist Durm of the Grotto"
+    }, {
+        "id": "8949",
+        "name": "Enchanter Thana of the Grotto"
+    }, {
+        "id": "8972",
+        "name": "Battle Mage Cromwell of the Grotto"
+    }, {
+        "id": "8980",
+        "name": "Witch Zelda of the Grotto"
+    }, {
+        "id": "8994",
+        "name": "Adept Circe of the Grotto"
+    }, {
+        "id": "9007",
+        "name": "Battle Mage Malthus of the Grotto"
+    }, {
+        "id": "9038",
+        "name": "Magus Azar of the Grotto"
+    }, {
+        "id": "9049",
+        "name": "Sage Brutus of the Grotto"
+    }, {
+        "id": "9086",
+        "name": "Battle Mage Thor of the Grotto"
+    }, {
+        "id": "9111",
+        "name": "Enchanter Maia of the Grotto"
+    }, {
+        "id": "9127",
+        "name": "Magus Artis of the Grotto"
+    }, {
+        "id": "9138",
+        "name": "Artificer Thana of the Grotto"
+    }, {
+        "id": "9159",
+        "name": "Charmer Daphne of the Grotto"
+    }, {
+        "id": "9245",
+        "name": "Archmagus David of the Grotto"
+    }, {
+        "id": "9266",
+        "name": "Arch-Magician Quddus of the Grotto"
+    }, {
+        "id": "9348",
+        "name": "Alchemist Talon of the Grotto"
+    }, {
+        "id": "9374",
+        "name": "Sorcerer Shigenjo of the Grotto"
+    }, {
+        "id": "9449",
+        "name": "Chaos Mage Godfrey of the Grotto"
+    }, {
+        "id": "9559",
+        "name": "Hedge Wizard Peppy of the Grotto"
+    }, {
+        "id": "9636",
+        "name": "Archmagus Ozohr of the Grotto"
+    }, {
+        "id": "9696",
+        "name": "Archmagus  of the Grotto"
+    }, {
+        "id": "9750",
+        "name": "Hedge Wizard Rita of the Grotto"
+    }, {
+        "id": "9779",
+        "name": "Charmer Carly of the Grotto"
+    }, {
+        "id": "9797",
+        "name": "Arch-Magician Arabella of the Grotto"
+    }, {
+        "id": "9843",
+        "name": "Hedge Wizard Carly of the Grotto"
+    }, {
+        "id": "9855",
+        "name": "Hedge Wizard Brown Cow of the Grotto"
+    }, {
+        "id": "9880",
+        "name": "Archmagus Aleister of the Grotto"
+    }, {
+        "id": "9894",
+        "name": "Magus Amir of the Grotto"
+    }],
+    "Brine": [{
+        "id": "571",
+        "name": "Iprix of the Brine"
+    }, {
+        "id": "580",
+        "name": "Sage Artis of the Brine"
+    }, {
+        "id": "905",
+        "name": "Bard Alessar of the Brine"
+    }, {
+        "id": "2311",
+        "name": "Geomancer Aslan of the Brine"
+    }, {
+        "id": "2408",
+        "name": "Sorcerer Jahid of the Brine"
+    }, {
+        "id": "2427",
+        "name": "Clairvoyant  of the Brine"
+    }, {
+        "id": "3005",
+        "name": "Charmer Thana of the Brine"
+    }, {
+        "id": "3135",
+        "name": "Archmagus Zaros of the Brine"
+    }, {
+        "id": "3489",
+        "name": "Thaumaturge Dutorn of the Brine"
+    }, {
+        "id": "3566",
+        "name": "Conjurer Rodolfo of the Brine"
+    }, {
+        "id": "3618",
+        "name": "Arcanist Koop of the Brine"
+    }, {
+        "id": "3948",
+        "name": "Sorcerer Ozohr of the Brine"
+    }, {
+        "id": "4066",
+        "name": "Hydromancer Pandora of the Brine"
+    }, {
+        "id": "4251",
+        "name": "Archmagus Udor of the Brine"
+    }, {
+        "id": "4581",
+        "name": "Electromancer Danny of the Brine"
+    }, {
+        "id": "4906",
+        "name": "Shaman Ixar of the Brine"
+    }, {
+        "id": "4974",
+        "name": "Hedge Wizard Basil of the Brine"
+    }, {
+        "id": "5011",
+        "name": "Hydromancer Talon of the Brine"
+    }, {
+        "id": "5515",
+        "name": "Enchanter Astrid of the Brine"
+    }, {
+        "id": "6278",
+        "name": "Battle Mage Robert of the Brine"
+    }, {
+        "id": "6643",
+        "name": "Battle Mage Danny of the Brine"
+    }, {
+        "id": "6694",
+        "name": "Evoker Goliath of the Brine"
+    }, {
+        "id": "6861",
+        "name": "Hydromancer Hanataka of the Brine"
+    }, {
+        "id": "6930",
+        "name": "Archmagus Jasper of the Brine"
+    }, {
+        "id": "7027",
+        "name": "Archmagus Digby of the Brine"
+    }, {
+        "id": "8262",
+        "name": "Archmagus Uvlius of the Brine"
+    }, {
+        "id": "9514",
+        "name": "Merlon of the Brine"
+    }, {
+        "id": "9829",
+        "name": "Mina of the Brine"
+    }],
+    "Sea": [{
+        "id": "37",
+        "name": "Holy Monk Alvaro of the Sea"
+    }, {
+        "id": "128",
+        "name": "Arcanist Helix of the Sea"
+    }, {
+        "id": "268",
+        "name": "Aeromancer Bojangles of the Sea"
+    }, {
+        "id": "523",
+        "name": "Shaman Udor of the Sea"
+    }, {
+        "id": "598",
+        "name": "Spellsinger Soya of the Sea"
+    }, {
+        "id": "921",
+        "name": "Charmer Titania of the Sea"
+    }, {
+        "id": "924",
+        "name": "Battlemage Ravana of the Sea"
+    }, {
+        "id": "1178",
+        "name": "Hydromancer George of the Sea"
+    }, {
+        "id": "1211",
+        "name": "Illusionist Bolin of the Sea"
+    }, {
+        "id": "1298",
+        "name": "Druid Hothor of the Sea"
+    }, {
+        "id": "1417",
+        "name": "Hydromancer Caligari of the Sea"
+    }, {
+        "id": "1514",
+        "name": "Aleister of the Sea"
+    }, {
+        "id": "1684",
+        "name": "Alchemist Yan of the Sea"
+    }, {
+        "id": "1799",
+        "name": "Adept Alessar of the Sea"
+    }, {
+        "id": "2018",
+        "name": "Magus Willow of the Sea"
+    }, {
+        "id": "2062",
+        "name": "Adept Daria of the Sea"
+    }, {
+        "id": "2077",
+        "name": "Archmagus Aleister of the Sea"
+    }, {
+        "id": "2194",
+        "name": "Hydromancer Alizam of the Sea"
+    }, {
+        "id": "2424",
+        "name": "Diviner Enigma of the Sea"
+    }, {
+        "id": "2709",
+        "name": "Shaman Hashim of the Sea"
+    }, {
+        "id": "3238",
+        "name": "Battle Mage Baird of the Sea"
+    }, {
+        "id": "3250",
+        "name": "Alchemist Gellert of the Sea"
+    }, {
+        "id": "3254",
+        "name": "Hydromancer Wazir of the Sea"
+    }, {
+        "id": "3743",
+        "name": "Artificer Ozohr of the Sea"
+    }, {
+        "id": "3853",
+        "name": "Sage Ali of the Sea"
+    }, {
+        "id": "4260",
+        "name": "Alchemist Jerret of the Sea"
+    }, {
+        "id": "4415",
+        "name": "Spellsinger Lux of the Sea"
+    }, {
+        "id": "4583",
+        "name": "Archmagus Devo of the Sea"
+    }, {
+        "id": "4794",
+        "name": "Sage Sondra of the Sea"
+    }, {
+        "id": "5188",
+        "name": "Battle Mage Godfrey of the Sea"
+    }, {
+        "id": "5201",
+        "name": "Cleric David of the Sea"
+    }, {
+        "id": "5378",
+        "name": "Arch-Magician Malthus of the Sea"
+    }, {
+        "id": "5801",
+        "name": "Archmagus Ursula of the Sea"
+    }, {
+        "id": "5896",
+        "name": "Hydromancer Toka of the Sea"
+    }, {
+        "id": "6358",
+        "name": "Hedge Wizard Jeldor of the Sea"
+    }, {
+        "id": "6479",
+        "name": "Battle Mage Hansel of the Sea"
+    }, {
+        "id": "7130",
+        "name": "Illusionist Ofaris of the Sea"
+    }, {
+        "id": "7455",
+        "name": "Magus Eggplant of the Sea"
+    }, {
+        "id": "7497",
+        "name": "Chaos Mage Oberon of the Sea"
+    }, {
+        "id": "7653",
+        "name": "Hydromancer Gil of the Sea"
+    }, {
+        "id": "7781",
+        "name": "Sorcerer Isaac of the Sea"
+    }, {
+        "id": "7901",
+        "name": "Battle Mage Angus of the Sea"
+    }, {
+        "id": "8383",
+        "name": "Arch-Magician Daphne of the Sea"
+    }, {
+        "id": "8400",
+        "name": "Adept Jameel of the Sea"
+    }, {
+        "id": "8456",
+        "name": "Alchemist Eggplant of the Sea"
+    }, {
+        "id": "8498",
+        "name": "Geomancer Ozohr of the Sea"
+    }, {
+        "id": "8559",
+        "name": "Hydromancer Aleister of the Sea"
+    }, {
+        "id": "8788",
+        "name": "Hydromancer Angus of the Sea"
+    }, {
+        "id": "8825",
+        "name": "Alchemist Nicolas of the Sea"
+    }, {
+        "id": "9027",
+        "name": "Necromancer Asmodeus of the Sea"
+    }, {
+        "id": "9048",
+        "name": "Archmagus Magpie of the Sea"
+    }, {
+        "id": "9315",
+        "name": "Archmagus Ofaris of the Sea"
+    }, {
+        "id": "9340",
+        "name": "Arch-Magician Pino of the Sea"
+    }, {
+        "id": "9635",
+        "name": "Enchanter Circe of the Sea"
+    }, {
+        "id": "9721",
+        "name": "Voodoo Priest Victor of the Sea"
+    }],
+    "Ether": [{
+        "id": "42",
+        "name": "Cosmic Mage Voidoth of the Ether"
+    }, {
+        "id": "367",
+        "name": "Illusionist Udor of the Ether"
+    }, {
+        "id": "418",
+        "name": "Thaumaturge Davos of the Ether"
+    }, {
+        "id": "430",
+        "name": "Archmagus Remus of the Ether"
+    }, {
+        "id": "548",
+        "name": "Battle Mage Malthus of the Ether"
+    }, {
+        "id": "659",
+        "name": "Battle Mage Gary of the Ether"
+    }, {
+        "id": "668",
+        "name": "Oracle Abbadon of the Ether"
+    }, {
+        "id": "701",
+        "name": "Alatar of the Ether"
+    }, {
+        "id": "763",
+        "name": "Shadow Mage Zelroth of the Ether"
+    }, {
+        "id": "927",
+        "name": "Magus Aleister of the Ether"
+    }, {
+        "id": "964",
+        "name": "Archmagus Velorina of the Ether"
+    }, {
+        "id": "973",
+        "name": "Ghost Eater Aamon of the Ether"
+    }, {
+        "id": "1115",
+        "name": "Sorcerer Ifran of the Ether"
+    }, {
+        "id": "1120",
+        "name": "Aeromancer Titania of the Ether"
+    }, {
+        "id": "1149",
+        "name": "Cosmic Mage Rafiq of the Ether"
+    }, {
+        "id": "1242",
+        "name": "Archmagus Ronald of the Ether"
+    }, {
+        "id": "1286",
+        "name": "Arcanist Soya of the Ether"
+    }, {
+        "id": "1524",
+        "name": "Thaumaturge Lux of the Ether"
+    }, {
+        "id": "1577",
+        "name": "Adept Danny of the Ether"
+    }, {
+        "id": "1622",
+        "name": "Hydromancer Gourdon of the Ether"
+    }, {
+        "id": "1625",
+        "name": "Mystic Scorch of the Ether"
+    }, {
+        "id": "1702",
+        "name": "Ghost Eater Ulysse of the Ether"
+    }, {
+        "id": "1721",
+        "name": "Alchemist Sabina of the Ether"
+    }, {
+        "id": "1751",
+        "name": "Adept Jianyu of the Ether"
+    }, {
+        "id": "1882",
+        "name": "Alchemist Devin of the Ether"
+    }, {
+        "id": "1980",
+        "name": "Chaos Mage Lumos of the Ether"
+    }, {
+        "id": "2066",
+        "name": "Hex Mage Bao of the Ether"
+    }, {
+        "id": "2129",
+        "name": "Illusionist Aleister of the Ether"
+    }, {
+        "id": "2182",
+        "name": "Mystic Lumos of the Ether"
+    }, {
+        "id": "2210",
+        "name": "Sorcerer Hadrien of the Ether"
+    }, {
+        "id": "2361",
+        "name": "Geomancer Rowena of the Ether"
+    }, {
+        "id": "2474",
+        "name": "Illusionist Colorman of the Ether"
+    }, {
+        "id": "2504",
+        "name": "Witch Rowena of the Ether"
+    }, {
+        "id": "2532",
+        "name": "Adept Karasu of the Ether"
+    }, {
+        "id": "2601",
+        "name": "Sorcerer Apollo of the Ether"
+    }, {
+        "id": "2614",
+        "name": "Enchanter Oxnard of the Ether"
+    }, {
+        "id": "2695",
+        "name": "Archmagus Lumos of the Ether"
+    }, {
+        "id": "2700",
+        "name": "Magus Nazim of the Ether"
+    }, {
+        "id": "2741",
+        "name": "Sage Shukri of the Ether"
+    }, {
+        "id": "2768",
+        "name": "Hedge Wizard Circe of the Ether"
+    }, {
+        "id": "2936",
+        "name": "Hedge Wizard Poppy of the Ether"
+    }, {
+        "id": "2938",
+        "name": "Geomancer Cedric of the Ether"
+    }, {
+        "id": "3220",
+        "name": "Arcanist Dr. Death of the Ether"
+    }, {
+        "id": "3246",
+        "name": "Archmagus Isaac of the Ether"
+    }, {
+        "id": "3578",
+        "name": "Magus Tumbaj of the Ether"
+    }, {
+        "id": "3596",
+        "name": "Scryer Sondra of the Ether"
+    }, {
+        "id": "3642",
+        "name": "Spellsinger Nikolas of the Ether"
+    }, {
+        "id": "3717",
+        "name": "Spellsinger Luther of the Ether"
+    }, {
+        "id": "3721",
+        "name": "Summoner Soran of the Ether"
+    }, {
+        "id": "3826",
+        "name": "Shaman Salah of the Ether"
+    }, {
+        "id": "3841",
+        "name": "Electromancer Uvlius of the Ether"
+    }, {
+        "id": "3933",
+        "name": "Magus Hothor of the Ether"
+    }, {
+        "id": "3994",
+        "name": "Battle Mage Cromwell of the Ether"
+    }, {
+        "id": "4090",
+        "name": "Sage Alice of the Ether"
+    }, {
+        "id": "4154",
+        "name": "Sorcerer Iprix of the Ether"
+    }, {
+        "id": "4304",
+        "name": "Enchanter Velorina of the Ether"
+    }, {
+        "id": "4307",
+        "name": "Shaman Shigenjo of the Ether"
+    }, {
+        "id": "4319",
+        "name": "Sorcerer Uvlius of the Ether"
+    }, {
+        "id": "4328",
+        "name": "Hedge Wizard Shukri of the Ether"
+    }, {
+        "id": "4404",
+        "name": "Battle Mage Borak of the Ether"
+    }, {
+        "id": "4460",
+        "name": "Evoker Hadrien of the Ether"
+    }, {
+        "id": "4529",
+        "name": "Hedge Wizard Beyna of the Ether"
+    }, {
+        "id": "4586",
+        "name": "Sorcerer Solomon of the Ether"
+    }, {
+        "id": "4627",
+        "name": "Merlon of the Ether"
+    }, {
+        "id": "4655",
+        "name": "Charmer Carly of the Ether"
+    }, {
+        "id": "4693",
+        "name": "Thaumaturge Casper of the Ether"
+    }, {
+        "id": "4740",
+        "name": "Sorcerer Milton of the Ether"
+    }, {
+        "id": "4768",
+        "name": "Pyromancer Brown Cow of the Ether"
+    }, {
+        "id": "4803",
+        "name": "Archmagus Calista of the Ether"
+    }, {
+        "id": "4806",
+        "name": "Spellsinger Arcus of the Ether"
+    }, {
+        "id": "4948",
+        "name": "Wild Mage Agapito of the Ether"
+    }, {
+        "id": "4958",
+        "name": "Sorcerer Hadrien of the Ether"
+    }, {
+        "id": "5040",
+        "name": "Wild Mage Jianyu of the Ether"
+    }, {
+        "id": "5045",
+        "name": "Bard Merlon of the Ether"
+    }, {
+        "id": "5070",
+        "name": "Maia of the Ether"
+    }, {
+        "id": "5181",
+        "name": "Sorcerer Chiyo of the Ether"
+    }, {
+        "id": "5238",
+        "name": "Battlemage Iprix of the Ether"
+    }, {
+        "id": "5270",
+        "name": "Sorcerer Allistair of the Ether"
+    }, {
+        "id": "5313",
+        "name": "Charmer Daria of the Ether"
+    }, {
+        "id": "5347",
+        "name": "Archmagus Azahl of the Ether"
+    }, {
+        "id": "5359",
+        "name": "Druid Eric of the Ether"
+    }, {
+        "id": "5556",
+        "name": "Shaman Umber of the Ether"
+    }, {
+        "id": "5893",
+        "name": "Magus Nixie of the Ether"
+    }, {
+        "id": "5956",
+        "name": "Ghost Eater Virgil of the Ether"
+    }, {
+        "id": "6072",
+        "name": "Battle Mage Danny of the Ether"
+    }, {
+        "id": "6126",
+        "name": "Shaman Baird of the Ether"
+    }, {
+        "id": "6202",
+        "name": "Sorcerer Aleister of the Ether"
+    }, {
+        "id": "6205",
+        "name": "Ghost Eater Bayard of the Ether"
+    }, {
+        "id": "6298",
+        "name": "Archmagus Soya of the Ether"
+    }, {
+        "id": "6329",
+        "name": "Adept Merlon of the Ether"
+    }, {
+        "id": "6439",
+        "name": "Ozohr of the Ether"
+    }, {
+        "id": "6554",
+        "name": "Archmagus Jahid of the Ether"
+    }, {
+        "id": "6609",
+        "name": "Runecaster Ixar of the Ether"
+    }, {
+        "id": "6718",
+        "name": "Arch-Magician Gellert of the Ether"
+    }, {
+        "id": "6770",
+        "name": "Diviner Zaros of the Ether"
+    }, {
+        "id": "6812",
+        "name": "Adept Nolan of the Ether"
+    }, {
+        "id": "6900",
+        "name": "Sorcerer Jeldor of the Ether"
+    }, {
+        "id": "7068",
+        "name": "Sage Crobas of the Ether"
+    }, {
+        "id": "7268",
+        "name": "Druid Beyna of the Ether"
+    }, {
+        "id": "7328",
+        "name": "Sorcerer Goliath of the Ether"
+    }, {
+        "id": "7368",
+        "name": "Battle Mage Talon of the Ether"
+    }, {
+        "id": "7542",
+        "name": "Null Mage Soya of the Ether"
+    }, {
+        "id": "7576",
+        "name": "Sorcerer Merlon of the Ether"
+    }, {
+        "id": "7584",
+        "name": "Druid Cairon of the Ether"
+    }, {
+        "id": "7674",
+        "name": "Evoker Armstrong of the Ether"
+    }, {
+        "id": "7682",
+        "name": "Jerret of the Ether"
+    }, {
+        "id": "7703",
+        "name": "Battle Mage Brutus of the Ether"
+    }, {
+        "id": "7794",
+        "name": "Archmagus Davos of the Ether"
+    }, {
+        "id": "7952",
+        "name": "Ghost Eater Koop of the Ether"
+    }, {
+        "id": "8028",
+        "name": "Diabolist Aleister of the Ether"
+    }, {
+        "id": "8041",
+        "name": "Electromancer Moka of the Ether"
+    }, {
+        "id": "8118",
+        "name": "Enchanter Jianyu of the Ether"
+    }, {
+        "id": "8240",
+        "name": "Stellar Mage Gunthor of the Ether"
+    }, {
+        "id": "8278",
+        "name": "Archmagus Soya of the Ether"
+    }, {
+        "id": "8313",
+        "name": "Arch-Magician Ixar of the Ether"
+    }, {
+        "id": "8433",
+        "name": "Soran of the Ether"
+    }, {
+        "id": "8435",
+        "name": "Magus Amir of the Ether"
+    }, {
+        "id": "8560",
+        "name": "Alchemist Auguste of the Ether"
+    }, {
+        "id": "8604",
+        "name": "Archmagus Eden of the Ether"
+    }, {
+        "id": "8610",
+        "name": "Archmagus Jig of the Ether"
+    }, {
+        "id": "8669",
+        "name": "Shadow Mage Calliope of the Ether"
+    }, {
+        "id": "8751",
+        "name": "Archmagus Alatar of the Ether"
+    }, {
+        "id": "8873",
+        "name": "Sorcerer Chooki of the Ether"
+    }, {
+        "id": "8961",
+        "name": "Scryer Jaffer of the Ether"
+    }, {
+        "id": "9099",
+        "name": "Adept Eden of the Ether"
+    }, {
+        "id": "9246",
+        "name": "Pyromancer Patch of the Ether"
+    }, {
+        "id": "9278",
+        "name": "Archmagus Ixar of the Ether"
+    }, {
+        "id": "9735",
+        "name": "Magus Eronin of the Ether"
+    }, {
+        "id": "9763",
+        "name": "Sorcerer Casper of the Ether"
+    }, {
+        "id": "9824",
+        "name": "Runecaster Eden of the Ether"
+    }, {
+        "id": "9898",
+        "name": "Enchanter Evangeline of the Ether"
+    }, {
+        "id": "9959",
+        "name": "Magus Tengu of the Ether"
+    }],
+    "Mountain": [{
+        "id": "24",
+        "name": "Philosopher Nietzsche of the Mountain"
+    }, {
+        "id": "69",
+        "name": "Scryer Aleister of the Mountain"
+    }, {
+        "id": "169",
+        "name": "Necromancer Seth of the Mountain"
+    }, {
+        "id": "512",
+        "name": "Witch Florah of the Mountain"
+    }, {
+        "id": "526",
+        "name": "Cosmic Mage Galatea of the Mountain"
+    }, {
+        "id": "776",
+        "name": "Sorcerer Alizam of the Mountain"
+    }, {
+        "id": "888",
+        "name": "Geomancer Hind of the Mountain"
+    }, {
+        "id": "1001",
+        "name": "Hedge Wizard Armstrong of the Mountain"
+    }, {
+        "id": "1060",
+        "name": "Archmagus Salvatore of the Mountain"
+    }, {
+        "id": "1074",
+        "name": "Victoria of the Mountain"
+    }, {
+        "id": "1134",
+        "name": "Enchanter Circe of the Mountain"
+    }, {
+        "id": "1581",
+        "name": "Aeromancer Daria of the Mountain"
+    }, {
+        "id": "1606",
+        "name": "Augurer Blaise of the Mountain"
+    }, {
+        "id": "1646",
+        "name": "Enchanter Arabella of the Mountain"
+    }, {
+        "id": "1709",
+        "name": "Summoner Circe of the Mountain"
+    }, {
+        "id": "1907",
+        "name": "Enchanter Calista of the Mountain"
+    }, {
+        "id": "2005",
+        "name": "Adept Woomba of the Mountain"
+    }, {
+        "id": "2055",
+        "name": "Archmagus Aleister of the Mountain"
+    }, {
+        "id": "2136",
+        "name": "Druid Basil of the Mountain"
+    }, {
+        "id": "2284",
+        "name": "Shaman Iris of the Mountain"
+    }, {
+        "id": "2380",
+        "name": "Larissa of the Mountain"
+    }, {
+        "id": "2492",
+        "name": "Battle Mage Durm of the Mountain"
+    }, {
+        "id": "2603",
+        "name": "Hedge Wizard Rita of the Mountain"
+    }, {
+        "id": "2632",
+        "name": "Clairvoyant Properpine of the Mountain"
+    }, {
+        "id": "2660",
+        "name": "Aeromancer Merlon of the Mountain"
+    }, {
+        "id": "2910",
+        "name": "Mystic Zelroth of the Mountain"
+    }, {
+        "id": "2960",
+        "name": "Mystic Herne of the Mountain"
+    }, {
+        "id": "2973",
+        "name": "Enchanter Circe of the Mountain"
+    }, {
+        "id": "3062",
+        "name": "Wild Mage Alatar of the Mountain"
+    }, {
+        "id": "3165",
+        "name": "Archmagus  of the Mountain"
+    }, {
+        "id": "3337",
+        "name": "Necromancer JackDaw of the Mountain"
+    }, {
+        "id": "3342",
+        "name": "Enchanter Artis of the Mountain"
+    }, {
+        "id": "3470",
+        "name": "Cryptomancer Layla of the Mountain"
+    }, {
+        "id": "3518",
+        "name": "Archmagus Aldus of the Mountain"
+    }, {
+        "id": "3553",
+        "name": "Witch Hagatha of the Mountain"
+    }, {
+        "id": "3774",
+        "name": "Hydromancer Layla of the Mountain"
+    }, {
+        "id": "3780",
+        "name": "Hedge Wizard Remus of the Mountain"
+    }, {
+        "id": "3936",
+        "name": "Adept Eliphas of the Mountain"
+    }, {
+        "id": "4040",
+        "name": "Augurer Rita of the Mountain"
+    }, {
+        "id": "4072",
+        "name": "Pandora of the Mountain"
+    }, {
+        "id": "4132",
+        "name": "Battle Mage Eric of the Mountain"
+    }, {
+        "id": "4259",
+        "name": "Magus Bayard of the Mountain"
+    }, {
+        "id": "4289",
+        "name": "Mystic Dario of the Mountain"
+    }, {
+        "id": "4452",
+        "name": "Artificer Sabina of the Mountain"
+    }, {
+        "id": "4455",
+        "name": "Arch-Magician Goliath of the Mountain"
+    }, {
+        "id": "4467",
+        "name": "Artificer Sonja of the Mountain"
+    }, {
+        "id": "4490",
+        "name": "Artificer Mushy of the Mountain"
+    }, {
+        "id": "4637",
+        "name": "Witch Marceline of the Mountain"
+    }, {
+        "id": "4656",
+        "name": "Witch Elena of the Mountain"
+    }, {
+        "id": "4674",
+        "name": "Alchemist Naoki of the Mountain"
+    }, {
+        "id": "4815",
+        "name": "Archmagus Aleister of the Mountain"
+    }, {
+        "id": "5160",
+        "name": "Diabolist Sonja of the Mountain"
+    }, {
+        "id": "5260",
+        "name": "Battle Mage Magnus of the Mountain"
+    }, {
+        "id": "5299",
+        "name": "Aeromancer Velorina of the Mountain"
+    }, {
+        "id": "5384",
+        "name": "Alchemist Gary of the Mountain"
+    }, {
+        "id": "5415",
+        "name": "Archmagus Devon of the Mountain"
+    }, {
+        "id": "5418",
+        "name": "Witch Properpine of the Mountain"
+    }, {
+        "id": "5435",
+        "name": "Archmagus Astrid of the Mountain"
+    }, {
+        "id": "5439",
+        "name": "Geomancer Pix of the Mountain"
+    }, {
+        "id": "5451",
+        "name": "Witch Drusilla of the Mountain"
+    }, {
+        "id": "5623",
+        "name": "Enchanter Hanko of the Mountain"
+    }, {
+        "id": "5640",
+        "name": "Arch-Magician Velorina of the Mountain"
+    }, {
+        "id": "5779",
+        "name": "Battle Mage Hansel of the Mountain"
+    }, {
+        "id": "5815",
+        "name": "Hedge Wizard Lenora of the Mountain"
+    }, {
+        "id": "5916",
+        "name": "Pyromancer Althea of the Mountain"
+    }, {
+        "id": "5990",
+        "name": "Arcanist Durm of the Mountain"
+    }, {
+        "id": "6030",
+        "name": "Sonja of the Mountain"
+    }, {
+        "id": "6076",
+        "name": "Sorcerer Qasim of the Mountain"
+    }, {
+        "id": "6266",
+        "name": "Magus Zeromus of the Mountain"
+    }, {
+        "id": "6353",
+        "name": "Enchanter Carly of the Mountain"
+    }, {
+        "id": "6374",
+        "name": "Runecaster Finn of the Mountain"
+    }, {
+        "id": "6496",
+        "name": "Uvlius of the Mountain"
+    }, {
+        "id": "6706",
+        "name": "Battle Mage Cromwell of the Mountain"
+    }, {
+        "id": "6746",
+        "name": "Devon of the Mountain"
+    }, {
+        "id": "6796",
+        "name": "Sorcerer Aleister of the Mountain"
+    }, {
+        "id": "6906",
+        "name": "Geomancer Hongo of the Mountain"
+    }, {
+        "id": "6946",
+        "name": "Electromancer Milton of the Mountain"
+    }, {
+        "id": "6976",
+        "name": "Witch Juniper of the Mountain"
+    }, {
+        "id": "7014",
+        "name": "Battle Mage Khudalf of the Mountain"
+    }, {
+        "id": "7029",
+        "name": "Alchemist Eronin of the Mountain"
+    }, {
+        "id": "7040",
+        "name": "Sage Gomorrah of the Mountain"
+    }, {
+        "id": "7066",
+        "name": "Battle Mage Angus of the Mountain"
+    }, {
+        "id": "7098",
+        "name": "Alessar of the Mountain"
+    }, {
+        "id": "7207",
+        "name": "Diabolist Lamia of the Mountain"
+    }, {
+        "id": "7239",
+        "name": "Archmagus Alatar of the Mountain"
+    }, {
+        "id": "7387",
+        "name": "Hedge Wizard Muntjac of the Mountain"
+    }, {
+        "id": "7426",
+        "name": "Alchemist Tundror of the Mountain"
+    }, {
+        "id": "7443",
+        "name": "Sage Layla of the Mountain"
+    }, {
+        "id": "7488",
+        "name": "Charmer Arabella of the Mountain"
+    }, {
+        "id": "7499",
+        "name": "Oracle Mina of the Mountain"
+    }, {
+        "id": "7667",
+        "name": "Witch Liliana of the Mountain"
+    }, {
+        "id": "7721",
+        "name": "Wild Mage Mina of the Mountain"
+    }, {
+        "id": "7889",
+        "name": "Arch-Magician Eric of the Mountain"
+    }, {
+        "id": "7909",
+        "name": "Enchanter Daphne of the Mountain"
+    }, {
+        "id": "7920",
+        "name": "Hydromancer Aleister of the Mountain"
+    }, {
+        "id": "8026",
+        "name": "Magus Daphne of the Mountain"
+    }, {
+        "id": "8060",
+        "name": "Alchemist Cassiopeia of the Mountain"
+    }, {
+        "id": "8214",
+        "name": "Conjurer Lin of the Mountain"
+    }, {
+        "id": "8292",
+        "name": "Archmagus Davos of the Mountain"
+    }, {
+        "id": "8309",
+        "name": "Cleric Atlas of the Mountain"
+    }, {
+        "id": "8414",
+        "name": "Mystic Daria of the Mountain"
+    }, {
+        "id": "8472",
+        "name": "Runecaster Galatea of the Mountain"
+    }, {
+        "id": "8670",
+        "name": "Arcanist Xue of the Mountain"
+    }, {
+        "id": "8776",
+        "name": "Druid Shroomer of the Mountain"
+    }, {
+        "id": "8852",
+        "name": "Hedge Wizard Quigly of the Mountain"
+    }, {
+        "id": "8864",
+        "name": "Magus Asphodel of the Mountain"
+    }, {
+        "id": "8879",
+        "name": "Battle Mage Axel of the Mountain"
+    }, {
+        "id": "8897",
+        "name": "Battle Mage Axel of the Mountain"
+    }, {
+        "id": "8941",
+        "name": "Magus Diana of the Mountain"
+    }, {
+        "id": "8943",
+        "name": "Battle Mage Bartholomew of the Mountain"
+    }, {
+        "id": "8984",
+        "name": "Sorcerer Celah of the Mountain"
+    }, {
+        "id": "9067",
+        "name": "Hydromancer Gunthor of the Mountain"
+    }, {
+        "id": "9181",
+        "name": "Magus Zafar of the Mountain"
+    }, {
+        "id": "9312",
+        "name": "Scryer Finn of the Mountain"
+    }, {
+        "id": "9487",
+        "name": "Hedge Wizard Angus of the Mountain"
+    }, {
+        "id": "9595",
+        "name": "Geomancer Talon of the Mountain"
+    }, {
+        "id": "9728",
+        "name": "Enchanter Robert of the Mountain"
+    }, {
+        "id": "9821",
+        "name": "Pyromancer Faye of the Mountain"
+    }, {
+        "id": "9822",
+        "name": "Geomancer Venga of the Mountain"
+    }],
+    "Catacombs": [{
+        "id": "4252",
+        "name": "Void Disciple Zagan of the Catacombs"
+    }],
+    "Death": [{
+        "id": "3795",
+        "name": "Null Mage Malcom of Death"
+    }, {
+        "id": "6029",
+        "name": "Shadow Mage Bathsheba of Death"
+    }, {
+        "id": "6133",
+        "name": "Conjurer Moloch of Death"
+    }, {
+        "id": "7061",
+        "name": "Adept Roy G. Biv of Death"
+    }],
+    "Rainbow": [{
+        "id": "412",
+        "name": "Arch-Magician Jasper of the Rainbow"
+    }, {
+        "id": "9044",
+        "name": "Celah of the Rainbow"
+    }],
+    "Quantum Shadow": [{
+        "id": "195",
+        "name": "Alchemist Rowena of the Quantum Shadow"
+    }, {
+        "id": "377",
+        "name": "Hex Mage Orpheus of the Quantum Shadow"
+    }, {
+        "id": "380",
+        "name": "Alchemist Alessar of the Quantum Shadow"
+    }, {
+        "id": "496",
+        "name": "Void Disciple Lupa of the Quantum Shadow"
+    }, {
+        "id": "581",
+        "name": "Battle Mage Samuel of the Quantum Shadow"
+    }, {
+        "id": "1432",
+        "name": "Pyromancer Herne of the Quantum Shadow"
+    }, {
+        "id": "1618",
+        "name": "Void Disciple Seth of the Quantum Shadow"
+    }, {
+        "id": "2078",
+        "name": "Battle Mage Homer of the Quantum Shadow"
+    }, {
+        "id": "2225",
+        "name": "Artificer Shivra of the Quantum Shadow"
+    }, {
+        "id": "2297",
+        "name": "Cryptomancer Cairon of the Quantum Shadow"
+    }, {
+        "id": "2458",
+        "name": "Archmagus Aleister of the Quantum Shadow"
+    }, {
+        "id": "2696",
+        "name": "Void Disciple Chiron of the Quantum Shadow"
+    }, {
+        "id": "2728",
+        "name": "Druid Orpheus of the Quantum Shadow"
+    }, {
+        "id": "2785",
+        "name": "Hex Mage Yog-Sothoth of the Quantum Shadow"
+    }, {
+        "id": "2790",
+        "name": "Necromancer Bane of the Quantum Shadow"
+    }, {
+        "id": "3105",
+        "name": "Druid Magpie of the Quantum Shadow"
+    }, {
+        "id": "3610",
+        "name": "Amir of the Quantum Shadow"
+    }, {
+        "id": "3712",
+        "name": "Archmagus Zaros of the Quantum Shadow"
+    }, {
+        "id": "3839",
+        "name": "Necromancer Thor of the Quantum Shadow"
+    }, {
+        "id": "4314",
+        "name": "Battle Mage Cassius of the Quantum Shadow"
+    }, {
+        "id": "4908",
+        "name": "Summoner Milton of the Quantum Shadow"
+    }, {
+        "id": "4916",
+        "name": "Sage Soya of the Quantum Shadow"
+    }, {
+        "id": "5080",
+        "name": "Shaman Flamos of the Quantum Shadow"
+    }, {
+        "id": "5657",
+        "name": "Sorcerer Isaac of the Quantum Shadow"
+    }, {
+        "id": "5976",
+        "name": "Shaman Solomon of the Quantum Shadow"
+    }, {
+        "id": "6060",
+        "name": "Artificer Robert of the Quantum Shadow"
+    }, {
+        "id": "6350",
+        "name": "Thaumaturge Rowena of the Quantum Shadow"
+    }, {
+        "id": "6456",
+        "name": "Sky Master Magpie of the Quantum Shadow"
+    }, {
+        "id": "6459",
+        "name": "Artificer Elvio of the Quantum Shadow"
+    }, {
+        "id": "6526",
+        "name": "Battle Mage Ratko of the Quantum Shadow"
+    }, {
+        "id": "6803",
+        "name": "Chaos Mage Davos of the Quantum Shadow"
+    }, {
+        "id": "7302",
+        "name": "Pyromancer Fire Eater of the Quantum Shadow"
+    }, {
+        "id": "7643",
+        "name": "Druid JackDaw of the Quantum Shadow"
+    }, {
+        "id": "7857",
+        "name": "Chaos Mage Ratko of the Quantum Shadow"
+    }, {
+        "id": "8103",
+        "name": "Mystic David of the Quantum Shadow"
+    }, {
+        "id": "8217",
+        "name": "Mystic Cromwell of the Quantum Shadow"
+    }, {
+        "id": "8871",
+        "name": "Archmagus Hadrien of the Quantum Shadow"
+    }, {
+        "id": "8933",
+        "name": "Pyromancer Peppy of the Quantum Shadow"
+    }, {
+        "id": "9380",
+        "name": "Sorcerer Hadrien of the Quantum Shadow"
+    }],
+    "Bastion": [{
+        "id": "111",
+        "name": "Battle Mage Durm of the Bastion"
+    }, {
+        "id": "252",
+        "name": "Chaos Mage Eden of the Bastion"
+    }, {
+        "id": "258",
+        "name": "Alchemist Ramiz of the Bastion"
+    }, {
+        "id": "259",
+        "name": "Magus Yuki of the Bastion"
+    }, {
+        "id": "426",
+        "name": "Augurer Milton of the Bastion"
+    }, {
+        "id": "464",
+        "name": "Shaman Bobbin of the Bastion"
+    }, {
+        "id": "482",
+        "name": "Sorcerer Izible of the Bastion"
+    }, {
+        "id": "640",
+        "name": "Magus Apollo of the Bastion"
+    }, {
+        "id": "654",
+        "name": "Archmagus Hadrien of the Bastion"
+    }, {
+        "id": "710",
+        "name": "Battle Mage Rodolfo of the Bastion"
+    }, {
+        "id": "739",
+        "name": "Summoner Kryll of the Bastion"
+    }, {
+        "id": "745",
+        "name": "Charmer Galatea of the Bastion"
+    }, {
+        "id": "770",
+        "name": "Sky Master Hank of the Bastion"
+    }, {
+        "id": "834",
+        "name": "Arch-Magician Marceau of the Bastion"
+    }, {
+        "id": "864",
+        "name": "Archmagus Isaac of the Bastion"
+    }, {
+        "id": "1038",
+        "name": "Hydromancer Vorvadoss of the Bastion"
+    }, {
+        "id": "1049",
+        "name": "Cartomancer Aiko of the Bastion"
+    }, {
+        "id": "1333",
+        "name": "Hedge Wizard Caligula of the Bastion"
+    }, {
+        "id": "1352",
+        "name": "Druid Poppy of the Bastion"
+    }, {
+        "id": "1455",
+        "name": "Runecaster Soya of the Bastion"
+    }, {
+        "id": "1528",
+        "name": "Archmagus Milton of the Bastion"
+    }, {
+        "id": "1708",
+        "name": "Chronomancer Atlas of the Bastion"
+    }, {
+        "id": "1798",
+        "name": "Sage Cromwell of the Bastion"
+    }, {
+        "id": "1802",
+        "name": "Archmagus Cairon of the Bastion"
+    }, {
+        "id": "1810",
+        "name": "Sorcerer Remus of the Bastion"
+    }, {
+        "id": "1822",
+        "name": "Artificer Zaros of the Bastion"
+    }, {
+        "id": "1906",
+        "name": "Artificer Nemo of the Bastion"
+    }, {
+        "id": "1979",
+        "name": "Archmagus Hadrien of the Bastion"
+    }, {
+        "id": "2014",
+        "name": "Archmagus Milton of the Bastion"
+    }, {
+        "id": "2071",
+        "name": "Alatar of the Bastion"
+    }, {
+        "id": "2149",
+        "name": "Voodoo Priest Le Blanc of the Bastion"
+    }, {
+        "id": "2251",
+        "name": "Hedge Wizard Gourdon of the Bastion"
+    }, {
+        "id": "2413",
+        "name": "Enchanter Marceau of the Bastion"
+    }, {
+        "id": "2566",
+        "name": "Enchanter Diana of the Bastion"
+    }, {
+        "id": "2609",
+        "name": "Archmagus Hadrien of the Bastion"
+    }, {
+        "id": "2622",
+        "name": "Battle Mage Caligula of the Bastion"
+    }, {
+        "id": "2650",
+        "name": "Sage Draven of the Bastion"
+    }, {
+        "id": "2780",
+        "name": "Archmagus Lumos of the Bastion"
+    }, {
+        "id": "2835",
+        "name": "Sorcerer Lumos of the Bastion"
+    }, {
+        "id": "2859",
+        "name": "Alchemist Hadrien of the Bastion"
+    }, {
+        "id": "2874",
+        "name": "Spellsinger Norix of the Bastion"
+    }, {
+        "id": "2884",
+        "name": "Alchemist Alice of the Bastion"
+    }, {
+        "id": "2921",
+        "name": "Witch Imeena of the Bastion"
+    }, {
+        "id": "3011",
+        "name": "Sorcerer Allistair of the Bastion"
+    }, {
+        "id": "3068",
+        "name": "Aeromancer Udor of the Bastion"
+    }, {
+        "id": "3132",
+        "name": "Shaman Sahir of the Bastion"
+    }, {
+        "id": "3236",
+        "name": "Alchemist Kalo of the Bastion"
+    }, {
+        "id": "3475",
+        "name": "Hedge Wizard Buttons of the Bastion"
+    }, {
+        "id": "3572",
+        "name": "Chronomancer Fugh of the Bastion"
+    }, {
+        "id": "3667",
+        "name": "Summoner Soya of the Bastion"
+    }, {
+        "id": "3852",
+        "name": "Chronomancer Cromwell of the Bastion"
+    }, {
+        "id": "3957",
+        "name": "Lunar Mage Rixxa of the Bastion"
+    }, {
+        "id": "4005",
+        "name": "Hedge Wizard Merlon of the Bastion"
+    }, {
+        "id": "4116",
+        "name": "Illusionist Trollin of the Bastion"
+    }, {
+        "id": "4159",
+        "name": "Artificer Horace of the Bastion"
+    }, {
+        "id": "4231",
+        "name": "Archmagus David of the Bastion"
+    }, {
+        "id": "4337",
+        "name": "Necromancer Aiko of the Bastion"
+    }, {
+        "id": "4387",
+        "name": "Archmagus Nikolas of the Bastion"
+    }, {
+        "id": "4393",
+        "name": "Voodoo Priest Hugo of the Bastion"
+    }, {
+        "id": "4406",
+        "name": "Sorcerer Iprix of the Bastion"
+    }, {
+        "id": "4486",
+        "name": "Battle Mage Tundror of the Bastion"
+    }, {
+        "id": "4539",
+        "name": "Holy Monk Chandler of the Bastion"
+    }, {
+        "id": "4652",
+        "name": "Conjurer Durm of the Bastion"
+    }, {
+        "id": "4810",
+        "name": "Illusionist Hansel of the Bastion"
+    }, {
+        "id": "4885",
+        "name": "Shaman Bojangles of the Bastion"
+    }, {
+        "id": "4986",
+        "name": "Artificer Soya of the Bastion"
+    }, {
+        "id": "5034",
+        "name": "Druid Luther of the Bastion"
+    }, {
+        "id": "5121",
+        "name": "Sorcerer Zane of the Bastion"
+    }, {
+        "id": "5145",
+        "name": "Evoker Homer of the Bastion"
+    }, {
+        "id": "5363",
+        "name": "Battle Mage Hothor of the Bastion"
+    }, {
+        "id": "5414",
+        "name": "Thaumaturge Hagar of the Bastion"
+    }, {
+        "id": "5504",
+        "name": "Charmer Bathsheba of the Bastion"
+    }, {
+        "id": "5508",
+        "name": "Sage Beyna of the Bastion"
+    }, {
+        "id": "5579",
+        "name": "Cleric Duzzle of the Bastion"
+    }, {
+        "id": "5664",
+        "name": "Shaman Ravana of the Bastion"
+    }, {
+        "id": "5672",
+        "name": "Larissa of the Bastion"
+    }, {
+        "id": "5802",
+        "name": "Aldus of the Bastion"
+    }, {
+        "id": "6010",
+        "name": "Enchanter Angus of the Bastion"
+    }, {
+        "id": "6083",
+        "name": "Enchanter Oberon of the Bastion"
+    }, {
+        "id": "6142",
+        "name": "Enchanter Larissa of the Bastion"
+    }, {
+        "id": "6151",
+        "name": "Diabolist Alessar of the Bastion"
+    }, {
+        "id": "6245",
+        "name": "Ghost Eater Gorgana of the Bastion"
+    }, {
+        "id": "6294",
+        "name": "Lunar Mage Patch of the Bastion"
+    }, {
+        "id": "6321",
+        "name": "Evoker Woomba of the Bastion"
+    }, {
+        "id": "6546",
+        "name": "Arcanist Goliath of the Bastion"
+    }, {
+        "id": "6652",
+        "name": "Diviner Angus of the Bastion"
+    }, {
+        "id": "6760",
+        "name": "Enchanter Aiko of the Bastion"
+    }, {
+        "id": "6795",
+        "name": "Archmagus Aldus of the Bastion"
+    }, {
+        "id": "7100",
+        "name": "Milton of the Bastion"
+    }, {
+        "id": "7209",
+        "name": "Artificer Soya of the Bastion"
+    }, {
+        "id": "7307",
+        "name": "Scryer Aiko of the Bastion"
+    }, {
+        "id": "7348",
+        "name": "Conjurer Homer of the Bastion"
+    }, {
+        "id": "7382",
+        "name": "Battle Mage Luther of the Bastion"
+    }, {
+        "id": "7691",
+        "name": "Artificer Gallo of the Bastion"
+    }, {
+        "id": "7698",
+        "name": "Augurer Zelroth of the Bastion"
+    }, {
+        "id": "7962",
+        "name": "Archmagus Ozohr of the Bastion"
+    }, {
+        "id": "8102",
+        "name": "Runecaster Corvin of the Bastion"
+    }, {
+        "id": "8160",
+        "name": "Archmagus Aldo of the Bastion"
+    }, {
+        "id": "8175",
+        "name": "Archmagus Jerret of the Bastion"
+    }, {
+        "id": "8244",
+        "name": "Oracle Celeste of the Bastion"
+    }, {
+        "id": "8263",
+        "name": "Arcanist Thor of the Bastion"
+    }, {
+        "id": "8451",
+        "name": "Sorcerer Eden of the Bastion"
+    }, {
+        "id": "8550",
+        "name": "Pyromancer Scorch of the Bastion"
+    }, {
+        "id": "8600",
+        "name": "Archmagus Jerret of the Bastion"
+    }, {
+        "id": "8624",
+        "name": "Bard Caligari of the Bastion"
+    }, {
+        "id": "8625",
+        "name": "Aeromancer Izible of the Bastion"
+    }, {
+        "id": "8721",
+        "name": "Arch-Magician Pumlo of the Bastion"
+    }, {
+        "id": "8727",
+        "name": "Chaos Mage Voidoth of the Bastion"
+    }, {
+        "id": "8745",
+        "name": "Voodoo Priest Vadim of the Bastion"
+    }, {
+        "id": "8809",
+        "name": "Sage Nicolas of the Bastion"
+    }, {
+        "id": "8890",
+        "name": "Necromancer Anton of the Bastion"
+    }, {
+        "id": "8898",
+        "name": "Mystic Merlon of the Bastion"
+    }, {
+        "id": "8964",
+        "name": "Arcanist Merlon of the Bastion"
+    }, {
+        "id": "8979",
+        "name": "Pyromancer Sylvia of the Bastion"
+    }, {
+        "id": "9091",
+        "name": "Evoker Nicolas of the Bastion"
+    }, {
+        "id": "9375",
+        "name": "Enchanter Diana of the Bastion"
+    }, {
+        "id": "9403",
+        "name": "Mystic Argus of the Bastion"
+    }, {
+        "id": "9430",
+        "name": "Archmagus Baird of the Bastion"
+    }, {
+        "id": "9433",
+        "name": "Jerret of the Bastion"
+    }, {
+        "id": "9457",
+        "name": "Archmagus Argus of the Bastion"
+    }, {
+        "id": "9459",
+        "name": "Fortune Teller Isaac of the Bastion"
+    }, {
+        "id": "9569",
+        "name": "Shadow Mage Cromwell of the Bastion"
+    }, {
+        "id": "9681",
+        "name": "Sage Horace of the Bastion"
+    }, {
+        "id": "9774",
+        "name": "Archmagus Zubin of the Bastion"
+    }, {
+        "id": "9802",
+        "name": "Arcanist Durm of the Bastion"
+    }, {
+        "id": "9815",
+        "name": "Mystic David of the Bastion"
+    }],
+    "Forest": [{
+        "id": "54",
+        "name": "Druid Mina of the Forest"
+    }, {
+        "id": "71",
+        "name": "Enchanter Ash of the Forest"
+    }, {
+        "id": "85",
+        "name": "Enchanter Daphne of the Forest"
+    }, {
+        "id": "158",
+        "name": "Enchanter Atlanta of the Forest"
+    }, {
+        "id": "190",
+        "name": "Aeromancer Onaxx of the Forest"
+    }, {
+        "id": "247",
+        "name": "Magus Amir of the Forest"
+    }, {
+        "id": "623",
+        "name": "Enchanter Evangeline of the Forest"
+    }, {
+        "id": "690",
+        "name": "Diabolist Hagar of the Forest"
+    }, {
+        "id": "791",
+        "name": "Geomancer Ariadne of the Forest"
+    }, {
+        "id": "882",
+        "name": "Enchanter Sondra of the Forest"
+    }, {
+        "id": "995",
+        "name": "Merlon of the Forest"
+    }, {
+        "id": "1160",
+        "name": "Magus Bartholomew of the Forest"
+    }, {
+        "id": "1188",
+        "name": "Spellsinger Daria of the Forest"
+    }, {
+        "id": "1353",
+        "name": "Arch-Magician Drusilla of the Forest"
+    }, {
+        "id": "1355",
+        "name": "Magus Elena of the Forest"
+    }, {
+        "id": "1426",
+        "name": "Conjurer Crobas of the Forest"
+    }, {
+        "id": "1456",
+        "name": "Arch-Magician Giacomo of the Forest"
+    }, {
+        "id": "1556",
+        "name": "Adept Iris of the Forest"
+    }, {
+        "id": "1583",
+        "name": "Druid Circe of the Forest"
+    }, {
+        "id": "1640",
+        "name": "Thaumaturge Enigma of the Forest"
+    }, {
+        "id": "1654",
+        "name": "Battle Mage Cassius of the Forest"
+    }, {
+        "id": "1665",
+        "name": "Aeromancer Sondra of the Forest"
+    }, {
+        "id": "1727",
+        "name": "Sage Ulysse of the Forest"
+    }, {
+        "id": "1774",
+        "name": "Witch Eronin of the Forest"
+    }, {
+        "id": "1820",
+        "name": "Oracle Sondra of the Forest"
+    }, {
+        "id": "1884",
+        "name": "Battle Mage Khudalf of the Forest"
+    }, {
+        "id": "1908",
+        "name": "Cybele of the Forest"
+    }, {
+        "id": "1970",
+        "name": "Enchanter Hongo of the Forest"
+    }, {
+        "id": "2094",
+        "name": "Alchemist Yuki of the Forest"
+    }, {
+        "id": "2197",
+        "name": "Adept Asphodel of the Forest"
+    }, {
+        "id": "2231",
+        "name": "Mystic Cassius of the Forest"
+    }, {
+        "id": "2307",
+        "name": "Charmer Beyna of the Forest"
+    }, {
+        "id": "2366",
+        "name": "Archmagus Ozohr of the Forest"
+    }, {
+        "id": "2390",
+        "name": "Charmer Beyna of the Forest"
+    }, {
+        "id": "2439",
+        "name": "Archmagus Hadrien of the Forest"
+    }, {
+        "id": "2459",
+        "name": "Druid  of the Forest"
+    }, {
+        "id": "2536",
+        "name": "Artificer Robin of the Forest"
+    }, {
+        "id": "2699",
+        "name": "Merlon of the Forest"
+    }, {
+        "id": "2717",
+        "name": "Battle Mage Gunthor of the Forest"
+    }, {
+        "id": "2766",
+        "name": "Null Mage Quddus of the Forest"
+    }, {
+        "id": "2947",
+        "name": "Druid Celeste of the Forest"
+    }, {
+        "id": "3070",
+        "name": "Shadow Mage Galatea of the Forest"
+    }, {
+        "id": "3145",
+        "name": "Arch-Magician Aden of the Forest"
+    }, {
+        "id": "3213",
+        "name": "Sage Ursula of the Forest"
+    }, {
+        "id": "3282",
+        "name": "Shaman Pan of the Forest"
+    }, {
+        "id": "3419",
+        "name": "Thana of the Forest"
+    }, {
+        "id": "3423",
+        "name": "Augurer Robert of the Forest"
+    }, {
+        "id": "3490",
+        "name": "Druid Galatea of the Forest"
+    }, {
+        "id": "3792",
+        "name": "Enchanter Asphodel of the Forest"
+    }, {
+        "id": "3803",
+        "name": "Battle Mage Hagar of the Forest"
+    }, {
+        "id": "4077",
+        "name": "Druid Pandora of the Forest"
+    }, {
+        "id": "4082",
+        "name": "Wild Mage Jahid of the Forest"
+    }, {
+        "id": "4164",
+        "name": "Oracle Amir of the Forest"
+    }, {
+        "id": "4375",
+        "name": "Druid Orpheus of the Forest"
+    }, {
+        "id": "4416",
+        "name": "Artificer Artis of the Forest"
+    }, {
+        "id": "4497",
+        "name": "Artificer Goliath of the Forest"
+    }, {
+        "id": "4536",
+        "name": "Oberon of the Forest"
+    }, {
+        "id": "4538",
+        "name": "Archmagus Chooki of the Forest"
+    }, {
+        "id": "4599",
+        "name": "Aleister of the Forest"
+    }, {
+        "id": "4756",
+        "name": "Mystic Eden of the Forest"
+    }, {
+        "id": "4881",
+        "name": "Geomancer Fungi of the Forest"
+    }, {
+        "id": "4989",
+        "name": "Druid Rowena of the Forest"
+    }, {
+        "id": "5062",
+        "name": "Druid Anton of the Forest"
+    }, {
+        "id": "5150",
+        "name": "Battle Mage Tundror of the Forest"
+    }, {
+        "id": "5205",
+        "name": "Hedge Wizard Apollo of the Forest"
+    }, {
+        "id": "5442",
+        "name": "Alchemist Velorina of the Forest"
+    }, {
+        "id": "5461",
+        "name": "Magus Sylvia of the Forest"
+    }, {
+        "id": "5478",
+        "name": "Arcanist Mina of the Forest"
+    }, {
+        "id": "5631",
+        "name": "Enchanter Calliope of the Forest"
+    }, {
+        "id": "5755",
+        "name": "Magus Robert of the Forest"
+    }, {
+        "id": "5792",
+        "name": "Chronomancer Milo of the Forest"
+    }, {
+        "id": "5861",
+        "name": "Geomancer Eggplant of the Forest"
+    }, {
+        "id": "5907",
+        "name": "Archmagus Adrienne of the Forest"
+    }, {
+        "id": "5938",
+        "name": "Archmagus Aleister of the Forest"
+    }, {
+        "id": "5961",
+        "name": "Shadow Mage Impy of the Forest"
+    }, {
+        "id": "6322",
+        "name": "Arcanist Hadrien of the Forest"
+    }, {
+        "id": "6419",
+        "name": "Enchanter Leah of the Forest"
+    }, {
+        "id": "6436",
+        "name": "Enchanter Celeste of the Forest"
+    }, {
+        "id": "6729",
+        "name": "Enchanter Calista of the Forest"
+    }, {
+        "id": "6748",
+        "name": "Shadow Mage Cassiopeia of the Forest"
+    }, {
+        "id": "6753",
+        "name": "Druid Goliath of the Forest"
+    }, {
+        "id": "6815",
+        "name": "Archmagus  of the Forest"
+    }, {
+        "id": "6872",
+        "name": "Pyromancer Toby of the Forest"
+    }, {
+        "id": "7123",
+        "name": "Hex Mage Udor of the Forest"
+    }, {
+        "id": "7312",
+        "name": "Cleric Jasper of the Forest"
+    }, {
+        "id": "7321",
+        "name": "Magus Jahid of the Forest"
+    }, {
+        "id": "7458",
+        "name": "Ghost Eater Bogey of the Forest"
+    }, {
+        "id": "7483",
+        "name": "Cosmic Mage Ekmira of the Forest"
+    }, {
+        "id": "7487",
+        "name": "Voodoo Priest Providence of the Forest"
+    }, {
+        "id": "7663",
+        "name": "Circe of the Forest"
+    }, {
+        "id": "7912",
+        "name": "Wild Mage Dante of the Forest"
+    }, {
+        "id": "7922",
+        "name": "Enchanter Chyou of the Forest"
+    }, {
+        "id": "8124",
+        "name": "Battle Mage Tundror of the Forest"
+    }, {
+        "id": "8135",
+        "name": "Aeromancer Herne of the Forest"
+    }, {
+        "id": "8159",
+        "name": "Alchemist Hothor of the Forest"
+    }, {
+        "id": "8284",
+        "name": "Archmagus Celah of the Forest"
+    }, {
+        "id": "8373",
+        "name": "Witch Asphodel of the Forest"
+    }, {
+        "id": "8438",
+        "name": "Augurer Bathsheba of the Forest"
+    }, {
+        "id": "8445",
+        "name": "Shaman Aleister of the Forest"
+    }, {
+        "id": "8470",
+        "name": "Arch-Magician Milo of the Forest"
+    }, {
+        "id": "8612",
+        "name": "Cosmic Mage Adrienne of the Forest"
+    }, {
+        "id": "8719",
+        "name": "Illusionist Magpie of the Forest"
+    }, {
+        "id": "8848",
+        "name": "Geomancer Baozhai of the Forest"
+    }, {
+        "id": "9149",
+        "name": "Alchemist Jadis of the Forest"
+    }, {
+        "id": "9194",
+        "name": "Sage Durm of the Forest"
+    }, {
+        "id": "9198",
+        "name": "Enchanter Faye of the Forest"
+    }, {
+        "id": "9306",
+        "name": "Battle Mage Homer of the Forest"
+    }, {
+        "id": "9532",
+        "name": "Witch Ivy of the Forest"
+    }, {
+        "id": "9539",
+        "name": "Enchanter Arabella of the Forest"
+    }, {
+        "id": "9656",
+        "name": "Sorcerer Chooki of the Forest"
+    }, {
+        "id": "9683",
+        "name": "Sorcerer Silas of the Forest"
+    }, {
+        "id": "9752",
+        "name": "Mystic Aleister of the Forest"
+    }, {
+        "id": "9818",
+        "name": "Hedge Wizard Koop of the Forest"
+    }],
+    "Court": [{
+        "id": "194",
+        "name": "Alchemist George of the Court"
+    }, {
+        "id": "366",
+        "name": "Druid Isaac of the Court"
+    }, {
+        "id": "382",
+        "name": "Battle Mage Blaise of the Court"
+    }, {
+        "id": "440",
+        "name": "Illusionist Ethan of the Court"
+    }, {
+        "id": "605",
+        "name": "Wild Mage Sturgis of the Court"
+    }, {
+        "id": "651",
+        "name": "Sage Pumlo of the Court"
+    }, {
+        "id": "729",
+        "name": "Artificer Hanataka of the Court"
+    }, {
+        "id": "1018",
+        "name": "Alchemist Hadrien of the Court"
+    }, {
+        "id": "1082",
+        "name": "Archmagus Argus of the Court"
+    }, {
+        "id": "1296",
+        "name": "Witch Rita of the Court"
+    }, {
+        "id": "1394",
+        "name": "Archmagus Alessar of the Court"
+    }, {
+        "id": "1439",
+        "name": "Summoner Eden of the Court"
+    }, {
+        "id": "1477",
+        "name": "Enchanter Pandora of the Court"
+    }, {
+        "id": "1554",
+        "name": "Arch-Magician Rafiq of the Court"
+    }, {
+        "id": "2028",
+        "name": "Battle Mage Ratko of the Court"
+    }, {
+        "id": "2088",
+        "name": "Runecaster Ali of the Court"
+    }, {
+        "id": "2091",
+        "name": "Battle Mage Bayard of the Court"
+    }, {
+        "id": "2145",
+        "name": "Wild Mage Ulysse of the Court"
+    }, {
+        "id": "2217",
+        "name": "Sorcerer Ozohr of the Court"
+    }, {
+        "id": "2335",
+        "name": "Enchanter Lumos of the Court"
+    }, {
+        "id": "2820",
+        "name": "Sorcerer Jameel of the Court"
+    }, {
+        "id": "2848",
+        "name": "Artificer Actaeon of the Court"
+    }, {
+        "id": "2901",
+        "name": "Spellsinger Liliana of the Court"
+    }, {
+        "id": "2914",
+        "name": "Artificer Celeste of the Court"
+    }, {
+        "id": "2933",
+        "name": "Druid Ofaris of the Court"
+    }, {
+        "id": "2975",
+        "name": "Archmagus Aleister of the Court"
+    }, {
+        "id": "3041",
+        "name": "Archmagus Alizam of the Court"
+    }, {
+        "id": "3387",
+        "name": "Sorcerer Hadrien of the Court"
+    }, {
+        "id": "3576",
+        "name": "Adept Peppy of the Court"
+    }, {
+        "id": "3705",
+        "name": "Archmagus Amir of the Court"
+    }, {
+        "id": "3816",
+        "name": "Archmagus Iluzor of the Court"
+    }, {
+        "id": "3951",
+        "name": "Battle Mage Khudalf of the Court"
+    }, {
+        "id": "4110",
+        "name": "Ghost Eater Rowena of the Court"
+    }, {
+        "id": "4335",
+        "name": "Enchanter Sondra of the Court"
+    }, {
+        "id": "4363",
+        "name": "Clairvoyant Merlon of the Court"
+    }, {
+        "id": "4420",
+        "name": "Arch-Magician Gil of the Court"
+    }, {
+        "id": "4518",
+        "name": "Arcanist Galatea of the Court"
+    }, {
+        "id": "4592",
+        "name": "Enchanter Cybele of the Court"
+    }, {
+        "id": "5074",
+        "name": "Arcanist Izible of the Court"
+    }, {
+        "id": "5088",
+        "name": "Arch-Magician Ratko of the Court"
+    }, {
+        "id": "5176",
+        "name": "Cosmic Mage Alessar of the Court"
+    }, {
+        "id": "5220",
+        "name": "Pyromancer Hagar of the Court"
+    }, {
+        "id": "5227",
+        "name": "Battle Mage Eric of the Court"
+    }, {
+        "id": "5736",
+        "name": "Arch-Magician Aleister of the Court"
+    }, {
+        "id": "5814",
+        "name": "Sage Bucky of the Court"
+    }, {
+        "id": "6026",
+        "name": "Archmagus Alatar of the Court"
+    }, {
+        "id": "6071",
+        "name": "Druid Kalo of the Court"
+    }, {
+        "id": "6176",
+        "name": "Enchanter Arabella of the Court"
+    }, {
+        "id": "6440",
+        "name": "Illusionist Godfrey of the Court"
+    }, {
+        "id": "6441",
+        "name": "Archmagus Milton of the Court"
+    }, {
+        "id": "6444",
+        "name": "Druid Atlas of the Court"
+    }, {
+        "id": "6916",
+        "name": "George of the Court"
+    }, {
+        "id": "7097",
+        "name": "Mystic Aldus of the Court"
+    }, {
+        "id": "7113",
+        "name": "Archmagus Alessar of the Court"
+    }, {
+        "id": "7189",
+        "name": "Magus Quddus of the Court"
+    }, {
+        "id": "7236",
+        "name": "Hedge Wizard Casper of the Court"
+    }, {
+        "id": "7297",
+        "name": "Shaman Godfrey of the Court"
+    }, {
+        "id": "7463",
+        "name": "Conjurer Jerret of the Court"
+    }, {
+        "id": "7478",
+        "name": "Enchanter Carly of the Court"
+    }, {
+        "id": "7628",
+        "name": "Summoner Silas of the Court"
+    }, {
+        "id": "8105",
+        "name": "Cleric Remus of the Court"
+    }, {
+        "id": "8141",
+        "name": "Archmagus Ofaris of the Court"
+    }, {
+        "id": "8276",
+        "name": "Voodoo Priest Marceau of the Court"
+    }, {
+        "id": "8493",
+        "name": "Witch Sylvia of the Court"
+    }, {
+        "id": "8495",
+        "name": "Druid Jean Leon of the Court"
+    }, {
+        "id": "8508",
+        "name": "Battle Mage Cromwell of the Court"
+    }, {
+        "id": "8697",
+        "name": "Thaumaturge Rowena of the Court"
+    }, {
+        "id": "8781",
+        "name": "Enchanter Talbot of the Court"
+    }, {
+        "id": "8882",
+        "name": "Shadow Mage Nicolas of the Court"
+    }, {
+        "id": "9288",
+        "name": "Archmagus Aleister of the Court"
+    }, {
+        "id": "9618",
+        "name": "Archmagus Soya of the Court"
+    }, {
+        "id": "9646",
+        "name": "Enchanter Sarah of the Court"
+    }, {
+        "id": "9836",
+        "name": "Archmagus Soya of the Court"
+    }, {
+        "id": "9924",
+        "name": "Void Disciple Faustus of the Court"
+    }, {
+        "id": "9942",
+        "name": "Thaumaturge Iprix of the Court"
+    }, {
+        "id": "9998",
+        "name": "Hydromancer Robert of the Court"
+    }],
+    "Inferno": [{
+        "id": "131",
+        "name": "Shadow Mage Alessar of the Inferno"
+    }, {
+        "id": "243",
+        "name": "Archmagus Remus of the Inferno"
+    }, {
+        "id": "622",
+        "name": "Cosmic Mage Winter Squash of the Inferno"
+    }, {
+        "id": "670",
+        "name": "Enchanter Eden of the Inferno"
+    }, {
+        "id": "1028",
+        "name": "Sorcerer Aleister of the Inferno"
+    }, {
+        "id": "1252",
+        "name": "Electromancer Hanataka of the Inferno"
+    }, {
+        "id": "1295",
+        "name": "Witch Rowena of the Inferno"
+    }, {
+        "id": "1981",
+        "name": "Archmagus Crowley of the Inferno"
+    }, {
+        "id": "2048",
+        "name": "Mystic Jeldor of the Inferno"
+    }, {
+        "id": "2117",
+        "name": "Archmagus Eizo of the Inferno"
+    }, {
+        "id": "2697",
+        "name": "Sorcerer Cairon of the Inferno"
+    }, {
+        "id": "3323",
+        "name": "Archmagus Zelroth of the Inferno"
+    }, {
+        "id": "3785",
+        "name": "Arch-Magician Tengu of the Inferno"
+    }, {
+        "id": "3935",
+        "name": "Magus Herne of the Inferno"
+    }, {
+        "id": "4095",
+        "name": "Druid Impy of the Inferno"
+    }, {
+        "id": "4100",
+        "name": "Sorcerer Remus of the Inferno"
+    }, {
+        "id": "4146",
+        "name": "Sorcerer Gogol of the Inferno"
+    }, {
+        "id": "4626",
+        "name": "Electromancer Iprix of the Inferno"
+    }, {
+        "id": "4917",
+        "name": "Magus Woomba of the Inferno"
+    }, {
+        "id": "5459",
+        "name": "Diabolist Jay of the Inferno"
+    }, {
+        "id": "5575",
+        "name": "Alchemist Cosmo of the Inferno"
+    }, {
+        "id": "6821",
+        "name": "Battlemage Pierre of the Inferno"
+    }, {
+        "id": "7770",
+        "name": "Hedge Wizard Beyna of the Inferno"
+    }, {
+        "id": "7854",
+        "name": "Sorcerer Uday of the Inferno"
+    }, {
+        "id": "7876",
+        "name": "Chaos Mage Jerret of the Inferno"
+    }, {
+        "id": "7986",
+        "name": "Ghost Eater Black Goat of the Inferno"
+    }, {
+        "id": "8051",
+        "name": "Electromancer Milton of the Inferno"
+    }, {
+        "id": "8593",
+        "name": "Witch Gino of the Inferno"
+    }, {
+        "id": "9083",
+        "name": "Solar Mage Crowley of the Inferno"
+    }, {
+        "id": "9426",
+        "name": "Mystic Magnus of the Inferno"
+    }],
+    "Temple": [{
+        "id": "127",
+        "name": "Pyromancer Rodolfo of the Temple"
+    }, {
+        "id": "221",
+        "name": "Mystic Merlon of the Temple"
+    }, {
+        "id": "783",
+        "name": "Summoner Milton of the Temple"
+    }, {
+        "id": "1094",
+        "name": "Adept Gil of the Temple"
+    }, {
+        "id": "1213",
+        "name": "Wild Mage Basil of the Temple"
+    }, {
+        "id": "1294",
+        "name": "Sorcerer Uday of the Temple"
+    }, {
+        "id": "1408",
+        "name": "Thaumaturge Godfrey of the Temple"
+    }, {
+        "id": "1655",
+        "name": "Zelroth of the Temple"
+    }, {
+        "id": "1764",
+        "name": "Evoker Angus of the Temple"
+    }, {
+        "id": "1969",
+        "name": "Adept Soya of the Temple"
+    }, {
+        "id": "1982",
+        "name": "Archmagus Lumos of the Temple"
+    }, {
+        "id": "2485",
+        "name": "Chaos Mage Uvlius of the Temple"
+    }, {
+        "id": "2535",
+        "name": "Shaman Marceau of the Temple"
+    }, {
+        "id": "3491",
+        "name": "Druid Gourdon of the Temple"
+    }, {
+        "id": "3496",
+        "name": "Hex Mage Apollo of the Temple"
+    }, {
+        "id": "3524",
+        "name": "Sorcerer Soran of the Temple"
+    }, {
+        "id": "3630",
+        "name": "Battle Mage Darick of the Temple"
+    }, {
+        "id": "3820",
+        "name": "Thaumaturge Amir of the Temple"
+    }, {
+        "id": "3822",
+        "name": "Magus Hongo of the Temple"
+    }, {
+        "id": "3906",
+        "name": "Battle Mage Tundror of the Temple"
+    }, {
+        "id": "4023",
+        "name": "Magus Sahir of the Temple"
+    }, {
+        "id": "4127",
+        "name": "Archmagus Ofaris of the Temple"
+    }, {
+        "id": "4167",
+        "name": "Cosmic Mage Alatar of the Temple"
+    }, {
+        "id": "4174",
+        "name": "Aeromancer Qianfan of the Temple"
+    }, {
+        "id": "4278",
+        "name": "Sage Nikolas of the Temple"
+    }, {
+        "id": "4544",
+        "name": "Sage Corvin of the Temple"
+    }, {
+        "id": "4670",
+        "name": "Mina of the Temple"
+    }, {
+        "id": "4819",
+        "name": "Pyromancer Borak of the Temple"
+    }, {
+        "id": "4979",
+        "name": "Diviner Arabella of the Temple"
+    }, {
+        "id": "5122",
+        "name": "Battle Mage Bayard of the Temple"
+    }, {
+        "id": "5155",
+        "name": "Evoker Rook of the Temple"
+    }, {
+        "id": "5173",
+        "name": "Arcanist Woomba of the Temple"
+    }, {
+        "id": "5229",
+        "name": "Druid Hashim of the Temple"
+    }, {
+        "id": "5307",
+        "name": "Voodoo Priest Eliphas of the Temple"
+    }, {
+        "id": "5340",
+        "name": "Runecaster George of the Temple"
+    }, {
+        "id": "5365",
+        "name": "Evoker Eden of the Temple"
+    }, {
+        "id": "5409",
+        "name": "Sorcerer Zafar of the Temple"
+    }, {
+        "id": "5436",
+        "name": "Arcanist Chandler of the Temple"
+    }, {
+        "id": "5574",
+        "name": "Battle Mage Aslan of the Temple"
+    }, {
+        "id": "5715",
+        "name": "Cosmic Mage Isaac of the Temple"
+    }, {
+        "id": "5926",
+        "name": "Sorcerer Soya of the Temple"
+    }, {
+        "id": "5934",
+        "name": "Artificer Eden of the Temple"
+    }, {
+        "id": "5936",
+        "name": "Battle Mage Wolfram of the Temple"
+    }, {
+        "id": "6038",
+        "name": "Archmagus Merlon of the Temple"
+    }, {
+        "id": "6488",
+        "name": "Archmagus Silas of the Temple"
+    }, {
+        "id": "6835",
+        "name": "Geomancer Bullock of the Temple"
+    }, {
+        "id": "6839",
+        "name": "Artificer Uvlius of the Temple"
+    }, {
+        "id": "6925",
+        "name": "Battle Mage Hothor of the Temple"
+    }, {
+        "id": "6943",
+        "name": "Electromancer Gellert of the Temple"
+    }, {
+        "id": "7024",
+        "name": "Hedge Wizard Durm of the Temple"
+    }, {
+        "id": "7064",
+        "name": "Druid Shivra of the Temple"
+    }, {
+        "id": "7204",
+        "name": "Magus George of the Temple"
+    }, {
+        "id": "7254",
+        "name": "Geomancer Rook of the Temple"
+    }, {
+        "id": "7275",
+        "name": "Archmagus Zubin of the Temple"
+    }, {
+        "id": "7324",
+        "name": "Battle Mage Tundror of the Temple"
+    }, {
+        "id": "7394",
+        "name": "Archmagus Ixar of the Temple"
+    }, {
+        "id": "7412",
+        "name": "Chronomancer Zorko of the Temple"
+    }, {
+        "id": "7502",
+        "name": "Archmagus Eronin of the Temple"
+    }, {
+        "id": "7510",
+        "name": "Cleric Sturgis of the Temple"
+    }, {
+        "id": "7558",
+        "name": "Sorcerer Nikolas of the Temple"
+    }, {
+        "id": "7767",
+        "name": "Aeromancer Davos of the Temple"
+    }, {
+        "id": "8007",
+        "name": "Cleric Flynn of the Temple"
+    }, {
+        "id": "8180",
+        "name": "Hedge Wizard Beyna of the Temple"
+    }, {
+        "id": "8342",
+        "name": "Archmagus Soya of the Temple"
+    }, {
+        "id": "8353",
+        "name": "Artificer Bao of the Temple"
+    }, {
+        "id": "8363",
+        "name": "Witch Rita of the Temple"
+    }, {
+        "id": "8507",
+        "name": "Necromancer Thoth of the Temple"
+    }, {
+        "id": "8644",
+        "name": "Archmagus Zelroth of the Temple"
+    }, {
+        "id": "8772",
+        "name": "Pyromancer Arabella of the Temple"
+    }, {
+        "id": "8789",
+        "name": "Magus Danny of the Temple"
+    }, {
+        "id": "8861",
+        "name": "Shadow Mage Caligula of the Temple"
+    }, {
+        "id": "9090",
+        "name": "Sage Pan of the Temple"
+    }, {
+        "id": "9743",
+        "name": "Archmagus Uvlius of the Temple"
+    }, {
+        "id": "9828",
+        "name": "Archmagus Uvlius of the Temple"
+    }],
+    "Limbo": [{
+        "id": "926",
+        "name": "Soran of Limbo"
+    }, {
+        "id": "2262",
+        "name": "Runecaster Ozohr of Limbo"
+    }, {
+        "id": "2648",
+        "name": "Voodoo Priest Baptiste of Limbo"
+    }, {
+        "id": "2750",
+        "name": "Runecaster Lucien of Limbo"
+    }, {
+        "id": "3298",
+        "name": "Magus George of Limbo"
+    }, {
+        "id": "3456",
+        "name": "Adept Udor of Limbo"
+    }, {
+        "id": "3528",
+        "name": "Sorcerer Salah of Limbo"
+    }, {
+        "id": "3786",
+        "name": "Aleister of Limbo"
+    }, {
+        "id": "3797",
+        "name": "Archmagus  of Limbo"
+    }, {
+        "id": "4024",
+        "name": "Arch-Magician Aleister of Limbo"
+    }, {
+        "id": "4360",
+        "name": "Merlon of Limbo"
+    }, {
+        "id": "4362",
+        "name": "Sorcerer Moloch of Limbo"
+    }, {
+        "id": "4519",
+        "name": "Hedge Wizard Luther of Limbo"
+    }, {
+        "id": "5081",
+        "name": "Sage Soran of Limbo"
+    }, {
+        "id": "5423",
+        "name": "Spellsinger Arabella of Limbo"
+    }, {
+        "id": "5720",
+        "name": "Archmagus Casper of Limbo"
+    }, {
+        "id": "6738",
+        "name": "Sorcerer Eden of Limbo"
+    }, {
+        "id": "7527",
+        "name": "Hex Mage Cassandra of Limbo"
+    }, {
+        "id": "7762",
+        "name": "Artificer Udor of Limbo"
+    }, {
+        "id": "7915",
+        "name": "Artificer Yog-Sothoth of Limbo"
+    }, {
+        "id": "8200",
+        "name": "Alchemist Keziah of Limbo"
+    }, {
+        "id": "8733",
+        "name": "Jeldor of Limbo"
+    }, {
+        "id": "9377",
+        "name": "Cleric Durm of Limbo"
+    }],
+    "Fey": [{
+        "id": "123",
+        "name": "Charmer Circe of the Fey"
+    }, {
+        "id": "309",
+        "name": "Adept Darick of the Fey"
+    }, {
+        "id": "446",
+        "name": "Hedge Wizard Peter of the Fey"
+    }, {
+        "id": "893",
+        "name": "Orpheus of the Fey"
+    }, {
+        "id": "956",
+        "name": "Conjurer Takao of the Fey"
+    }, {
+        "id": "959",
+        "name": "Holy Monk Drokore of the Fey"
+    }, {
+        "id": "1081",
+        "name": "David of the Fey"
+    }, {
+        "id": "1180",
+        "name": "Druid Samuel of the Fey"
+    }, {
+        "id": "1246",
+        "name": "Ghost Eater Trollin of the Fey"
+    }, {
+        "id": "1291",
+        "name": "Alchemist Ursula of the Fey"
+    }, {
+        "id": "1712",
+        "name": "Arch-Magician Aleister of the Fey"
+    }, {
+        "id": "1772",
+        "name": "Sage Cairon of the Fey"
+    }, {
+        "id": "1847",
+        "name": "Arch-Magician Lucinda of the Fey"
+    }, {
+        "id": "1925",
+        "name": "Shaman Shanyuan of the Fey"
+    }, {
+        "id": "2199",
+        "name": "Pyromancer Uvlius of the Fey"
+    }, {
+        "id": "2375",
+        "name": "Archmagus Alatar of the Fey"
+    }, {
+        "id": "2553",
+        "name": "Magus Wolfram of the Fey"
+    }, {
+        "id": "2644",
+        "name": "Pyromancer Sisk of the Fey"
+    }, {
+        "id": "2879",
+        "name": "Battle Mage Robert of the Fey"
+    }, {
+        "id": "3271",
+        "name": "Summoner Rita of the Fey"
+    }, {
+        "id": "3334",
+        "name": "Enchanter Atlanta of the Fey"
+    }, {
+        "id": "3425",
+        "name": "Sorcerer Merlon of the Fey"
+    }, {
+        "id": "3436",
+        "name": "Hedge Wizard Fredo of the Fey"
+    }, {
+        "id": "3620",
+        "name": "Magus Sahir of the Fey"
+    }, {
+        "id": "3693",
+        "name": "Arcanist Allistair of the Fey"
+    }, {
+        "id": "3767",
+        "name": "Arcanist Caligari of the Fey"
+    }, {
+        "id": "3842",
+        "name": "Arch-Magician Zubin of the Fey"
+    }, {
+        "id": "4189",
+        "name": "Enchanter Calista of the Fey"
+    }, {
+        "id": "4408",
+        "name": "Sorcerer Hadrien of the Fey"
+    }, {
+        "id": "4612",
+        "name": "Magus Poppy of the Fey"
+    }, {
+        "id": "4821",
+        "name": "Arcanist Udor of the Fey"
+    }, {
+        "id": "4971",
+        "name": "Arch-Magician Mace of the Fey"
+    }, {
+        "id": "5162",
+        "name": "Ghost Eater Lenora of the Fey"
+    }, {
+        "id": "5626",
+        "name": "Archmagus Atlanta of the Fey"
+    }, {
+        "id": "5659",
+        "name": "Evoker Angus of the Fey"
+    }, {
+        "id": "5790",
+        "name": "Archmagus Jerret of the Fey"
+    }, {
+        "id": "5842",
+        "name": "Sorcerer Alatar of the Fey"
+    }, {
+        "id": "6003",
+        "name": "Chaos Mage Setsuko of the Fey"
+    }, {
+        "id": "6172",
+        "name": "Enchanter Remus of the Fey"
+    }, {
+        "id": "6484",
+        "name": "Shaman Azahl of the Fey"
+    }, {
+        "id": "6501",
+        "name": "Arch-Magician Izible of the Fey"
+    }, {
+        "id": "6608",
+        "name": "David of the Fey"
+    }, {
+        "id": "6702",
+        "name": "Cosmic Mage Soya of the Fey"
+    }, {
+        "id": "6708",
+        "name": "Archmagus Basil of the Fey"
+    }, {
+        "id": "6787",
+        "name": "Battle Mage Durm of the Fey"
+    }, {
+        "id": "6908",
+        "name": "Spellsinger Charlie of the Fey"
+    }, {
+        "id": "7226",
+        "name": "Necromancer Anton of the Fey"
+    }, {
+        "id": "7314",
+        "name": "Sorcerer Alizam of the Fey"
+    }, {
+        "id": "7513",
+        "name": "Holy Monk Onaxx of the Fey"
+    }, {
+        "id": "7642",
+        "name": "Druid Hothor of the Fey"
+    }, {
+        "id": "7836",
+        "name": "Holy Monk Mace of the Fey"
+    }, {
+        "id": "8081",
+        "name": "Enchanter Cassiopeia of the Fey"
+    }, {
+        "id": "8130",
+        "name": "Enchanter Diana of the Fey"
+    }, {
+        "id": "8282",
+        "name": "Battle Mage Bayard of the Fey"
+    }, {
+        "id": "8531",
+        "name": "Battle Mage Magnus of the Fey"
+    }, {
+        "id": "8628",
+        "name": "Shadow Mage Baird of the Fey"
+    }, {
+        "id": "8633",
+        "name": "Cleric Diana of the Fey"
+    }, {
+        "id": "8679",
+        "name": "Sorcerer Ilyas of the Fey"
+    }, {
+        "id": "9335",
+        "name": "Battle Mage Durm of the Fey"
+    }, {
+        "id": "9442",
+        "name": "Archmagus Hind of the Fey"
+    }, {
+        "id": "9676",
+        "name": "Archmagus Adium of the Fey"
+    }, {
+        "id": "9726",
+        "name": "Arcanist Quddus of the Fey"
+    }, {
+        "id": "9812",
+        "name": "Alchemist Danny of the Fey"
+    }, {
+        "id": "9847",
+        "name": "Enchanter Larissa of the Fey"
+    }],
+    "Surf": [{
+        "id": "1440",
+        "name": "Witch David of the Surf"
+    }, {
+        "id": "1509",
+        "name": "Battle Mage Bayard of the Surf"
+    }, {
+        "id": "1549",
+        "name": "Artificer Kingsley of the Surf"
+    }, {
+        "id": "1630",
+        "name": "Hydromancer Qasim of the Surf"
+    }, {
+        "id": "1997",
+        "name": "Arcanist Shigenjo of the Surf"
+    }, {
+        "id": "2336",
+        "name": "Archmagus Oberon of the Surf"
+    }, {
+        "id": "3252",
+        "name": "Battle Mage Aslan of the Surf"
+    }, {
+        "id": "3261",
+        "name": "Sage Numpty of the Surf"
+    }, {
+        "id": "3563",
+        "name": "Battle Mage Tundror of the Surf"
+    }, {
+        "id": "3850",
+        "name": "Diviner Meloogen of the Surf"
+    }, {
+        "id": "4286",
+        "name": "Alchemist Bobbin of the Surf"
+    }, {
+        "id": "5289",
+        "name": "Remus of the Surf"
+    }, {
+        "id": "5577",
+        "name": "Battlemage Delilah of the Surf"
+    }, {
+        "id": "5637",
+        "name": "Battle Mage Cromwell of the Surf"
+    }, {
+        "id": "6074",
+        "name": "Enchanter Artis of the Surf"
+    }, {
+        "id": "6332",
+        "name": "Runecaster Diabolos of the Surf"
+    }, {
+        "id": "6953",
+        "name": "Fortune Teller George of the Surf"
+    }, {
+        "id": "6984",
+        "name": "Enchanter Daria of the Surf"
+    }, {
+        "id": "7783",
+        "name": "Artificer Mushy of the Surf"
+    }, {
+        "id": "8265",
+        "name": "Aeromancer Asmodeus of the Surf"
+    }, {
+        "id": "8631",
+        "name": "Shaman Edge of the Surf"
+    }, {
+        "id": "8810",
+        "name": "Summoner Hadrien of the Surf"
+    }, {
+        "id": "8901",
+        "name": "Oracle Ixar of the Surf"
+    }, {
+        "id": "9238",
+        "name": "Magus Rafiq of the Surf"
+    }, {
+        "id": "9578",
+        "name": "Enchanter Carly of the Surf"
+    }, {
+        "id": "9872",
+        "name": "Sage Bayard of the Surf"
+    }],
+    "North": [{
+        "id": "392",
+        "name": "Archmagus Eric of the North"
+    }, {
+        "id": "1413",
+        "name": "Ice Mage Brutus of the North"
+    }, {
+        "id": "1482",
+        "name": "Ice Mage Porto of the North"
+    }, {
+        "id": "2373",
+        "name": "Archmagus Zaros of the North"
+    }, {
+        "id": "2783",
+        "name": "Charmer Lamia of the North"
+    }, {
+        "id": "3622",
+        "name": "Magus Ivy of the North"
+    }, {
+        "id": "3778",
+        "name": "Magus Gogol of the North"
+    }, {
+        "id": "4002",
+        "name": "Ice Mage Nolan of the North"
+    }, {
+        "id": "5407",
+        "name": "Hedge Wizard Diabolos of the North"
+    }, {
+        "id": "5516",
+        "name": "Arcanist Providence of the North"
+    }, {
+        "id": "5541",
+        "name": "Shaman Celeste of the North"
+    }, {
+        "id": "5701",
+        "name": "Illusionist Rowena of the North"
+    }, {
+        "id": "5905",
+        "name": "Ice Mage Delilah of the North"
+    }, {
+        "id": "6233",
+        "name": "Archmagus Solomon of the North"
+    }, {
+        "id": "6759",
+        "name": "Witch Gwendolin of the North"
+    }, {
+        "id": "7129",
+        "name": "Hex Mage Zaros of the North"
+    }, {
+        "id": "7261",
+        "name": "Sage Layla of the North"
+    }, {
+        "id": "7700",
+        "name": "Battle Mage Magnus of the North"
+    }, {
+        "id": "7709",
+        "name": "Aeromancer Kryll of the North"
+    }, {
+        "id": "7764",
+        "name": "Ice Mage Chromo of the North"
+    }, {
+        "id": "7999",
+        "name": "Arch-Magician Zane of the North"
+    }, {
+        "id": "8956",
+        "name": "Devon of the North"
+    }, {
+        "id": "9140",
+        "name": "Evoker Axel of the North"
+    }, {
+        "id": "9577",
+        "name": "Arcanist Caligula of the North"
+    }],
+    "Obelisk": [{
+        "id": "630",
+        "name": "Holy Monk Eronin of the Obelisk"
+    }, {
+        "id": "883",
+        "name": "Aeromancer Min of the Obelisk"
+    }, {
+        "id": "949",
+        "name": "Arch-Magician Aslan of the Obelisk"
+    }, {
+        "id": "1130",
+        "name": "Illusionist Hobbs of the Obelisk"
+    }, {
+        "id": "1143",
+        "name": "Cryptomancer Aleister of the Obelisk"
+    }, {
+        "id": "1380",
+        "name": "Chronomancer Zane of the Obelisk"
+    }, {
+        "id": "1383",
+        "name": "Arcanist Soran of the Obelisk"
+    }, {
+        "id": "1420",
+        "name": "Illusionist Huizhong of the Obelisk"
+    }, {
+        "id": "1703",
+        "name": "Electromancer Gully of the Obelisk"
+    }, {
+        "id": "1967",
+        "name": "Sorcerer Oberon of the Obelisk"
+    }, {
+        "id": "2447",
+        "name": "Alchemist Malthus of the Obelisk"
+    }, {
+        "id": "2591",
+        "name": "Holy Monk Damien of the Obelisk"
+    }, {
+        "id": "3148",
+        "name": "Archmagus Merlon of the Obelisk"
+    }, {
+        "id": "3197",
+        "name": "Pyromancer Ivy of the Obelisk"
+    }, {
+        "id": "3312",
+        "name": "Shaman Thor of the Obelisk"
+    }, {
+        "id": "3534",
+        "name": "Chaos Mage Soran of the Obelisk"
+    }, {
+        "id": "3569",
+        "name": "Magus Isaac of the Obelisk"
+    }, {
+        "id": "3754",
+        "name": "Ixar of the Obelisk"
+    }, {
+        "id": "3770",
+        "name": "Hedge Wizard Tabitha of the Obelisk"
+    }, {
+        "id": "3887",
+        "name": "Archmagus Hagar of the Obelisk"
+    }, {
+        "id": "3889",
+        "name": "Archmagus Aleister of the Obelisk"
+    }, {
+        "id": "3898",
+        "name": "Celah of the Obelisk"
+    }, {
+        "id": "3928",
+        "name": "Arch-Magician Caligari of the Obelisk"
+    }, {
+        "id": "3930",
+        "name": "Battlemage Drako of the Obelisk"
+    }, {
+        "id": "3963",
+        "name": "Pyromancer Amir of the Obelisk"
+    }, {
+        "id": "4487",
+        "name": "Enchanter Carly of the Obelisk"
+    }, {
+        "id": "4606",
+        "name": "Magus Jerret of the Obelisk"
+    }, {
+        "id": "4638",
+        "name": "Sorcerer Tumbaj of the Obelisk"
+    }, {
+        "id": "4678",
+        "name": "Adept Merlon of the Obelisk"
+    }, {
+        "id": "4767",
+        "name": "Magus Trollin of the Obelisk"
+    }, {
+        "id": "4790",
+        "name": "Witch Rita of the Obelisk"
+    }, {
+        "id": "4822",
+        "name": "Sorcerer Jahid of the Obelisk"
+    }, {
+        "id": "4880",
+        "name": "Cryptomancer Remus of the Obelisk"
+    }, {
+        "id": "5256",
+        "name": "Cleric Aldus of the Obelisk"
+    }, {
+        "id": "5382",
+        "name": "Sorcerer Ali of the Obelisk"
+    }, {
+        "id": "5518",
+        "name": "Enchanter Celah of the Obelisk"
+    }, {
+        "id": "5582",
+        "name": "Enchanter Thana of the Obelisk"
+    }, {
+        "id": "5666",
+        "name": "Hydromancer Cassiopeia of the Obelisk"
+    }, {
+        "id": "5909",
+        "name": "Aeromancer Impy of the Obelisk"
+    }, {
+        "id": "6007",
+        "name": "Enchanter Shanyuan of the Obelisk"
+    }, {
+        "id": "6048",
+        "name": "Alchemist Koop of the Obelisk"
+    }, {
+        "id": "6223",
+        "name": "Druid Orlando of the Obelisk"
+    }, {
+        "id": "6227",
+        "name": "Alchemist Leah of the Obelisk"
+    }, {
+        "id": "6352",
+        "name": "Geomancer Suki of the Obelisk"
+    }, {
+        "id": "6639",
+        "name": "Summoner Tumbaj of the Obelisk"
+    }, {
+        "id": "6703",
+        "name": "Medium Delilah of the Obelisk"
+    }, {
+        "id": "6792",
+        "name": "Chronomancer Peppy of the Obelisk"
+    }, {
+        "id": "6891",
+        "name": "Bard Elena of the Obelisk"
+    }, {
+        "id": "6945",
+        "name": "Artificer Magnus of the Obelisk"
+    }, {
+        "id": "7019",
+        "name": "Necromancer Azazel of the Obelisk"
+    }, {
+        "id": "7107",
+        "name": "Magus Jaffer of the Obelisk"
+    }, {
+        "id": "7171",
+        "name": "Witch Jezebel of the Obelisk"
+    }, {
+        "id": "7622",
+        "name": "Aeromancer George of the Obelisk"
+    }, {
+        "id": "7745",
+        "name": "Battle Mage Axel of the Obelisk"
+    }, {
+        "id": "7832",
+        "name": "Enchanter Milo of the Obelisk"
+    }, {
+        "id": "8023",
+        "name": "Arcanist Ixar of the Obelisk"
+    }, {
+        "id": "8099",
+        "name": "Hedge Wizard Qasim of the Obelisk"
+    }, {
+        "id": "8106",
+        "name": "Magus Dutorn of the Obelisk"
+    }, {
+        "id": "8212",
+        "name": "Archmagus Oberon of the Obelisk"
+    }, {
+        "id": "8377",
+        "name": "Arch-Magician Taqi of the Obelisk"
+    }, {
+        "id": "8389",
+        "name": "Arcanist Goober of the Obelisk"
+    }, {
+        "id": "8630",
+        "name": "Battlemage Pezo of the Obelisk"
+    }, {
+        "id": "8677",
+        "name": "Shadow Mage Cassandra of the Obelisk"
+    }, {
+        "id": "8761",
+        "name": "Arcanist Hadrien of the Obelisk"
+    }, {
+        "id": "8884",
+        "name": "Sorcerer Remus of the Obelisk"
+    }, {
+        "id": "8913",
+        "name": "Shadow Mage Hadrien of the Obelisk"
+    }, {
+        "id": "8966",
+        "name": "Chronomancer Shanyuan of the Obelisk"
+    }, {
+        "id": "9157",
+        "name": "Archmagus Crowley of the Obelisk"
+    }, {
+        "id": "9183",
+        "name": "Diabolist Dario of the Obelisk"
+    }, {
+        "id": "9261",
+        "name": "Archmagus Crowley of the Obelisk"
+    }, {
+        "id": "9304",
+        "name": "Celah of the Obelisk"
+    }, {
+        "id": "9526",
+        "name": "Geomancer Jastor of the Obelisk"
+    }, {
+        "id": "9748",
+        "name": "Sorcerer Hashim of the Obelisk"
+    }, {
+        "id": "9813",
+        "name": "Magus Udor of the Obelisk"
+    }],
+    "Arctic": [{
+        "id": "1329",
+        "name": "Ice Mage Cullen of the Arctic"
+    }, {
+        "id": "2665",
+        "name": "Magus Chooki of the Arctic"
+    }, {
+        "id": "2713",
+        "name": "Ice Mage Aiko of the Arctic"
+    }, {
+        "id": "3683",
+        "name": "Hedge Wizard Rowena of the Arctic"
+    }, {
+        "id": "3944",
+        "name": "Sorcerer Soya of the Arctic"
+    }, {
+        "id": "3974",
+        "name": "Ice Mage Enzo of the Arctic"
+    }, {
+        "id": "4446",
+        "name": "Thaumaturge Basil of the Arctic"
+    }, {
+        "id": "4884",
+        "name": "Oracle Angus of the Arctic"
+    }, {
+        "id": "5433",
+        "name": "Battle Mage Homer of the Arctic"
+    }, {
+        "id": "5497",
+        "name": "Witch Ophelia of the Arctic"
+    }, {
+        "id": "6297",
+        "name": "Sage Aslan of the Arctic"
+    }, {
+        "id": "7016",
+        "name": "Enchanter Victoria of the Arctic"
+    }, {
+        "id": "7577",
+        "name": "Battlemage Hagar of the Arctic"
+    }, {
+        "id": "7623",
+        "name": "Archmagus Wolfram of the Arctic"
+    }, {
+        "id": "7728",
+        "name": "Alchemist Hagar of the Arctic"
+    }, {
+        "id": "8382",
+        "name": "Arcanist Cassiopeia of the Arctic"
+    }, {
+        "id": "8684",
+        "name": "Oracle Homer of the Arctic"
+    }, {
+        "id": "8859",
+        "name": "Illusionist  of the Arctic"
+    }, {
+        "id": "8928",
+        "name": "Hedge Wizard Hadrien of the Arctic"
+    }, {
+        "id": "9400",
+        "name": "Archmagus Soran of the Arctic"
+    }, {
+        "id": "9417",
+        "name": "Wild Mage Azahl of the Arctic"
+    }, {
+        "id": "9849",
+        "name": "Archmagus Baptiste of the Arctic"
+    }],
+    "Expanse": [{
+        "id": "2131",
+        "name": "Adept Homer of the Expanse"
+    }, {
+        "id": "2649",
+        "name": "Aeromancer Squiddly of the Expanse"
+    }, {
+        "id": "2802",
+        "name": "Sorcerer Ofaris of the Expanse"
+    }, {
+        "id": "3648",
+        "name": "Ice Mage Horace of the Expanse"
+    }, {
+        "id": "3745",
+        "name": "Ice Mage Cromwell of the Expanse"
+    }, {
+        "id": "4502",
+        "name": "Ice Mage Victor of the Expanse"
+    }, {
+        "id": "5190",
+        "name": "Voodoo Priest Nolan of the Expanse"
+    }, {
+        "id": "5242",
+        "name": "Ice Mage Zubin of the Expanse"
+    }, {
+        "id": "5559",
+        "name": "Summoner Baird of the Expanse"
+    }, {
+        "id": "5598",
+        "name": "Ice Mage Sonja of the Expanse"
+    }, {
+        "id": "5694",
+        "name": "Sorcerer Orpheus of the Expanse"
+    }, {
+        "id": "6604",
+        "name": "Sorcerer George of the Expanse"
+    }, {
+        "id": "6649",
+        "name": "Oracle Oberon of the Expanse"
+    }, {
+        "id": "7105",
+        "name": "Druid Chanterelle of the Expanse"
+    }, {
+        "id": "7757",
+        "name": "Druid Udor of the Expanse"
+    }, {
+        "id": "7885",
+        "name": "Cairon of the Expanse"
+    }, {
+        "id": "9616",
+        "name": "Argus of the Expanse"
+    }, {
+        "id": "9742",
+        "name": "Ice Mage Nori of the Expanse"
+    }],
+    "Glacier": [{
+        "id": "850",
+        "name": "Illusionist Ozohr of the Glacier"
+    }, {
+        "id": "874",
+        "name": "Enchanter Danny of the Glacier"
+    }, {
+        "id": "976",
+        "name": "Necromancer Nemo of the Glacier"
+    }, {
+        "id": "1870",
+        "name": "Orpheus of the Glacier"
+    }, {
+        "id": "2259",
+        "name": "Runecaster Hagar of the Glacier"
+    }, {
+        "id": "2637",
+        "name": "Archmagus Robert of the Glacier"
+    }, {
+        "id": "3186",
+        "name": "Geomancer Bayard of the Glacier"
+    }, {
+        "id": "3354",
+        "name": "Mystic Blaise of the Glacier"
+    }, {
+        "id": "3488",
+        "name": "Artificer Cromwell of the Glacier"
+    }, {
+        "id": "3565",
+        "name": "Sorcerer Hadrien of the Glacier"
+    }, {
+        "id": "4616",
+        "name": "Arcanist Rowena of the Glacier"
+    }, {
+        "id": "5257",
+        "name": "Shaman Hothor of the Glacier"
+    }, {
+        "id": "6653",
+        "name": "Diabolist Ulysse of the Glacier"
+    }, {
+        "id": "7590",
+        "name": "Ice Mage Kazud of the Glacier"
+    }, {
+        "id": "7612",
+        "name": "Druid Baird of the Glacier"
+    }, {
+        "id": "7819",
+        "name": "Ice Mage Eric of the Glacier"
+    }, {
+        "id": "7830",
+        "name": "Battle Mage Hagar of the Glacier"
+    }, {
+        "id": "8567",
+        "name": "Ice Mage Zubin of the Glacier"
+    }, {
+        "id": "8925",
+        "name": "Evoker Amir of the Glacier"
+    }, {
+        "id": "9291",
+        "name": "Battle Mage Hagar of the Glacier"
+    }],
+    "Sun": [{
+        "id": "104",
+        "name": "Sky Master JackDaw of the Sun"
+    }, {
+        "id": "149",
+        "name": "Archmagus Akron of the Sun"
+    }, {
+        "id": "154",
+        "name": "Druid Soya of the Sun"
+    }, {
+        "id": "172",
+        "name": "Transmuter Alessar of the Sun"
+    }, {
+        "id": "251",
+        "name": "Battle Mage Blaise of the Sun"
+    }, {
+        "id": "328",
+        "name": "Thaumaturge Aldus of the Sun"
+    }, {
+        "id": "422",
+        "name": "Illusionist Xiaobo of the Sun"
+    }, {
+        "id": "535",
+        "name": "Alchemist Goliath of the Sun"
+    }, {
+        "id": "613",
+        "name": "Sorcerer Basil of the Sun"
+    }, {
+        "id": "685",
+        "name": "Arch-Magician Edge of the Sun"
+    }, {
+        "id": "848",
+        "name": "Alchemist Oberon of the Sun"
+    }, {
+        "id": "1162",
+        "name": "Sorcerer Faiz of the Sun"
+    }, {
+        "id": "1254",
+        "name": "Salvatore of the Sun"
+    }, {
+        "id": "1270",
+        "name": "Sorcerer Casper of the Sun"
+    }, {
+        "id": "1320",
+        "name": "Arcanist Gully of the Sun"
+    }, {
+        "id": "1374",
+        "name": "Artificer Jerret of the Sun"
+    }, {
+        "id": "1565",
+        "name": "Ghost Eater Ethan of the Sun"
+    }, {
+        "id": "1637",
+        "name": "Cleric Caligula of the Sun"
+    }, {
+        "id": "1767",
+        "name": "Void Disciple Jasper of the Sun"
+    }, {
+        "id": "1832",
+        "name": "Shadow Mage Idris of the Sun"
+    }, {
+        "id": "1844",
+        "name": "Artificer Xiaobo of the Sun"
+    }, {
+        "id": "1850",
+        "name": "Lux of the Sun"
+    }, {
+        "id": "1971",
+        "name": "Wild Mage Chooki of the Sun"
+    }, {
+        "id": "1972",
+        "name": "Runecaster Milton of the Sun"
+    }, {
+        "id": "1991",
+        "name": "Sorcerer Jerret of the Sun"
+    }, {
+        "id": "2150",
+        "name": "Arch-Magician Bao of the Sun"
+    }, {
+        "id": "2294",
+        "name": "Charmer Arabella of the Sun"
+    }, {
+        "id": "2330",
+        "name": "Archmagus Milo of the Sun"
+    }, {
+        "id": "2332",
+        "name": "Archmagus Ronald of the Sun"
+    }, {
+        "id": "2417",
+        "name": "Geomancer Auguste of the Sun"
+    }, {
+        "id": "2434",
+        "name": "Sage Thor of the Sun"
+    }, {
+        "id": "2530",
+        "name": "Thaumaturge Blaise of the Sun"
+    }, {
+        "id": "2579",
+        "name": "Shaman Nazim of the Sun"
+    }, {
+        "id": "2580",
+        "name": "Shadow Mage Zelroth of the Sun"
+    }, {
+        "id": "2598",
+        "name": "Battle Mage Nicolas of the Sun"
+    }, {
+        "id": "2811",
+        "name": "Thaumaturge Horace of the Sun"
+    }, {
+        "id": "2867",
+        "name": "Shaman Liliana of the Sun"
+    }, {
+        "id": "3051",
+        "name": "Shaman Armstrong of the Sun"
+    }, {
+        "id": "3082",
+        "name": "Enchanter Salvatore of the Sun"
+    }, {
+        "id": "3114",
+        "name": "Artificer Goliath of the Sun"
+    }, {
+        "id": "3324",
+        "name": "Alchemist Sturgis of the Sun"
+    }, {
+        "id": "3364",
+        "name": "Arcanist Armstrong of the Sun"
+    }, {
+        "id": "3427",
+        "name": "Void Disciple Samael of the Sun"
+    }, {
+        "id": "3428",
+        "name": "Aeromancer Jianyu of the Sun"
+    }, {
+        "id": "3455",
+        "name": "Sorcerer Nazim of the Sun"
+    }, {
+        "id": "3494",
+        "name": "Witch Hagatha of the Sun"
+    }, {
+        "id": "3740",
+        "name": "Pyromancer Giacomo of the Sun"
+    }, {
+        "id": "3910",
+        "name": "Sorcerer Reza of the Sun"
+    }, {
+        "id": "3941",
+        "name": "Alessar of the Sun"
+    }, {
+        "id": "3968",
+        "name": "Lumos of the Sun"
+    }, {
+        "id": "4021",
+        "name": "Battle Mage Hothor of the Sun"
+    }, {
+        "id": "4041",
+        "name": "Archmagus Azahl of the Sun"
+    }, {
+        "id": "4076",
+        "name": "Magus Feng of the Sun"
+    }, {
+        "id": "4126",
+        "name": "Shaman Zevi of the Sun"
+    }, {
+        "id": "4208",
+        "name": "Sorcerer Soran of the Sun"
+    }, {
+        "id": "4279",
+        "name": "Shaman Rita of the Sun"
+    }, {
+        "id": "4349",
+        "name": "Wild Mage Angus of the Sun"
+    }, {
+        "id": "4430",
+        "name": "Light Mage Ilu of the Sun"
+    }, {
+        "id": "4433",
+        "name": "Battle Mage Danny of the Sun"
+    }, {
+        "id": "4481",
+        "name": "Magus Ilyas of the Sun"
+    }, {
+        "id": "4507",
+        "name": "Voodoo Priest Louis of the Sun"
+    }, {
+        "id": "4508",
+        "name": "Shaman Jameel of the Sun"
+    }, {
+        "id": "4547",
+        "name": "Sorcerer Lumos of the Sun"
+    }, {
+        "id": "4563",
+        "name": "Enchanter Zubin of the Sun"
+    }, {
+        "id": "4642",
+        "name": "Fortune Teller Shoi-Ming of the Sun"
+    }, {
+        "id": "4677",
+        "name": "Hydromancer Shu of the Sun"
+    }, {
+        "id": "4766",
+        "name": "Archmagus George of the Sun"
+    }, {
+        "id": "4783",
+        "name": "Archmagus Eronin of the Sun"
+    }, {
+        "id": "4904",
+        "name": "Aeromancer Eizo of the Sun"
+    }, {
+        "id": "5087",
+        "name": "Battle Mage Armstrong of the Sun"
+    }, {
+        "id": "5203",
+        "name": "Evoker Bucky of the Sun"
+    }, {
+        "id": "5228",
+        "name": "Medium Blaise of the Sun"
+    }, {
+        "id": "5547",
+        "name": "Archmagus Basil of the Sun"
+    }, {
+        "id": "5614",
+        "name": "Hedge Wizard Gorg of the Sun"
+    }, {
+        "id": "5708",
+        "name": "Witch Rowena of the Sun"
+    }, {
+        "id": "5901",
+        "name": "Archmagus Orpheus of the Sun"
+    }, {
+        "id": "5955",
+        "name": "Augurer Nori of the Sun"
+    }, {
+        "id": "6025",
+        "name": "Enchanter Giuseppe of the Sun"
+    }, {
+        "id": "6049",
+        "name": "Mystic Jean Leon of the Sun"
+    }, {
+        "id": "6057",
+        "name": "Illusionist Diana of the Sun"
+    }, {
+        "id": "6067",
+        "name": "Shaman Ozohr of the Sun"
+    }, {
+        "id": "6086",
+        "name": "Geomancer Quddus of the Sun"
+    }, {
+        "id": "6197",
+        "name": "Battle Mage Cassius of the Sun"
+    }, {
+        "id": "6215",
+        "name": "Sorcerer Qasim of the Sun"
+    }, {
+        "id": "6219",
+        "name": "Wild Mage Ratko of the Sun"
+    }, {
+        "id": "6226",
+        "name": "Runecaster Ifran of the Sun"
+    }, {
+        "id": "6284",
+        "name": "Sage Hashim of the Sun"
+    }, {
+        "id": "6404",
+        "name": "Arcanist Qasim of the Sun"
+    }, {
+        "id": "6448",
+        "name": "Pyromancer Impy of the Sun"
+    }, {
+        "id": "6514",
+        "name": "Shaman Devin of the Sun"
+    }, {
+        "id": "6559",
+        "name": "Hedge Wizard Herne of the Sun"
+    }, {
+        "id": "6567",
+        "name": "Arch-Magician Spore Boy of the Sun"
+    }, {
+        "id": "6736",
+        "name": "Artificer Salah of the Sun"
+    }, {
+        "id": "6749",
+        "name": "Battle Mage Cromwell of the Sun"
+    }, {
+        "id": "6763",
+        "name": "Necromancer Black Phillip of the Sun"
+    }, {
+        "id": "6776",
+        "name": "Sorcerer Qaid of the Sun"
+    }, {
+        "id": "6783",
+        "name": "Void Disciple Diabolos of the Sun"
+    }, {
+        "id": "6819",
+        "name": "Enchanter Ixar of the Sun"
+    }, {
+        "id": "6881",
+        "name": "Cosmic Mage Jerret of the Sun"
+    }, {
+        "id": "7007",
+        "name": "Enchanter Jadis of the Sun"
+    }, {
+        "id": "7038",
+        "name": "Arcanist Aleister of the Sun"
+    }, {
+        "id": "7076",
+        "name": "Sorcerer George of the Sun"
+    }, {
+        "id": "7109",
+        "name": "Arch-Magician Angus of the Sun"
+    }, {
+        "id": "7411",
+        "name": "Pyromancer Scorch of the Sun"
+    }, {
+        "id": "7471",
+        "name": "Hedge Wizard Feng of the Sun"
+    }, {
+        "id": "7477",
+        "name": "Evoker Flynn of the Sun"
+    }, {
+        "id": "7511",
+        "name": "Magus Nazim of the Sun"
+    }, {
+        "id": "7569",
+        "name": "Electromancer Homer of the Sun"
+    }, {
+        "id": "7706",
+        "name": "Pyromancer Merlon of the Sun"
+    }, {
+        "id": "7710",
+        "name": "Alchemist Ali of the Sun"
+    }, {
+        "id": "7775",
+        "name": "Magus  of the Sun"
+    }, {
+        "id": "7787",
+        "name": "Druid Zelroth of the Sun"
+    }, {
+        "id": "7848",
+        "name": "Artificer Enzo of the Sun"
+    }, {
+        "id": "7862",
+        "name": "Archmagus Eizo of the Sun"
+    }, {
+        "id": "8044",
+        "name": "Shaman Samuel of the Sun"
+    }, {
+        "id": "8196",
+        "name": "Clairvoyant Thor of the Sun"
+    }, {
+        "id": "8423",
+        "name": "Battle Mage Axel of the Sun"
+    }, {
+        "id": "8663",
+        "name": "Enchanter Jabir of the Sun"
+    }, {
+        "id": "8687",
+        "name": "Shaman Damien of the Sun"
+    }, {
+        "id": "8728",
+        "name": "Magus Jerret of the Sun"
+    }, {
+        "id": "8764",
+        "name": "Arch-Magician Ilyas of the Sun"
+    }, {
+        "id": "8820",
+        "name": "Lumos of the Sun"
+    }, {
+        "id": "8903",
+        "name": "Aleister of the Sun"
+    }, {
+        "id": "9006",
+        "name": "Aeromancer Rook of the Sun"
+    }, {
+        "id": "9016",
+        "name": "Adept Zeromus of the Sun"
+    }, {
+        "id": "9188",
+        "name": "Mystic Corvin of the Sun"
+    }, {
+        "id": "9394",
+        "name": "Sorcerer Kazem of the Sun"
+    }, {
+        "id": "9513",
+        "name": "Runecaster Qaid of the Sun"
+    }, {
+        "id": "9542",
+        "name": "Archmagus Oberon of the Sun"
+    }, {
+        "id": "9606",
+        "name": "Voodoo Priest Victor of the Sun"
+    }, {
+        "id": "9617",
+        "name": "Magus Zafar of the Sun"
+    }, {
+        "id": "9698",
+        "name": "Battle Mage Armstrong of the Sun"
+    }, {
+        "id": "9893",
+        "name": "Archmagus Davos of the Sun"
+    }, {
+        "id": "9900",
+        "name": "Arcanist Kazem of the Sun"
+    }, {
+        "id": "9925",
+        "name": "Magus Wazir of the Sun"
+    }],
+    "The Hills": [{
+        "id": "75",
+        "name": "Dwarzgarth of The Hills"
+    }],
+    "Desert": [{
+        "id": "86",
+        "name": "Battle Mage Khudalf of the Desert"
+    }, {
+        "id": "285",
+        "name": "Archmagus Aleister of the Desert"
+    }, {
+        "id": "407",
+        "name": "Sorcerer Taqi of the Desert"
+    }, {
+        "id": "493",
+        "name": "Archmagus Katherine of the Desert"
+    }, {
+        "id": "508",
+        "name": "Hedge Wizard Bolin of the Desert"
+    }, {
+        "id": "517",
+        "name": "Sage Nazim of the Desert"
+    }, {
+        "id": "602",
+        "name": "Ghost Eater Milo of the Desert"
+    }, {
+        "id": "672",
+        "name": "Enchanter Apollo of the Desert"
+    }, {
+        "id": "713",
+        "name": "Zane of the Desert"
+    }, {
+        "id": "819",
+        "name": "Sorcerer Celah of the Desert"
+    }, {
+        "id": "837",
+        "name": "Shaman Ixar of the Desert"
+    }, {
+        "id": "861",
+        "name": "Hedge Wizard Robert of the Desert"
+    }, {
+        "id": "870",
+        "name": "Artificer Bayard of the Desert"
+    }, {
+        "id": "891",
+        "name": "Arch-Magician Angus of the Desert"
+    }, {
+        "id": "904",
+        "name": "Sage Idris of the Desert"
+    }, {
+        "id": "928",
+        "name": "Hadrien of the Desert"
+    }, {
+        "id": "931",
+        "name": "Shadow Mage Zevi of the Desert"
+    }, {
+        "id": "1072",
+        "name": "Hedge Wizard Danny of the Desert"
+    }, {
+        "id": "1098",
+        "name": "Battle Mage Cromwell of the Desert"
+    }, {
+        "id": "1142",
+        "name": "Enchanter Daria of the Desert"
+    }, {
+        "id": "1151",
+        "name": "Alchemist Venga of the Desert"
+    }, {
+        "id": "1158",
+        "name": "Spellsinger Ravana of the Desert"
+    }, {
+        "id": "1239",
+        "name": "Archmagus Zubin of the Desert"
+    }, {
+        "id": "1272",
+        "name": "Cleric Pandora of the Desert"
+    }, {
+        "id": "1343",
+        "name": "Hedge Wizard Goliath of the Desert"
+    }, {
+        "id": "1344",
+        "name": "Zelroth of the Desert"
+    }, {
+        "id": "1376",
+        "name": "Adept Nikolas of the Desert"
+    }, {
+        "id": "1422",
+        "name": "Archmagus Aldus of the Desert"
+    }, {
+        "id": "1447",
+        "name": "Shaman Nassif of the Desert"
+    }, {
+        "id": "1511",
+        "name": "Lux of the Desert"
+    }, {
+        "id": "1525",
+        "name": "Battle Mage Goliath of the Desert"
+    }, {
+        "id": "1544",
+        "name": "Archmagus Jerret of the Desert"
+    }, {
+        "id": "1642",
+        "name": "Necromancer  of the Desert"
+    }, {
+        "id": "1649",
+        "name": "Wild Mage Borak of the Desert"
+    }, {
+        "id": "1726",
+        "name": "Archmagus Alessar of the Desert"
+    }, {
+        "id": "1741",
+        "name": "Fortune Teller Apollo of the Desert"
+    }, {
+        "id": "1782",
+        "name": "Wild Mage Cromwell of the Desert"
+    }, {
+        "id": "1817",
+        "name": "Enchanter Jerret of the Desert"
+    }, {
+        "id": "1831",
+        "name": "Alchemist Otto of the Desert"
+    }, {
+        "id": "1849",
+        "name": "Shadow Mage Gaspard of the Desert"
+    }, {
+        "id": "1869",
+        "name": "Lamia of the Desert"
+    }, {
+        "id": "1944",
+        "name": "Adept Udor of the Desert"
+    }, {
+        "id": "1999",
+        "name": "Archmagus Argus of the Desert"
+    }, {
+        "id": "2043",
+        "name": "Arch-Magician Axel of the Desert"
+    }, {
+        "id": "2124",
+        "name": "Sorcerer Basil of the Desert"
+    }, {
+        "id": "2162",
+        "name": "Diviner Cairon of the Desert"
+    }, {
+        "id": "2171",
+        "name": "Adept Dario of the Desert"
+    }, {
+        "id": "2190",
+        "name": "Enchanter Moloch of the Desert"
+    }, {
+        "id": "2191",
+        "name": "Cartomancer Merlon of the Desert"
+    }, {
+        "id": "2193",
+        "name": "Runecaster Gwendolin of the Desert"
+    }, {
+        "id": "2195",
+        "name": "Arch-Magician Fabio of the Desert"
+    }, {
+        "id": "2214",
+        "name": "Druid Jadis of the Desert"
+    }, {
+        "id": "2237",
+        "name": "Chaos Mage Properpine of the Desert"
+    }, {
+        "id": "2248",
+        "name": "Electromancer Davos of the Desert"
+    }, {
+        "id": "2273",
+        "name": "Arch-Magician Borak of the Desert"
+    }, {
+        "id": "2290",
+        "name": "Sorcerer Feng of the Desert"
+    }, {
+        "id": "2334",
+        "name": "Sorcerer Jeldor of the Desert"
+    }, {
+        "id": "2393",
+        "name": "Arcanist Ariadne of the Desert"
+    }, {
+        "id": "2489",
+        "name": "Witch Drokore of the Desert"
+    }, {
+        "id": "2548",
+        "name": "Enchanter Magnus of the Desert"
+    }, {
+        "id": "2674",
+        "name": "Battle Mage Rodolfo of the Desert"
+    }, {
+        "id": "2719",
+        "name": "Sorcerer Hashim of the Desert"
+    }, {
+        "id": "2732",
+        "name": "Sage Aldus of the Desert"
+    }, {
+        "id": "2765",
+        "name": "Artificer Ulysse of the Desert"
+    }, {
+        "id": "2775",
+        "name": "Hedge Wizard Nolan of the Desert"
+    }, {
+        "id": "2787",
+        "name": "Layla of the Desert"
+    }, {
+        "id": "2842",
+        "name": "Aleister of the Desert"
+    }, {
+        "id": "2853",
+        "name": "Shaman Rodolfo of the Desert"
+    }, {
+        "id": "2880",
+        "name": "Voodoo Priest Ulysse of the Desert"
+    }, {
+        "id": "2956",
+        "name": "Druid Zeromus of the Desert"
+    }, {
+        "id": "3017",
+        "name": "Arch-Magician Ofaris of the Desert"
+    }, {
+        "id": "3026",
+        "name": "Solar Mage Akron of the Desert"
+    }, {
+        "id": "3042",
+        "name": "Conjurer Aleister of the Desert"
+    }, {
+        "id": "3087",
+        "name": "Battle Mage Robert of the Desert"
+    }, {
+        "id": "3152",
+        "name": "Sorcerer Nazim of the Desert"
+    }, {
+        "id": "3289",
+        "name": "Sorcerer Kazem of the Desert"
+    }, {
+        "id": "3340",
+        "name": "Arcanist Caligula of the Desert"
+    }, {
+        "id": "3370",
+        "name": "Alchemist Soran of the Desert"
+    }, {
+        "id": "3379",
+        "name": "Cleric Tumbaj of the Desert"
+    }, {
+        "id": "3468",
+        "name": "Cosmic Mage Zolona of the Desert"
+    }, {
+        "id": "3480",
+        "name": "Artificer Cairon of the Desert"
+    }, {
+        "id": "3515",
+        "name": "Archmagus Crowley of the Desert"
+    }, {
+        "id": "3582",
+        "name": "Witch Delilah of the Desert"
+    }, {
+        "id": "3602",
+        "name": "Arcanist Rixxa of the Desert"
+    }, {
+        "id": "3698",
+        "name": "Hedge Wizard Danny of the Desert"
+    }, {
+        "id": "3751",
+        "name": "Archmagus Hadrien of the Desert"
+    }, {
+        "id": "3782",
+        "name": "Archmagus Nikolas of the Desert"
+    }, {
+        "id": "3837",
+        "name": "Wild Mage Agapito of the Desert"
+    }, {
+        "id": "3851",
+        "name": "Geomancer Hadrien of the Desert"
+    }, {
+        "id": "3934",
+        "name": "Geomancer Zhan of the Desert"
+    }, {
+        "id": "3987",
+        "name": "Cleric Moka of the Desert"
+    }, {
+        "id": "4046",
+        "name": "Wild Mage Hagar of the Desert"
+    }, {
+        "id": "4054",
+        "name": "Conjurer George of the Desert"
+    }, {
+        "id": "4081",
+        "name": "Archmagus Ixar of the Desert"
+    }, {
+        "id": "4088",
+        "name": "Spellsinger Uvlius of the Desert"
+    }, {
+        "id": "4172",
+        "name": "Sorcerer Kazem of the Desert"
+    }, {
+        "id": "4187",
+        "name": "Diabolist Ifran of the Desert"
+    }, {
+        "id": "4192",
+        "name": "Shaman Darick of the Desert"
+    }, {
+        "id": "4234",
+        "name": "Sorcerer Rafiq of the Desert"
+    }, {
+        "id": "4309",
+        "name": "Enchanter Hagar of the Desert"
+    }, {
+        "id": "4498",
+        "name": "Sorcerer Zelroth of the Desert"
+    }, {
+        "id": "4537",
+        "name": "Sorcerer Jameel of the Desert"
+    }, {
+        "id": "4567",
+        "name": "of the Desert"
+    }, {
+        "id": "4622",
+        "name": "Archmagus Basil of the Desert"
+    }, {
+        "id": "4694",
+        "name": "Magus Lux of the Desert"
+    }, {
+        "id": "4747",
+        "name": "Eden of the Desert"
+    }, {
+        "id": "4837",
+        "name": "Ghost Eater Jerret of the Desert"
+    }, {
+        "id": "4975",
+        "name": "Archmagus Alex of the Desert"
+    }, {
+        "id": "5003",
+        "name": "Conjurer Pumlo of the Desert"
+    }, {
+        "id": "5076",
+        "name": "Druid Samael of the Desert"
+    }, {
+        "id": "5164",
+        "name": "Celah of the Desert"
+    }, {
+        "id": "5204",
+        "name": "Ghost Eater Zorko of the Desert"
+    }, {
+        "id": "5244",
+        "name": "Cosmic Mage Aldus of the Desert"
+    }, {
+        "id": "5277",
+        "name": "Artificer Axel of the Desert"
+    }, {
+        "id": "5286",
+        "name": "Mystic Lux of the Desert"
+    }, {
+        "id": "5334",
+        "name": "Battle Mage Hagar of the Desert"
+    }, {
+        "id": "5364",
+        "name": "Pyromancer Huizhong of the Desert"
+    }, {
+        "id": "5387",
+        "name": "Witch Lamia of the Desert"
+    }, {
+        "id": "5399",
+        "name": "Chaos Mage Hothor of the Desert"
+    }, {
+        "id": "5405",
+        "name": "Aeromancer Nazim of the Desert"
+    }, {
+        "id": "5457",
+        "name": "Hedge Wizard Eizo of the Desert"
+    }, {
+        "id": "5496",
+        "name": "Sky Master Corvin of the Desert"
+    }, {
+        "id": "5501",
+        "name": "Magus Zafar of the Desert"
+    }, {
+        "id": "5646",
+        "name": "Enchanter Daria of the Desert"
+    }, {
+        "id": "5733",
+        "name": "Shaman Bartholomew of the Desert"
+    }, {
+        "id": "5770",
+        "name": "Pyromancer Lumos of the Desert"
+    }, {
+        "id": "5846",
+        "name": "Hedge Wizard Rodolfo of the Desert"
+    }, {
+        "id": "5863",
+        "name": "Enchanter Celah of the Desert"
+    }, {
+        "id": "6075",
+        "name": "Illusionist  of the Desert"
+    }, {
+        "id": "6094",
+        "name": "Geomancer Borak of the Desert"
+    }, {
+        "id": "6098",
+        "name": "Alchemist Ofaris of the Desert"
+    }, {
+        "id": "6100",
+        "name": "Necromancer Alice of the Desert"
+    }, {
+        "id": "6109",
+        "name": "Enchanter Silas of the Desert"
+    }, {
+        "id": "6115",
+        "name": "Archmagus Adium of the Desert"
+    }, {
+        "id": "6156",
+        "name": "Chaos Mage Davos of the Desert"
+    }, {
+        "id": "6229",
+        "name": "Fortune Teller Crackerjack of the Desert"
+    }, {
+        "id": "6276",
+        "name": "Diabolist Nemo of the Desert"
+    }, {
+        "id": "6364",
+        "name": "Battlemage Armstrong of the Desert"
+    }, {
+        "id": "6385",
+        "name": "Aldus of the Desert"
+    }, {
+        "id": "6410",
+        "name": "Archmagus Casper of the Desert"
+    }, {
+        "id": "6438",
+        "name": "Summoner Hadrien of the Desert"
+    }, {
+        "id": "6485",
+        "name": "Druid Nori of the Desert"
+    }, {
+        "id": "6513",
+        "name": "Ghost Eater Chooki of the Desert"
+    }, {
+        "id": "6525",
+        "name": "Runecaster Carly of the Desert"
+    }, {
+        "id": "6548",
+        "name": "Shaman Wazir of the Desert"
+    }, {
+        "id": "6664",
+        "name": "Archmagus Gully of the Desert"
+    }, {
+        "id": "6713",
+        "name": "Geomancer Bartholomew of the Desert"
+    }, {
+        "id": "6731",
+        "name": "Sorcerer Hashim of the Desert"
+    }, {
+        "id": "6799",
+        "name": "Sorcerer Jaffer of the Desert"
+    }, {
+        "id": "6857",
+        "name": "Cleric Tumbaj of the Desert"
+    }, {
+        "id": "6863",
+        "name": "Transmuter Basil of the Desert"
+    }, {
+        "id": "6910",
+        "name": "Archmagus Gellert of the Desert"
+    }, {
+        "id": "6914",
+        "name": "Diabolist Ifran of the Desert"
+    }, {
+        "id": "6952",
+        "name": "Mystic Jerret of the Desert"
+    }, {
+        "id": "6987",
+        "name": "Sorcerer Pumlo of the Desert"
+    }, {
+        "id": "6996",
+        "name": "Shaman Setsuko of the Desert"
+    }, {
+        "id": "7082",
+        "name": "Wild Mage Bolin of the Desert"
+    }, {
+        "id": "7153",
+        "name": "Alchemist Armstrong of the Desert"
+    }, {
+        "id": "7183",
+        "name": "Alchemist Milo of the Desert"
+    }, {
+        "id": "7184",
+        "name": "Oracle Danny of the Desert"
+    }, {
+        "id": "7251",
+        "name": "Shaman Rafiq of the Desert"
+    }, {
+        "id": "7253",
+        "name": "Druid Althea of the Desert"
+    }, {
+        "id": "7331",
+        "name": "Shadow Mage Malthus of the Desert"
+    }, {
+        "id": "7339",
+        "name": "Conjurer David of the Desert"
+    }, {
+        "id": "7354",
+        "name": "Alchemist Nori of the Desert"
+    }, {
+        "id": "7432",
+        "name": "Ghost Eater Abaddon of the Desert"
+    }, {
+        "id": "7546",
+        "name": "Archmagus Milton of the Desert"
+    }, {
+        "id": "7616",
+        "name": "Battlemage Pino of the Desert"
+    }, {
+        "id": "7744",
+        "name": "Arcanist Apollo of the Desert"
+    }, {
+        "id": "7755",
+        "name": "Archmagus Ofaris of the Desert"
+    }, {
+        "id": "7786",
+        "name": "Cryptomancer  of the Desert"
+    }, {
+        "id": "7801",
+        "name": "Archmagus George of the Desert"
+    }, {
+        "id": "7864",
+        "name": "Oracle Jahid of the Desert"
+    }, {
+        "id": "7865",
+        "name": "Pyromancer Behemoth of the Desert"
+    }, {
+        "id": "7973",
+        "name": "Archmagus Aleister of the Desert"
+    }, {
+        "id": "8020",
+        "name": "Magus Angus of the Desert"
+    }, {
+        "id": "8050",
+        "name": "Artificer Bobbin of the Desert"
+    }, {
+        "id": "8093",
+        "name": "Battle Mage Talbot of the Desert"
+    }, {
+        "id": "8140",
+        "name": "Arch-Magician Lux of the Desert"
+    }, {
+        "id": "8185",
+        "name": "Hedge Wizard Ratko of the Desert"
+    }, {
+        "id": "8238",
+        "name": "Diabolist Ethan of the Desert"
+    }, {
+        "id": "8304",
+        "name": "Enchanter Basil of the Desert"
+    }, {
+        "id": "8322",
+        "name": "Hedge Wizard Sharx of the Desert"
+    }, {
+        "id": "8349",
+        "name": "Arcanist Goomer of the Desert"
+    }, {
+        "id": "8398",
+        "name": "Arcanist Jerret of the Desert"
+    }, {
+        "id": "8436",
+        "name": "Geomancer Alizam of the Desert"
+    }, {
+        "id": "8527",
+        "name": "Sorcerer Milo of the Desert"
+    }, {
+        "id": "8528",
+        "name": "Thaumaturge Alessar of the Desert"
+    }, {
+        "id": "8536",
+        "name": "Archmagus Eizo of the Desert"
+    }, {
+        "id": "8581",
+        "name": "Diabolist Aleister of the Desert"
+    }, {
+        "id": "8689",
+        "name": "Battle Mage Goliath of the Desert"
+    }, {
+        "id": "8817",
+        "name": "Archmagus Zeromus of the Desert"
+    }, {
+        "id": "8846",
+        "name": "Arcanist Cromwell of the Desert"
+    }, {
+        "id": "8857",
+        "name": "Thaumaturge Qasim of the Desert"
+    }, {
+        "id": "8908",
+        "name": "Necromancer Seth of the Desert"
+    }, {
+        "id": "8912",
+        "name": "Adept Bolin of the Desert"
+    }, {
+        "id": "8915",
+        "name": "Archmagus David of the Desert"
+    }, {
+        "id": "9029",
+        "name": "Diabolist Calypso of the Desert"
+    }, {
+        "id": "9082",
+        "name": "Artificer Le Blanc of the Desert"
+    }, {
+        "id": "9132",
+        "name": "Magus Sturgis of the Desert"
+    }, {
+        "id": "9147",
+        "name": "Shaman Nicolas of the Desert"
+    }, {
+        "id": "9209",
+        "name": "Enchanter Victoria of the Desert"
+    }, {
+        "id": "9254",
+        "name": "Shaman Danny of the Desert"
+    }, {
+        "id": "9287",
+        "name": "Electromancer Udor of the Desert"
+    }, {
+        "id": "9334",
+        "name": "Illusionist Jagger of the Desert"
+    }, {
+        "id": "9338",
+        "name": "Cryptomancer Sylvia of the Desert"
+    }, {
+        "id": "9358",
+        "name": "Sage Corvin of the Desert"
+    }, {
+        "id": "9364",
+        "name": "Charmer Arabella of the Desert"
+    }, {
+        "id": "9434",
+        "name": "Mystic Mei of the Desert"
+    }, {
+        "id": "9440",
+        "name": "Sorcerer Eden of the Desert"
+    }, {
+        "id": "9446",
+        "name": "Battle Mage Talon of the Desert"
+    }, {
+        "id": "9462",
+        "name": "Sorcerer Aldus of the Desert"
+    }, {
+        "id": "9645",
+        "name": "Witch Rowena of the Desert"
+    }, {
+        "id": "9745",
+        "name": "Enchanter Bathsheba of the Desert"
+    }, {
+        "id": "9788",
+        "name": "Voodoo Priest Hugo of the Desert"
+    }, {
+        "id": "9810",
+        "name": "Battle Mage Hothor of the Desert"
+    }, {
+        "id": "9814",
+        "name": "Sorcerer Nadeem of the Desert"
+    }, {
+        "id": "9842",
+        "name": "Mystic Malthus of the Desert"
+    }, {
+        "id": "9876",
+        "name": "Sorcerer Venga of the Desert"
+    }, {
+        "id": "9904",
+        "name": "Sorcerer Jahid of the Desert"
+    }, {
+        "id": "9907",
+        "name": "Sorcerer Soya of the Desert"
+    }, {
+        "id": "9949",
+        "name": "Chaos Mage Caligula of the Desert"
+    }, {
+        "id": "9957",
+        "name": "Cleric Alizam of the Desert"
+    }, {
+        "id": "9964",
+        "name": "Shaman Caligari of the Desert"
+    }],
+    "Mount": [{
+        "id": "3",
+        "name": "Voodoo Priest Caligari of the Mount"
+    }, {
+        "id": "43",
+        "name": "Enchanter Zelroth of the Mount"
+    }, {
+        "id": "151",
+        "name": "Ixar of the Mount"
+    }, {
+        "id": "229",
+        "name": "Wild Mage Jiang of the Mount"
+    }, {
+        "id": "313",
+        "name": "Druid Samuel of the Mount"
+    }, {
+        "id": "321",
+        "name": "Sorcerer Alatar of the Mount"
+    }, {
+        "id": "476",
+        "name": "Sorcerer Ali of the Mount"
+    }, {
+        "id": "644",
+        "name": "Arcanist Aleister of the Mount"
+    }, {
+        "id": "646",
+        "name": "Thaumaturge Basil of the Mount"
+    }, {
+        "id": "647",
+        "name": "Enchanter Rita of the Mount"
+    }, {
+        "id": "657",
+        "name": "Sorcerer Ali of the Mount"
+    }, {
+        "id": "693",
+        "name": "Aleister of the Mount"
+    }, {
+        "id": "817",
+        "name": "Alchemist Jianyu of the Mount"
+    }, {
+        "id": "939",
+        "name": "Bard Faiz of the Mount"
+    }, {
+        "id": "952",
+        "name": "Thaumaturge Woomba of the Mount"
+    }, {
+        "id": "1093",
+        "name": "Voodoo Priest Marius of the Mount"
+    }, {
+        "id": "1105",
+        "name": "Celeste of the Mount"
+    }, {
+        "id": "1112",
+        "name": "Hedge Wizard Borak of the Mount"
+    }, {
+        "id": "1141",
+        "name": "Arch-Magician Soya of the Mount"
+    }, {
+        "id": "1150",
+        "name": "Apollo of the Mount"
+    }, {
+        "id": "1161",
+        "name": "Runecaster Sondra of the Mount"
+    }, {
+        "id": "1191",
+        "name": "Spellsinger Salvatore of the Mount"
+    }, {
+        "id": "1274",
+        "name": "Magus Jerret of the Mount"
+    }, {
+        "id": "1401",
+        "name": "Cosmic Mage Bolin of the Mount"
+    }, {
+        "id": "1452",
+        "name": "Archmagus David of the Mount"
+    }, {
+        "id": "1469",
+        "name": "Alchemist Hagar of the Mount"
+    }, {
+        "id": "1498",
+        "name": "Sorcerer Azahl of the Mount"
+    }, {
+        "id": "1529",
+        "name": "Artificer Numpty of the Mount"
+    }, {
+        "id": "1541",
+        "name": "Chronomancer Arabella of the Mount"
+    }, {
+        "id": "1608",
+        "name": "Necromancer Lei of the Mount"
+    }, {
+        "id": "1636",
+        "name": "Hedge Wizard Baird of the Mount"
+    }, {
+        "id": "1664",
+        "name": "Conjurer Sahir of the Mount"
+    }, {
+        "id": "1723",
+        "name": "Diabolist Jig of the Mount"
+    }, {
+        "id": "1725",
+        "name": "Spellsinger Koop of the Mount"
+    }, {
+        "id": "1790",
+        "name": "Archmagus Aleister of the Mount"
+    }, {
+        "id": "1824",
+        "name": "Alchemist Fungi of the Mount"
+    }, {
+        "id": "1838",
+        "name": "Archmagus  of the Mount"
+    }, {
+        "id": "1909",
+        "name": "Battle Mage Danny of the Mount"
+    }, {
+        "id": "1911",
+        "name": "Archmagus Cairon of the Mount"
+    }, {
+        "id": "1912",
+        "name": "Electromancer Hansel of the Mount"
+    }, {
+        "id": "1994",
+        "name": "Summoner Sylvia of the Mount"
+    }, {
+        "id": "2050",
+        "name": "Alchemist  of the Mount"
+    }, {
+        "id": "2106",
+        "name": "Shadow Mage Rita of the Mount"
+    }, {
+        "id": "2198",
+        "name": "Alchemist Aleister of the Mount"
+    }, {
+        "id": "2260",
+        "name": "Hedge Wizard Lucinda of the Mount"
+    }, {
+        "id": "2339",
+        "name": "Uvlius of the Mount"
+    }, {
+        "id": "2394",
+        "name": "Battle Mage Malthus of the Mount"
+    }, {
+        "id": "2435",
+        "name": "Battle Mage Gunthor of the Mount"
+    }, {
+        "id": "2436",
+        "name": "Cryptomancer Artis of the Mount"
+    }, {
+        "id": "2486",
+        "name": "Magus Amir of the Mount"
+    }, {
+        "id": "2493",
+        "name": "Battle Mage Hagar of the Mount"
+    }, {
+        "id": "2495",
+        "name": "Battle Mage Ulysse of the Mount"
+    }, {
+        "id": "2563",
+        "name": "Druid Hishoken of the Mount"
+    }, {
+        "id": "2589",
+        "name": "Archmagus Alessar of the Mount"
+    }, {
+        "id": "2642",
+        "name": "Archmagus Fungi of the Mount"
+    }, {
+        "id": "2670",
+        "name": "Sorcerer Isaac of the Mount"
+    }, {
+        "id": "2706",
+        "name": "Archmagus Aldus of the Mount"
+    }, {
+        "id": "2789",
+        "name": "Hedge Wizard Darick of the Mount"
+    }, {
+        "id": "2837",
+        "name": "Archmagus Zubin of the Mount"
+    }, {
+        "id": "2911",
+        "name": "Archmagus Azahl of the Mount"
+    }, {
+        "id": "2950",
+        "name": "Cleric Nori of the Mount"
+    }, {
+        "id": "3074",
+        "name": "Hydromancer Zafar of the Mount"
+    }, {
+        "id": "3138",
+        "name": "Conjurer Crackerjack of the Mount"
+    }, {
+        "id": "3147",
+        "name": "Magus Tumbaj of the Mount"
+    }, {
+        "id": "3188",
+        "name": "Battle Mage Nolan of the Mount"
+    }, {
+        "id": "3237",
+        "name": "Aeromancer Zelroth of the Mount"
+    }, {
+        "id": "3255",
+        "name": "Cleric Axel of the Mount"
+    }, {
+        "id": "3326",
+        "name": "Cleric Nicolas of the Mount"
+    }, {
+        "id": "3330",
+        "name": "Magus Taqi of the Mount"
+    }, {
+        "id": "3360",
+        "name": "Chaos Mage Celah of the Mount"
+    }, {
+        "id": "3382",
+        "name": "Diabolist Zelda of the Mount"
+    }, {
+        "id": "3389",
+        "name": "Artificer Angus of the Mount"
+    }, {
+        "id": "3398",
+        "name": "Conjurer Goober of the Mount"
+    }, {
+        "id": "3403",
+        "name": "Alchemist Durm of the Mount"
+    }, {
+        "id": "3413",
+        "name": "Archmagus Alessar of the Mount"
+    }, {
+        "id": "3429",
+        "name": "Alchemist Salvatore of the Mount"
+    }, {
+        "id": "3443",
+        "name": "Medium Otto of the Mount"
+    }, {
+        "id": "3447",
+        "name": "Charmer Devon of the Mount"
+    }, {
+        "id": "3457",
+        "name": "Ozohr of the Mount"
+    }, {
+        "id": "3460",
+        "name": "Sorcerer Apollo of the Mount"
+    }, {
+        "id": "3531",
+        "name": "Archmagus Nikolas of the Mount"
+    }, {
+        "id": "3548",
+        "name": "Archmagus Amir of the Mount"
+    }, {
+        "id": "3604",
+        "name": "Battle Mage Samuel of the Mount"
+    }, {
+        "id": "3640",
+        "name": "Battle Mage Durm of the Mount"
+    }, {
+        "id": "3672",
+        "name": "Chronomancer Angus of the Mount"
+    }, {
+        "id": "3681",
+        "name": "Spellsinger Cassius of the Mount"
+    }, {
+        "id": "3714",
+        "name": "Magus Tundror of the Mount"
+    }, {
+        "id": "3738",
+        "name": "Arch-Magician Alizam of the Mount"
+    }, {
+        "id": "3845",
+        "name": "Alchemist Baird of the Mount"
+    }, {
+        "id": "3872",
+        "name": "Illusionist Asmodeus of the Mount"
+    }, {
+        "id": "3922",
+        "name": "Arch-Magician Isaac of the Mount"
+    }, {
+        "id": "3999",
+        "name": "Enchanter Galatea of the Mount"
+    }, {
+        "id": "4050",
+        "name": "Sky Master JackDaw of the Mount"
+    }, {
+        "id": "4065",
+        "name": "Pyromancer Elvio of the Mount"
+    }, {
+        "id": "4115",
+        "name": "Adept Rita of the Mount"
+    }, {
+        "id": "4117",
+        "name": "Illusionist Adium of the Mount"
+    }, {
+        "id": "4291",
+        "name": "Archmagus Orlando of the Mount"
+    }, {
+        "id": "4356",
+        "name": "Runecaster Cullen of the Mount"
+    }, {
+        "id": "4365",
+        "name": "Summoner Jabir of the Mount"
+    }, {
+        "id": "4396",
+        "name": "Astrid of the Mount"
+    }, {
+        "id": "4489",
+        "name": "Diviner Crobas of the Mount"
+    }, {
+        "id": "4546",
+        "name": "Solar Mage Ulysse of the Mount"
+    }, {
+        "id": "4603",
+        "name": "Hedge Wizard Jeldor of the Mount"
+    }, {
+        "id": "4624",
+        "name": "Arch-Magician Ozohr of the Mount"
+    }, {
+        "id": "4635",
+        "name": "Sorcerer Isaac of the Mount"
+    }, {
+        "id": "4801",
+        "name": "Druid Abaddon of the Mount"
+    }, {
+        "id": "4874",
+        "name": "Aeromancer Jabir of the Mount"
+    }, {
+        "id": "4910",
+        "name": "Ozohr of the Mount"
+    }, {
+        "id": "4940",
+        "name": "Conjurer Apollo of the Mount"
+    }, {
+        "id": "4945",
+        "name": "Battle Mage Eric of the Mount"
+    }, {
+        "id": "5010",
+        "name": "Battle Mage Robert of the Mount"
+    }, {
+        "id": "5065",
+        "name": "Sage Astrid of the Mount"
+    }, {
+        "id": "5137",
+        "name": "Sorcerer Amir of the Mount"
+    }, {
+        "id": "5224",
+        "name": "Artificer Adium of the Mount"
+    }, {
+        "id": "5231",
+        "name": "Archmagus Nikolas of the Mount"
+    }, {
+        "id": "5283",
+        "name": "Archmagus Lux of the Mount"
+    }, {
+        "id": "5367",
+        "name": "Bard Milton of the Mount"
+    }, {
+        "id": "5446",
+        "name": "Artificer Davos of the Mount"
+    }, {
+        "id": "5576",
+        "name": "Sorcerer Udor of the Mount"
+    }, {
+        "id": "5581",
+        "name": "Adept Durm of the Mount"
+    }, {
+        "id": "5655",
+        "name": "Archmagus Jeldor of the Mount"
+    }, {
+        "id": "5689",
+        "name": "Medium Luther of the Mount"
+    }, {
+        "id": "5717",
+        "name": "Battlemage Hadrien of the Mount"
+    }, {
+        "id": "5731",
+        "name": "Archmagus Ixar of the Mount"
+    }, {
+        "id": "5787",
+        "name": "Alchemist Gary of the Mount"
+    }, {
+        "id": "5819",
+        "name": "Sorcerer Ozohr of the Mount"
+    }, {
+        "id": "5822",
+        "name": "Magus Eden of the Mount"
+    }, {
+        "id": "5844",
+        "name": "Bard Jinx of the Mount"
+    }, {
+        "id": "5943",
+        "name": "Arcanist Akron of the Mount"
+    }, {
+        "id": "5948",
+        "name": "Orpheus of the Mount"
+    }, {
+        "id": "5965",
+        "name": "Electromancer Nixie of the Mount"
+    }, {
+        "id": "5989",
+        "name": "Voodoo Priest Jean Leon of the Mount"
+    }, {
+        "id": "5991",
+        "name": "Shaman Azahl of the Mount"
+    }, {
+        "id": "5995",
+        "name": "Archmagus Aleister of the Mount"
+    }, {
+        "id": "6033",
+        "name": "Archmagus Basil of the Mount"
+    }, {
+        "id": "6034",
+        "name": "Arcanist Bathsheba of the Mount"
+    }, {
+        "id": "6055",
+        "name": "Battle Mage Flynn of the Mount"
+    }, {
+        "id": "6137",
+        "name": "Adept Eronin of the Mount"
+    }, {
+        "id": "6159",
+        "name": "Sorcerer Lumos of the Mount"
+    }, {
+        "id": "6174",
+        "name": "Archmagus Atlas of the Mount"
+    }, {
+        "id": "6244",
+        "name": "Necromancer Anton of the Mount"
+    }, {
+        "id": "6282",
+        "name": "Magus Thor of the Mount"
+    }, {
+        "id": "6287",
+        "name": "Magus Wazir of the Mount"
+    }, {
+        "id": "6302",
+        "name": "Archmagus David of the Mount"
+    }, {
+        "id": "6325",
+        "name": "Arcanist Jagger of the Mount"
+    }, {
+        "id": "6361",
+        "name": "Alchemist  of the Mount"
+    }, {
+        "id": "6393",
+        "name": "Thaumaturge Lux of the Mount"
+    }, {
+        "id": "6454",
+        "name": "Asphodel of the Mount"
+    }, {
+        "id": "6480",
+        "name": "Archmagus Zelroth of the Mount"
+    }, {
+        "id": "6490",
+        "name": "Enchanter Daria of the Mount"
+    }, {
+        "id": "6523",
+        "name": "Adept Chu Hua of the Mount"
+    }, {
+        "id": "6569",
+        "name": "Battle Mage Angus of the Mount"
+    }, {
+        "id": "6578",
+        "name": "Archmagus Allistair of the Mount"
+    }, {
+        "id": "6659",
+        "name": "Hex Mage  of the Mount"
+    }, {
+        "id": "6683",
+        "name": "Battle Mage Brutus of the Mount"
+    }, {
+        "id": "6711",
+        "name": "Alchemist Ulysse of the Mount"
+    }, {
+        "id": "6807",
+        "name": "Holy Monk Ravana of the Mount"
+    }, {
+        "id": "6822",
+        "name": "Bard Bumble of the Mount"
+    }, {
+        "id": "6825",
+        "name": "Alchemist Ozohr of the Mount"
+    }, {
+        "id": "6892",
+        "name": "Charmer Arabella of the Mount"
+    }, {
+        "id": "6897",
+        "name": "Archmagus Peppy of the Mount"
+    }, {
+        "id": "6903",
+        "name": "Archmagus Argus of the Mount"
+    }, {
+        "id": "6947",
+        "name": "Arcanist Cairon of the Mount"
+    }, {
+        "id": "7045",
+        "name": "Sage George of the Mount"
+    }, {
+        "id": "7060",
+        "name": "Arch-Magician Remus of the Mount"
+    }, {
+        "id": "7090",
+        "name": "Cosmic Mage Sondra of the Mount"
+    }, {
+        "id": "7099",
+        "name": "Aeromancer Rita of the Mount"
+    }, {
+        "id": "7117",
+        "name": "Magus Shabbith-Ka of the Mount"
+    }, {
+        "id": "7193",
+        "name": "Alchemist Koop of the Mount"
+    }, {
+        "id": "7234",
+        "name": "Battle Mage Flynn of the Mount"
+    }, {
+        "id": "7245",
+        "name": "Archmagus Aldus of the Mount"
+    }, {
+        "id": "7323",
+        "name": "Archmagus Milton of the Mount"
+    }, {
+        "id": "7406",
+        "name": "Sorcerer Alessar of the Mount"
+    }, {
+        "id": "7407",
+        "name": "Magus Ramiz of the Mount"
+    }, {
+        "id": "7428",
+        "name": "Wizard Uur'lok of the Mount"
+    }, {
+        "id": "7430",
+        "name": "Sky Master Rook of the Mount"
+    }, {
+        "id": "7500",
+        "name": "Bard Poppy of the Mount"
+    }, {
+        "id": "7570",
+        "name": "Battlemage Isaac of the Mount"
+    }, {
+        "id": "7580",
+        "name": "Spellsinger Ofaris of the Mount"
+    }, {
+        "id": "7677",
+        "name": "Witch Zolona of the Mount"
+    }, {
+        "id": "7776",
+        "name": "Cryptomancer Celah of the Mount"
+    }, {
+        "id": "7788",
+        "name": "Archmagus Amir of the Mount"
+    }, {
+        "id": "7897",
+        "name": "Ghost Eater Morrow of the Mount"
+    }, {
+        "id": "7925",
+        "name": "Battle Mage Cromwell of the Mount"
+    }, {
+        "id": "7934",
+        "name": "Enchanter Apollo of the Mount"
+    }, {
+        "id": "7964",
+        "name": "Sorcerer Zorko of the Mount"
+    }, {
+        "id": "7965",
+        "name": "Mystic Hadrien of the Mount"
+    }, {
+        "id": "8008",
+        "name": "Aeromancer Talbot of the Mount"
+    }, {
+        "id": "8074",
+        "name": "Artificer Behemoth of the Mount"
+    }, {
+        "id": "8076",
+        "name": "Evoker Maia of the Mount"
+    }, {
+        "id": "8084",
+        "name": "Hedge Wizard Lux of the Mount"
+    }, {
+        "id": "8173",
+        "name": "Magus Cosmo of the Mount"
+    }, {
+        "id": "8253",
+        "name": "Shaman Uvlius of the Mount"
+    }, {
+        "id": "8317",
+        "name": "Pyromancer Faiz of the Mount"
+    }, {
+        "id": "8370",
+        "name": "Archmagus Aleister of the Mount"
+    }, {
+        "id": "8450",
+        "name": "Cosmic Mage Hecate of the Mount"
+    }, {
+        "id": "8501",
+        "name": "Medium Nolan of the Mount"
+    }, {
+        "id": "8513",
+        "name": "Sorcerer Faiz of the Mount"
+    }, {
+        "id": "8529",
+        "name": "Battle Mage Hagar of the Mount"
+    }, {
+        "id": "8563",
+        "name": "Archmagus Orlando of the Mount"
+    }, {
+        "id": "8573",
+        "name": "Artificer Nicolas of the Mount"
+    }, {
+        "id": "8584",
+        "name": "Arch-Magician Arabella of the Mount"
+    }, {
+        "id": "8613",
+        "name": "Arcanist Aleister of the Mount"
+    }, {
+        "id": "8645",
+        "name": "Adept Edge of the Mount"
+    }, {
+        "id": "8648",
+        "name": "Magus Louis of the Mount"
+    }, {
+        "id": "8707",
+        "name": "Charmer Cybele of the Mount"
+    }, {
+        "id": "8757",
+        "name": "Holy Monk Fark of the Mount"
+    }, {
+        "id": "8887",
+        "name": "Sorcerer Allistair of the Mount"
+    }, {
+        "id": "8906",
+        "name": "Archmagus Crowley of the Mount"
+    }, {
+        "id": "8918",
+        "name": "Arch-Magician Aleister of the Mount"
+    }, {
+        "id": "8922",
+        "name": "Aldus of the Mount"
+    }, {
+        "id": "8968",
+        "name": "Sorcerer Aldus of the Mount"
+    }, {
+        "id": "8990",
+        "name": "Aldus of the Mount"
+    }, {
+        "id": "8998",
+        "name": "Battle Mage Gunthor of the Mount"
+    }, {
+        "id": "9024",
+        "name": "Adept Cassiopeia of the Mount"
+    }, {
+        "id": "9040",
+        "name": "Thaumaturge Impy of the Mount"
+    }, {
+        "id": "9092",
+        "name": "Alchemist Yookoo of the Mount"
+    }, {
+        "id": "9108",
+        "name": "Cleric Jahid of the Mount"
+    }, {
+        "id": "9135",
+        "name": "Cleric Froggy of the Mount"
+    }, {
+        "id": "9241",
+        "name": "Mystic Numpty of the Mount"
+    }, {
+        "id": "9243",
+        "name": "Zaros of the Mount"
+    }, {
+        "id": "9251",
+        "name": "Druid Rixxa of the Mount"
+    }, {
+        "id": "9310",
+        "name": "Archmagus Milo of the Mount"
+    }, {
+        "id": "9333",
+        "name": "Arch-Magician Merlon of the Mount"
+    }, {
+        "id": "9359",
+        "name": "Wild Mage Poppy of the Mount"
+    }, {
+        "id": "9397",
+        "name": "Aldus of the Mount"
+    }, {
+        "id": "9407",
+        "name": "Magus Qasim of the Mount"
+    }, {
+        "id": "9421",
+        "name": "Medium Ethan of the Mount"
+    }, {
+        "id": "9488",
+        "name": "Battle Mage Cassius of the Mount"
+    }, {
+        "id": "9535",
+        "name": "Mystic Marceline of the Mount"
+    }, {
+        "id": "9543",
+        "name": "Hedge Wizard Winter Squash of the Mount"
+    }, {
+        "id": "9573",
+        "name": "Hedge Wizard Solomon of the Mount"
+    }, {
+        "id": "9637",
+        "name": "Mystic Diana of the Mount"
+    }, {
+        "id": "9734",
+        "name": "Druid Jeldor of the Mount"
+    }, {
+        "id": "9800",
+        "name": "Archmagus Soran of the Mount"
+    }, {
+        "id": "9801",
+        "name": "Cleric Caligula of the Mount"
+    }, {
+        "id": "9823",
+        "name": "Hedge Wizard Caligula of the Mount"
+    }, {
+        "id": "9845",
+        "name": "Archmagus Basil of the Mount"
+    }, {
+        "id": "9867",
+        "name": "Illusionist Xiaobo of the Mount"
+    }, {
+        "id": "9977",
+        "name": "Artificer Solomon of the Mount"
+    }, {
+        "id": "9984",
+        "name": "Ofaris of the Mount"
+    }],
+    "Road": [{
+        "id": "91",
+        "name": "Battle Mage Flynn of the Road"
+    }, {
+        "id": "152",
+        "name": "Hedge Wizard Victoria of the Road"
+    }, {
+        "id": "182",
+        "name": "Witch Hecate of the Road"
+    }, {
+        "id": "199",
+        "name": "Electromancer Shivra of the Road"
+    }, {
+        "id": "306",
+        "name": "Enchanter Ariadne of the Road"
+    }, {
+        "id": "376",
+        "name": "Salvatore of the Road"
+    }, {
+        "id": "438",
+        "name": "Enchanter Shizu of the Road"
+    }, {
+        "id": "441",
+        "name": "Arcanist Nolan of the Road"
+    }, {
+        "id": "563",
+        "name": "Hedge Wizard Jeldor of the Road"
+    }, {
+        "id": "588",
+        "name": "Wild Mage Edge of the Road"
+    }, {
+        "id": "625",
+        "name": "Magus Armstrong of the Road"
+    }, {
+        "id": "684",
+        "name": "Evoker Helix of the Road"
+    }, {
+        "id": "823",
+        "name": "Enchanter Cassiopeia of the Road"
+    }, {
+        "id": "933",
+        "name": "Arcanist Bullock of the Road"
+    }, {
+        "id": "958",
+        "name": "Lumos of the Road"
+    }, {
+        "id": "1249",
+        "name": "Enchanter Artis of the Road"
+    }, {
+        "id": "1250",
+        "name": "Enchanter Diana of the Road"
+    }, {
+        "id": "1293",
+        "name": "Shaman Uvlius of the Road"
+    }, {
+        "id": "1365",
+        "name": "Diabolist Adrienne of the Road"
+    }, {
+        "id": "1389",
+        "name": "Wild Mage Titania of the Road"
+    }, {
+        "id": "1399",
+        "name": "Aldus of the Road"
+    }, {
+        "id": "1448",
+        "name": "Geomancer Angus of the Road"
+    }, {
+        "id": "1459",
+        "name": "Alchemist Chyou of the Road"
+    }, {
+        "id": "1473",
+        "name": "Ghost Eater Artis of the Road"
+    }, {
+        "id": "1752",
+        "name": "Hedge Wizard Circe of the Road"
+    }, {
+        "id": "1754",
+        "name": "Hex Mage Jasper of the Road"
+    }, {
+        "id": "1768",
+        "name": "Magus Rita of the Road"
+    }, {
+        "id": "1858",
+        "name": "Sage Cromwell of the Road"
+    }, {
+        "id": "1928",
+        "name": "Summoner Caligula of the Road"
+    }, {
+        "id": "2076",
+        "name": "Magus Diana of the Road"
+    }, {
+        "id": "2100",
+        "name": "Evoker Cairon of the Road"
+    }, {
+        "id": "2230",
+        "name": "Enchanter Pandora of the Road"
+    }, {
+        "id": "2253",
+        "name": "Alchemist Lumos of the Road"
+    }, {
+        "id": "2404",
+        "name": "Archmagus Celeste of the Road"
+    }, {
+        "id": "2437",
+        "name": "Alchemist Rita of the Road"
+    }, {
+        "id": "2583",
+        "name": "Geomancer Baird of the Road"
+    }, {
+        "id": "2942",
+        "name": "Cosmic Mage Solomon of the Road"
+    }, {
+        "id": "3012",
+        "name": "Sage Min of the Road"
+    }, {
+        "id": "3131",
+        "name": "Archmagus Jerret of the Road"
+    }, {
+        "id": "3498",
+        "name": "Archmagus Cairon of the Road"
+    }, {
+        "id": "3541",
+        "name": "Evoker Thana of the Road"
+    }, {
+        "id": "3636",
+        "name": "Witch Calypso of the Road"
+    }, {
+        "id": "3689",
+        "name": "Hex Mage Faye of the Road"
+    }, {
+        "id": "3723",
+        "name": "Sage Althea of the Road"
+    }, {
+        "id": "3750",
+        "name": "Battle Mage Homer of the Road"
+    }, {
+        "id": "3789",
+        "name": "Thaumaturge Sisk of the Road"
+    }, {
+        "id": "3886",
+        "name": "Battle Mage Flynn of the Road"
+    }, {
+        "id": "3888",
+        "name": "Arcanist Robert of the Road"
+    }, {
+        "id": "3953",
+        "name": "Sorcerer Ursula of the Road"
+    }, {
+        "id": "3976",
+        "name": "Arch-Magician Ali of the Road"
+    }, {
+        "id": "3995",
+        "name": "Alchemist Uday of the Road"
+    }, {
+        "id": "4133",
+        "name": "Enchanter Iris of the Road"
+    }, {
+        "id": "4199",
+        "name": "Alchemist Apollo of the Road"
+    }, {
+        "id": "4241",
+        "name": "Arch-Magician Iprix of the Road"
+    }, {
+        "id": "4244",
+        "name": "Alchemist Junko of the Road"
+    }, {
+        "id": "4267",
+        "name": "Shaman Soya of the Road"
+    }, {
+        "id": "4271",
+        "name": "Witch Ivy of the Road"
+    }, {
+        "id": "4382",
+        "name": "Witch Stag of the Road"
+    }, {
+        "id": "4409",
+        "name": "Hedge Wizard Lucinda of the Road"
+    }, {
+        "id": "4453",
+        "name": "Illusionist Artis of the Road"
+    }, {
+        "id": "4466",
+        "name": "Alchemist Hothor of the Road"
+    }, {
+        "id": "4576",
+        "name": "Artificer Dutorn of the Road"
+    }, {
+        "id": "4675",
+        "name": "of the Road"
+    }, {
+        "id": "4686",
+        "name": "Battle Mage Caligula of the Road"
+    }, {
+        "id": "4723",
+        "name": "Enchanter Asphodel of the Road"
+    }, {
+        "id": "4772",
+        "name": "Arabella of the Road"
+    }, {
+        "id": "4875",
+        "name": "Witch Delilah of the Road"
+    }, {
+        "id": "5126",
+        "name": "Witch Wolfram of the Road"
+    }, {
+        "id": "5235",
+        "name": "Diabolist Merlon of the Road"
+    }, {
+        "id": "5293",
+        "name": "Summoner Rixxa of the Road"
+    }, {
+        "id": "5327",
+        "name": "Arcanist Fumiko of the Road"
+    }, {
+        "id": "5431",
+        "name": "Magus Celeste of the Road"
+    }, {
+        "id": "5491",
+        "name": "Cryptomancer Sondra of the Road"
+    }, {
+        "id": "5506",
+        "name": "Pyromancer Cedric of the Road"
+    }, {
+        "id": "5510",
+        "name": "Enchanter Daria of the Road"
+    }, {
+        "id": "5550",
+        "name": "Enchanter Artis of the Road"
+    }, {
+        "id": "5608",
+        "name": "Alchemist Onaxx of the Road"
+    }, {
+        "id": "5642",
+        "name": "Artificer Flynn of the Road"
+    }, {
+        "id": "5918",
+        "name": "Celeste of the Road"
+    }, {
+        "id": "5945",
+        "name": "Sorcerer Aleister of the Road"
+    }, {
+        "id": "5975",
+        "name": "Archmagus Alessar of the Road"
+    }, {
+        "id": "6210",
+        "name": "Witch Rita of the Road"
+    }, {
+        "id": "6327",
+        "name": "Shaman Dante of the Road"
+    }, {
+        "id": "6375",
+        "name": "Battle Mage Cassius of the Road"
+    }, {
+        "id": "6392",
+        "name": "Illusionist Eizo of the Road"
+    }, {
+        "id": "6434",
+        "name": "Magus Orlando of the Road"
+    }, {
+        "id": "6467",
+        "name": "Archmagus Aleister of the Road"
+    }, {
+        "id": "6571",
+        "name": "Magus Chooki of the Road"
+    }, {
+        "id": "6582",
+        "name": "Hydromancer Jadis of the Road"
+    }, {
+        "id": "6769",
+        "name": "Hedge Wizard Zaim of the Road"
+    }, {
+        "id": "6784",
+        "name": "Geomancer Kazud of the Road"
+    }, {
+        "id": "6844",
+        "name": "George of the Road"
+    }, {
+        "id": "6894",
+        "name": "Arcanist Magnus of the Road"
+    }, {
+        "id": "6926",
+        "name": "Arch-Magician Florah of the Road"
+    }, {
+        "id": "7002",
+        "name": "Hex Mage Devon of the Road"
+    }, {
+        "id": "7295",
+        "name": "Geomancer Talon of the Road"
+    }, {
+        "id": "7374",
+        "name": "Enchanter Hagatha of the Road"
+    }, {
+        "id": "7381",
+        "name": "Battle Mage Baird of the Road"
+    }, {
+        "id": "7525",
+        "name": "Adept Hansel of the Road"
+    }, {
+        "id": "7554",
+        "name": "Hedge Wizard Larissa of the Road"
+    }, {
+        "id": "7611",
+        "name": "Hedge Wizard Borak of the Road"
+    }, {
+        "id": "7618",
+        "name": "Enchanter Atlanta of the Road"
+    }, {
+        "id": "7621",
+        "name": "Adept Tundror of the Road"
+    }, {
+        "id": "7714",
+        "name": "Sorcerer Soya of the Road"
+    }, {
+        "id": "7753",
+        "name": "Alchemist Nadeem of the Road"
+    }, {
+        "id": "7828",
+        "name": "Alchemist Hagar of the Road"
+    }, {
+        "id": "7957",
+        "name": "Magus Xiaosheng of the Road"
+    }, {
+        "id": "7994",
+        "name": "Shaman Aslan of the Road"
+    }, {
+        "id": "8018",
+        "name": "Sky Master Corvin of the Road"
+    }, {
+        "id": "8024",
+        "name": "Pyromancer Isaac of the Road"
+    }, {
+        "id": "8122",
+        "name": "Shaman Bayard of the Road"
+    }, {
+        "id": "8176",
+        "name": "Enchanter Azahl of the Road"
+    }, {
+        "id": "8203",
+        "name": "Archmagus George of the Road"
+    }, {
+        "id": "8266",
+        "name": "Archmagus Salvatore of the Road"
+    }, {
+        "id": "8331",
+        "name": "Thaumaturge Amanita of the Road"
+    }, {
+        "id": "8460",
+        "name": "Chronomancer Argus of the Road"
+    }, {
+        "id": "8520",
+        "name": "Battle Mage Malthus of the Road"
+    }, {
+        "id": "8542",
+        "name": "Artificer Esme of the Road"
+    }, {
+        "id": "8646",
+        "name": "Enchanter Eliphas of the Road"
+    }, {
+        "id": "8664",
+        "name": "Enchanter Orbus of the Road"
+    }, {
+        "id": "8710",
+        "name": "Adept Fark of the Road"
+    }, {
+        "id": "8862",
+        "name": "Lunar Mage Thana of the Road"
+    }, {
+        "id": "8886",
+        "name": "Archmagus Fark of the Road"
+    }, {
+        "id": "8938",
+        "name": "Ghost Eater Jadis of the Road"
+    }, {
+        "id": "8962",
+        "name": "Solomon of the Road"
+    }, {
+        "id": "9005",
+        "name": "Mystic Tengu of the Road"
+    }, {
+        "id": "9022",
+        "name": "Diabolist Ariadne of the Road"
+    }, {
+        "id": "9076",
+        "name": "Casper of the Road"
+    }, {
+        "id": "9195",
+        "name": "Runecaster Baozhai of the Road"
+    }, {
+        "id": "9269",
+        "name": "Enchanter Celeste of the Road"
+    }, {
+        "id": "9282",
+        "name": "Archmagus Edge of the Road"
+    }, {
+        "id": "9410",
+        "name": "Wizard Kalo of the Road"
+    }, {
+        "id": "9443",
+        "name": "Hedge Wizard Basil of the Road"
+    }, {
+        "id": "9538",
+        "name": "Magus Taqi of the Road"
+    }, {
+        "id": "9706",
+        "name": "Artificer Lenora of the Road"
+    }, {
+        "id": "9765",
+        "name": "Illusionist Tundror of the Road"
+    }, {
+        "id": "9827",
+        "name": "Artificer Epher of the Road"
+    }, {
+        "id": "9837",
+        "name": "of the Road"
+    }, {
+        "id": "9838",
+        "name": "Charmer Daria of the Road"
+    }, {
+        "id": "9889",
+        "name": "Diabolist Jadis of the Road"
+    }],
+    "Blizzard": [{
+        "id": "832",
+        "name": "Ice Mage Magnus out of the Blizzard"
+    }, {
+        "id": "1301",
+        "name": "Battle Mage Robert out of the Blizzard"
+    }, {
+        "id": "3307",
+        "name": "Magus Mushy out of the Blizzard"
+    }, {
+        "id": "3333",
+        "name": "Archmagus Aleister out of the Blizzard"
+    }, {
+        "id": "3487",
+        "name": "Magus Pino out of the Blizzard"
+    }, {
+        "id": "3847",
+        "name": "Evoker Armstrong out of the Blizzard"
+    }, {
+        "id": "4012",
+        "name": "Battlemage Zaros out of the Blizzard"
+    }, {
+        "id": "4760",
+        "name": "Ice Mage Flamos out of the Blizzard"
+    }, {
+        "id": "5050",
+        "name": "Cleric Udor out of the Blizzard"
+    }, {
+        "id": "5383",
+        "name": "Archmagus Leah out of the Blizzard"
+    }, {
+        "id": "5544",
+        "name": "Fortune Teller Zeromus out of the Blizzard"
+    }, {
+        "id": "6101",
+        "name": "Druid Iluzor out of the Blizzard"
+    }, {
+        "id": "6136",
+        "name": "Druid Ofaris out of the Blizzard"
+    }, {
+        "id": "6938",
+        "name": "Battlemage Eden out of the Blizzard"
+    }, {
+        "id": "7164",
+        "name": "Hedge Wizard Sabina out of the Blizzard"
+    }, {
+        "id": "7515",
+        "name": "Nikolas out of the Blizzard"
+    }, {
+        "id": "7741",
+        "name": "Ice Mage Pandora out of the Blizzard"
+    }, {
+        "id": "8821",
+        "name": "Sage Lucinda out of the Blizzard"
+    }, {
+        "id": "9046",
+        "name": "Sorcerer Pumlo out of the Blizzard"
+    }, {
+        "id": "9190",
+        "name": "Cosmic Mage Zelroth out of the Blizzard"
+    }, {
+        "id": "9436",
+        "name": "Artificer Ulysse out of the Blizzard"
+    }, {
+        "id": "9499",
+        "name": "Ice Mage Zubin out of the Blizzard"
+    }],
+    "Brambles": [{
+        "id": "137",
+        "name": "Shaman Flynn of the Brambles"
+    }, {
+        "id": "272",
+        "name": "Druid Corky of the Brambles"
+    }, {
+        "id": "278",
+        "name": "Witch Lucinda of the Brambles"
+    }, {
+        "id": "310",
+        "name": "Druid Brutus of the Brambles"
+    }, {
+        "id": "334",
+        "name": "Battle Mage Wolfram of the Brambles"
+    }, {
+        "id": "416",
+        "name": "Conjurer Rita of the Brambles"
+    }, {
+        "id": "417",
+        "name": "Witch Juniper of the Brambles"
+    }, {
+        "id": "458",
+        "name": "Amir of the Brambles"
+    }, {
+        "id": "480",
+        "name": "Archmagus Lin of the Brambles"
+    }, {
+        "id": "589",
+        "name": "Sage Jeldor of the Brambles"
+    }, {
+        "id": "682",
+        "name": "Battle Mage Atlas of the Brambles"
+    }, {
+        "id": "704",
+        "name": "Conjurer Jack of the Brambles"
+    }, {
+        "id": "764",
+        "name": "Shaman Chyou of the Brambles"
+    }, {
+        "id": "795",
+        "name": "Adept Hind of the Brambles"
+    }, {
+        "id": "828",
+        "name": "Illusionist Celeste of the Brambles"
+    }, {
+        "id": "841",
+        "name": "Arch-Magician Bucky of the Brambles"
+    }, {
+        "id": "868",
+        "name": "Sorcerer Quddus of the Brambles"
+    }, {
+        "id": "950",
+        "name": "Runecaster Ixar of the Brambles"
+    }, {
+        "id": "954",
+        "name": "Conjurer Ulysse of the Brambles"
+    }, {
+        "id": "960",
+        "name": "Sorcerer Davos of the Brambles"
+    }, {
+        "id": "980",
+        "name": "Enchanter Finn of the Brambles"
+    }, {
+        "id": "985",
+        "name": "Electromancer Azahl of the Brambles"
+    }, {
+        "id": "994",
+        "name": "Druid Daria of the Brambles"
+    }, {
+        "id": "1138",
+        "name": "Enchanter Larissa of the Brambles"
+    }, {
+        "id": "1221",
+        "name": "Void Disciple Samael of the Brambles"
+    }, {
+        "id": "1253",
+        "name": "Arcanist Lumos of the Brambles"
+    }, {
+        "id": "1503",
+        "name": "Holy Monk Drokore of the Brambles"
+    }, {
+        "id": "1586",
+        "name": "Fortune Teller Ixar of the Brambles"
+    }, {
+        "id": "1619",
+        "name": "Conjurer Artis of the Brambles"
+    }, {
+        "id": "1639",
+        "name": "Battle Mage Rodolfo of the Brambles"
+    }, {
+        "id": "1644",
+        "name": "Enchanter Sarah of the Brambles"
+    }, {
+        "id": "1662",
+        "name": "Cryptomancer Celeste of the Brambles"
+    }, {
+        "id": "1722",
+        "name": "Enchanter Cassiopeia of the Brambles"
+    }, {
+        "id": "1821",
+        "name": "Pandora of the Brambles"
+    }, {
+        "id": "1863",
+        "name": "Artificer Moloch of the Brambles"
+    }, {
+        "id": "2019",
+        "name": "Sage Milton of the Brambles"
+    }, {
+        "id": "2101",
+        "name": "Hedge Wizard Marceau of the Brambles"
+    }, {
+        "id": "2115",
+        "name": "Runecaster Sondra of the Brambles"
+    }, {
+        "id": "2126",
+        "name": "Shaman Zane of the Brambles"
+    }, {
+        "id": "2266",
+        "name": "Enchanter Merlon of the Brambles"
+    }, {
+        "id": "2384",
+        "name": "Alchemist Hadrien of the Brambles"
+    }, {
+        "id": "2657",
+        "name": "Battle Mage Flynn of the Brambles"
+    }, {
+        "id": "2672",
+        "name": "Archmagus Cairon of the Brambles"
+    }, {
+        "id": "2680",
+        "name": "Mystic Blaise of the Brambles"
+    }, {
+        "id": "2863",
+        "name": "Archmagus Kalo of the Brambles"
+    }, {
+        "id": "2949",
+        "name": "Battle Mage Angus of the Brambles"
+    }, {
+        "id": "3093",
+        "name": "Geomancer Dante of the Brambles"
+    }, {
+        "id": "3110",
+        "name": "Carly of the Brambles"
+    }, {
+        "id": "3136",
+        "name": "Archmagus Jerret of the Brambles"
+    }, {
+        "id": "3302",
+        "name": "Battle Mage Danny of the Brambles"
+    }, {
+        "id": "3320",
+        "name": "Diabolist Carly of the Brambles"
+    }, {
+        "id": "3331",
+        "name": "Hedge Wizard Lenora of the Brambles"
+    }, {
+        "id": "3350",
+        "name": "Battle Mage Baird of the Brambles"
+    }, {
+        "id": "3365",
+        "name": "Magus Gourdon of the Brambles"
+    }, {
+        "id": "3432",
+        "name": "Druid Atlanta of the Brambles"
+    }, {
+        "id": "3439",
+        "name": "Enchanter Sondra of the Brambles"
+    }, {
+        "id": "3502",
+        "name": "Colormancer Hue of the Brambles"
+    }, {
+        "id": "3525",
+        "name": "Enchanter Bathsheba of the Brambles"
+    }, {
+        "id": "3643",
+        "name": "Arch-Magician Azahl of the Brambles"
+    }, {
+        "id": "3669",
+        "name": "Voodoo Priest Cromwell of the Brambles"
+    }, {
+        "id": "3727",
+        "name": "Diabolist Astrid of the Brambles"
+    }, {
+        "id": "3739",
+        "name": "Hex Mage Junko of the Brambles"
+    }, {
+        "id": "3765",
+        "name": "Cryptomancer Mina of the Brambles"
+    }, {
+        "id": "3821",
+        "name": "Sage Daria of the Brambles"
+    }, {
+        "id": "3871",
+        "name": "Cosmic Mage Velorina of the Brambles"
+    }, {
+        "id": "4015",
+        "name": "Archmagus Remus of the Brambles"
+    }, {
+        "id": "4025",
+        "name": "Sorcerer Soya of the Brambles"
+    }, {
+        "id": "4125",
+        "name": "Sorcerer Jabir of the Brambles"
+    }, {
+        "id": "4138",
+        "name": "Archmagus Azahl of the Brambles"
+    }, {
+        "id": "4153",
+        "name": "Archmagus Ofaris of the Brambles"
+    }, {
+        "id": "4166",
+        "name": "Sage Lucien of the Brambles"
+    }, {
+        "id": "4223",
+        "name": "Sorcerer Rodolfo of the Brambles"
+    }, {
+        "id": "4226",
+        "name": "Cleric Zane of the Brambles"
+    }, {
+        "id": "4312",
+        "name": "Arch-Magician Apollo of the Brambles"
+    }, {
+        "id": "4333",
+        "name": "Archmagus Udor of the Brambles"
+    }, {
+        "id": "4357",
+        "name": "Sorcerer Ifran of the Brambles"
+    }, {
+        "id": "4407",
+        "name": "Hedge Wizard Arabella of the Brambles"
+    }, {
+        "id": "4461",
+        "name": "Ixar of the Brambles"
+    }, {
+        "id": "4522",
+        "name": "Soran of the Brambles"
+    }, {
+        "id": "4542",
+        "name": "Hedge Wizard Ursula of the Brambles"
+    }, {
+        "id": "4559",
+        "name": "Cleric Ulysse of the Brambles"
+    }, {
+        "id": "4629",
+        "name": "Hedge Wizard Danny of the Brambles"
+    }, {
+        "id": "4738",
+        "name": "Electromancer Robert of the Brambles"
+    }, {
+        "id": "4817",
+        "name": "Geomancer Apollo of the Brambles"
+    }, {
+        "id": "4897",
+        "name": "Witch Lilith of the Brambles"
+    }, {
+        "id": "4922",
+        "name": "Cosmic Mage Hothor of the Brambles"
+    }, {
+        "id": "4953",
+        "name": "Magus Cassiopeia of the Brambles"
+    }, {
+        "id": "4976",
+        "name": "Artificer Bobbin of the Brambles"
+    }, {
+        "id": "5001",
+        "name": "Celah of the Brambles"
+    }, {
+        "id": "5104",
+        "name": "Silas of the Brambles"
+    }, {
+        "id": "5134",
+        "name": "Druid Lamia of the Brambles"
+    }, {
+        "id": "5251",
+        "name": "Conjurer Atlanta of the Brambles"
+    }, {
+        "id": "5254",
+        "name": "Witch Sabina of the Brambles"
+    }, {
+        "id": "5273",
+        "name": "Arch-Magician Judas of the Brambles"
+    }, {
+        "id": "5323",
+        "name": "Magus Robert of the Brambles"
+    }, {
+        "id": "5324",
+        "name": "Hydromancer Oxnard of the Brambles"
+    }, {
+        "id": "5331",
+        "name": "Amir of the Brambles"
+    }, {
+        "id": "5413",
+        "name": "Summoner Hydra of the Brambles"
+    }, {
+        "id": "5432",
+        "name": "Arcanist Zhan of the Brambles"
+    }, {
+        "id": "5524",
+        "name": "Illusionist Jahid of the Brambles"
+    }, {
+        "id": "5600",
+        "name": "Enchanter Iris of the Brambles"
+    }, {
+        "id": "5650",
+        "name": "Witch Rowena of the Brambles"
+    }, {
+        "id": "5673",
+        "name": "Thaumaturge Rita of the Brambles"
+    }, {
+        "id": "5696",
+        "name": "Archmagus Basil of the Brambles"
+    }, {
+        "id": "5753",
+        "name": "Druid Shukri of the Brambles"
+    }, {
+        "id": "5882",
+        "name": "Conjurer Thana of the Brambles"
+    }, {
+        "id": "6039",
+        "name": "Druid Drokore of the Brambles"
+    }, {
+        "id": "6084",
+        "name": "Alchemist Asmodeus of the Brambles"
+    }, {
+        "id": "6243",
+        "name": "Sage Victoria of the Brambles"
+    }, {
+        "id": "6250",
+        "name": "Cosmic Mage  of the Brambles"
+    }, {
+        "id": "6274",
+        "name": "Shaman Aleister of the Brambles"
+    }, {
+        "id": "6336",
+        "name": "Archmagus Alessar of the Brambles"
+    }, {
+        "id": "6391",
+        "name": "Summoner Celeste of the Brambles"
+    }, {
+        "id": "6531",
+        "name": "Witch Hestia of the Brambles"
+    }, {
+        "id": "6589",
+        "name": "Shaman Hishoken of the Brambles"
+    }, {
+        "id": "6630",
+        "name": "Magus Ilyas of the Brambles"
+    }, {
+        "id": "6669",
+        "name": "Sorcerer Alizam of the Brambles"
+    }, {
+        "id": "6826",
+        "name": "Diabolist Robert of the Brambles"
+    }, {
+        "id": "6899",
+        "name": "Enchanter Artis of the Brambles"
+    }, {
+        "id": "6920",
+        "name": "Archmagus Willow of the Brambles"
+    }, {
+        "id": "7000",
+        "name": "Alchemist Aldo of the Brambles"
+    }, {
+        "id": "7012",
+        "name": "Shaman Florah of the Brambles"
+    }, {
+        "id": "7039",
+        "name": "Milo of the Brambles"
+    }, {
+        "id": "7116",
+        "name": "Arcanist Cassandra of the Brambles"
+    }, {
+        "id": "7140",
+        "name": "Hydromancer Soran of the Brambles"
+    }, {
+        "id": "7182",
+        "name": "Witch Sylvia of the Brambles"
+    }, {
+        "id": "7241",
+        "name": "Ghost Eater Hecate of the Brambles"
+    }, {
+        "id": "7281",
+        "name": "Magus Nazim of the Brambles"
+    }, {
+        "id": "7282",
+        "name": "Arcanist Florah of the Brambles"
+    }, {
+        "id": "7438",
+        "name": "Enchanter Atlanta of the Brambles"
+    }, {
+        "id": "7451",
+        "name": "Druid Jezebel of the Brambles"
+    }, {
+        "id": "7491",
+        "name": "Mystic Cassius of the Brambles"
+    }, {
+        "id": "7524",
+        "name": "Udor of the Brambles"
+    }, {
+        "id": "7529",
+        "name": "Enchanter Asphodel of the Brambles"
+    }, {
+        "id": "7544",
+        "name": "Sage Hind of the Brambles"
+    }, {
+        "id": "7548",
+        "name": "Merlon of the Brambles"
+    }, {
+        "id": "7636",
+        "name": "Alchemist Merlon of the Brambles"
+    }, {
+        "id": "7782",
+        "name": "Archmagus Malcom of the Brambles"
+    }, {
+        "id": "8158",
+        "name": "Archmagus Chandler of the Brambles"
+    }, {
+        "id": "8163",
+        "name": "Battle Mage Axel of the Brambles"
+    }, {
+        "id": "8242",
+        "name": "Hedge Wizard Soya of the Brambles"
+    }, {
+        "id": "8375",
+        "name": "Arcanist Cassius of the Brambles"
+    }, {
+        "id": "8489",
+        "name": "Diviner Hagar of the Brambles"
+    }, {
+        "id": "8556",
+        "name": "Arch-Magician Angus of the Brambles"
+    }, {
+        "id": "8571",
+        "name": "Void Disciple Asmodeus of the Brambles"
+    }, {
+        "id": "8617",
+        "name": "Geomancer Amanita of the Brambles"
+    }, {
+        "id": "8643",
+        "name": "Artificer Reza of the Brambles"
+    }, {
+        "id": "8694",
+        "name": "Wild Mage Robert of the Brambles"
+    }, {
+        "id": "8702",
+        "name": "Geomancer Jagger of the Brambles"
+    }, {
+        "id": "8708",
+        "name": "Druid Azahl of the Brambles"
+    }, {
+        "id": "8715",
+        "name": "Battle Mage Flynn of the Brambles"
+    }, {
+        "id": "8738",
+        "name": "Geomancer Jameel of the Brambles"
+    }, {
+        "id": "8739",
+        "name": "Arcanist Sarah of the Brambles"
+    }, {
+        "id": "8784",
+        "name": "Sage Rita of the Brambles"
+    }, {
+        "id": "9039",
+        "name": "Archmagus Xiuying of the Brambles"
+    }, {
+        "id": "9124",
+        "name": "Shaman Darick of the Brambles"
+    }, {
+        "id": "9155",
+        "name": "Hydromancer Goliath of the Brambles"
+    }, {
+        "id": "9158",
+        "name": "Archmagus Lumos of the Brambles"
+    }, {
+        "id": "9170",
+        "name": "Sage Zubin of the Brambles"
+    }, {
+        "id": "9203",
+        "name": "Shaman Soya of the Brambles"
+    }, {
+        "id": "9221",
+        "name": "Mystic Hagatha of the Brambles"
+    }, {
+        "id": "9237",
+        "name": "Enchanter Atlanta of the Brambles"
+    }, {
+        "id": "9281",
+        "name": "Charmer Asphodel of the Brambles"
+    }, {
+        "id": "9314",
+        "name": "Hydromancer Pierre of the Brambles"
+    }, {
+        "id": "9323",
+        "name": "Mystic Willow of the Brambles"
+    }, {
+        "id": "9437",
+        "name": "Sorcerer Lin of the Brambles"
+    }, {
+        "id": "9441",
+        "name": "Spellsinger Toka of the Brambles"
+    }, {
+        "id": "9447",
+        "name": "Ghost Eater Ratko of the Brambles"
+    }, {
+        "id": "9453",
+        "name": "Druid Rocco of the Brambles"
+    }, {
+        "id": "9507",
+        "name": "Geomancer Moloch of the Brambles"
+    }, {
+        "id": "9556",
+        "name": "Sorcerer Isaac of the Brambles"
+    }, {
+        "id": "9563",
+        "name": "Hedge Wizard Hestia of the Brambles"
+    }, {
+        "id": "9664",
+        "name": "Holy Monk Adium of the Brambles"
+    }, {
+        "id": "9679",
+        "name": "Witch Ekmira of the Brambles"
+    }, {
+        "id": "9714",
+        "name": "Archmagus Gully of the Brambles"
+    }, {
+        "id": "9720",
+        "name": "Arcanist Danny of the Brambles"
+    }, {
+        "id": "9811",
+        "name": "Druid Lavinia of the Brambles"
+    }, {
+        "id": "9835",
+        "name": "Conjurer Nori of the Brambles"
+    }, {
+        "id": "9862",
+        "name": "Shaman Nolan of the Brambles"
+    }, {
+        "id": "9906",
+        "name": "Druid Delilah of the Brambles"
+    }, {
+        "id": "9989",
+        "name": "Circe of the Brambles"
+    }],
+    "Hollow": [{
+        "id": "44",
+        "name": "Wild Mage Lumos of the Hollow"
+    }, {
+        "id": "60",
+        "name": "Alchemist Soya of the Hollow"
+    }, {
+        "id": "108",
+        "name": "Artificer Nadeem of the Hollow"
+    }, {
+        "id": "115",
+        "name": "Witch Hecate of the Hollow"
+    }, {
+        "id": "170",
+        "name": "Voodoo Priest Impy of the Hollow"
+    }, {
+        "id": "178",
+        "name": "Chaos Mage Milo of the Hollow"
+    }, {
+        "id": "215",
+        "name": "Druid Ming of the Hollow"
+    }, {
+        "id": "295",
+        "name": "Enchanter Larissa of the Hollow"
+    }, {
+        "id": "303",
+        "name": "Enchanter Sarah of the Hollow"
+    }, {
+        "id": "311",
+        "name": "Conjurer Finn of the Hollow"
+    }, {
+        "id": "590",
+        "name": "Archmagus Amir of the Hollow"
+    }, {
+        "id": "631",
+        "name": "Thaumaturge Jahid of the Hollow"
+    }, {
+        "id": "698",
+        "name": "Archmagus Bogey of the Hollow"
+    }, {
+        "id": "709",
+        "name": "Jadis of the Hollow"
+    }, {
+        "id": "724",
+        "name": "Shaman Zelda of the Hollow"
+    }, {
+        "id": "779",
+        "name": "Hedge Wizard Lenora of the Hollow"
+    }, {
+        "id": "839",
+        "name": "Charmer Daria of the Hollow"
+    }, {
+        "id": "845",
+        "name": "Witch Ambrosia of the Hollow"
+    }, {
+        "id": "1002",
+        "name": "Charmer Artis of the Hollow"
+    }, {
+        "id": "1084",
+        "name": "Archmagus Silas of the Hollow"
+    }, {
+        "id": "1172",
+        "name": "Archmagus Xiaosheng of the Hollow"
+    }, {
+        "id": "1230",
+        "name": "Solar Mage Iris of the Hollow"
+    }, {
+        "id": "1414",
+        "name": "Enchanter Beyna of the Hollow"
+    }, {
+        "id": "1476",
+        "name": "Hedge Wizard Zelroth of the Hollow"
+    }, {
+        "id": "1513",
+        "name": "Archmagus Aleister of the Hollow"
+    }, {
+        "id": "1563",
+        "name": "Chaos Mage Kobold of the Hollow"
+    }, {
+        "id": "1656",
+        "name": "Shaman Jameel of the Hollow"
+    }, {
+        "id": "1693",
+        "name": "Sorcerer Nassif of the Hollow"
+    }, {
+        "id": "1733",
+        "name": "Magus Thor of the Hollow"
+    }, {
+        "id": "1748",
+        "name": "Archmagus Umber of the Hollow"
+    }, {
+        "id": "1865",
+        "name": "Archmagus Ozohr of the Hollow"
+    }, {
+        "id": "1879",
+        "name": "Hedge Wizard Diana of the Hollow"
+    }, {
+        "id": "1960",
+        "name": "Shaman Durm of the Hollow"
+    }, {
+        "id": "1962",
+        "name": "Geomancer Moloch of the Hollow"
+    }, {
+        "id": "2013",
+        "name": "Archmagus Galatea of the Hollow"
+    }, {
+        "id": "2037",
+        "name": "Alchemist Katherine of the Hollow"
+    }, {
+        "id": "2065",
+        "name": "Hedge Wizard Artis of the Hollow"
+    }, {
+        "id": "2097",
+        "name": "Shadow Mage Hestia of the Hollow"
+    }, {
+        "id": "2102",
+        "name": "Witch Sabina of the Hollow"
+    }, {
+        "id": "2176",
+        "name": "Archmagus Casper of the Hollow"
+    }, {
+        "id": "2314",
+        "name": "Archmagus Chu Hua of the Hollow"
+    }, {
+        "id": "2362",
+        "name": "Arch-Magician Ilu of the Hollow"
+    }, {
+        "id": "2410",
+        "name": "Archmagus Uvlius of the Hollow"
+    }, {
+        "id": "2448",
+        "name": "Amir of the Hollow"
+    }, {
+        "id": "2574",
+        "name": "Carly of the Hollow"
+    }, {
+        "id": "2592",
+        "name": "Althea of the Hollow"
+    }, {
+        "id": "2608",
+        "name": "Beyna of the Hollow"
+    }, {
+        "id": "2626",
+        "name": "Thaumaturge Daria of the Hollow"
+    }, {
+        "id": "2687",
+        "name": "Archmagus Milo of the Hollow"
+    }, {
+        "id": "2831",
+        "name": "Enchanter Daria of the Hollow"
+    }, {
+        "id": "2951",
+        "name": "Clairvoyant Faye of the Hollow"
+    }, {
+        "id": "3038",
+        "name": "Archmagus Celah of the Hollow"
+    }, {
+        "id": "3047",
+        "name": "Archmagus Alatar of the Hollow"
+    }, {
+        "id": "3079",
+        "name": "Archmagus Toka of the Hollow"
+    }, {
+        "id": "3149",
+        "name": "Sage Orpheus of the Hollow"
+    }, {
+        "id": "3159",
+        "name": "Enchanter Faye of the Hollow"
+    }, {
+        "id": "3172",
+        "name": "Mystic Aleister of the Hollow"
+    }, {
+        "id": "3190",
+        "name": "Medium Hansel of the Hollow"
+    }, {
+        "id": "3303",
+        "name": "Battlemage Quddus of the Hollow"
+    }, {
+        "id": "3362",
+        "name": "Hedge Wizard Daria of the Hollow"
+    }, {
+        "id": "3464",
+        "name": "Hedge Wizard Tumbaj of the Hollow"
+    }, {
+        "id": "3471",
+        "name": "Necromancer Edge of the Hollow"
+    }, {
+        "id": "3505",
+        "name": "Artificer Tundror of the Hollow"
+    }, {
+        "id": "3580",
+        "name": "Spellsinger Galatea of the Hollow"
+    }, {
+        "id": "3864",
+        "name": "Scryer Lenora of the Hollow"
+    }, {
+        "id": "3883",
+        "name": "Sonja of the Hollow"
+    }, {
+        "id": "3966",
+        "name": "Artificer Enzo of the Hollow"
+    }, {
+        "id": "4006",
+        "name": "Hydromancer Wolfram of the Hollow"
+    }, {
+        "id": "4128",
+        "name": "Hedge Wizard Florah of the Hollow"
+    }, {
+        "id": "4135",
+        "name": "Pyromancer Auguste of the Hollow"
+    }, {
+        "id": "4216",
+        "name": "Battle Mage Homer of the Hollow"
+    }, {
+        "id": "4268",
+        "name": "Shaman Seth of the Hollow"
+    }, {
+        "id": "4300",
+        "name": "Shaman Daria of the Hollow"
+    }, {
+        "id": "4308",
+        "name": "Conjurer Bartholomew of the Hollow"
+    }, {
+        "id": "4367",
+        "name": "Enchanter Miyo of the Hollow"
+    }, {
+        "id": "4503",
+        "name": "Shaman Tundror of the Hollow"
+    }, {
+        "id": "4552",
+        "name": "Illusionist Gunthor of the Hollow"
+    }, {
+        "id": "4713",
+        "name": "Witch Lamia of the Hollow"
+    }, {
+        "id": "4782",
+        "name": "Witch Sylvia of the Hollow"
+    }, {
+        "id": "4798",
+        "name": "Artificer Sabina of the Hollow"
+    }, {
+        "id": "4842",
+        "name": "Alchemist Arcus of the Hollow"
+    }, {
+        "id": "4999",
+        "name": "Wild Mage Ofaris of the Hollow"
+    }, {
+        "id": "5009",
+        "name": "Void Disciple Tengukensei of the Hollow"
+    }, {
+        "id": "5049",
+        "name": "Battle Mage Hansel of the Hollow"
+    }, {
+        "id": "5214",
+        "name": "Hedge Wizard Huan of the Hollow"
+    }, {
+        "id": "5215",
+        "name": "Augurer Rita of the Hollow"
+    }, {
+        "id": "5295",
+        "name": "Archmagus Uvlius of the Hollow"
+    }, {
+        "id": "5316",
+        "name": "Runecaster Merlon of the Hollow"
+    }, {
+        "id": "5319",
+        "name": "Sage Azahl of the Hollow"
+    }, {
+        "id": "5379",
+        "name": "Archmagus Onaxx of the Hollow"
+    }, {
+        "id": "5445",
+        "name": "Enchanter Pandora of the Hollow"
+    }, {
+        "id": "5560",
+        "name": "Sage Faye of the Hollow"
+    }, {
+        "id": "5572",
+        "name": "Cleric Cybele of the Hollow"
+    }, {
+        "id": "5653",
+        "name": "Geomancer Ursula of the Hollow"
+    }, {
+        "id": "5706",
+        "name": "Battle Mage Nicolas of the Hollow"
+    }, {
+        "id": "5749",
+        "name": "Archmagus Lumos of the Hollow"
+    }, {
+        "id": "5766",
+        "name": "Enchanter Devon of the Hollow"
+    }, {
+        "id": "5827",
+        "name": "Archmagus Malthus of the Hollow"
+    }, {
+        "id": "5913",
+        "name": "Shaman Tabitha of the Hollow"
+    }, {
+        "id": "5974",
+        "name": "Battle Mage Thor of the Hollow"
+    }, {
+        "id": "5988",
+        "name": "Sage Oberon of the Hollow"
+    }, {
+        "id": "5997",
+        "name": "Shadow Mage Azahl of the Hollow"
+    }, {
+        "id": "6050",
+        "name": "Adept Fark of the Hollow"
+    }, {
+        "id": "6112",
+        "name": "Wizard Lin of the Hollow"
+    }, {
+        "id": "6181",
+        "name": "Enchanter Lamia of the Hollow"
+    }, {
+        "id": "6200",
+        "name": "Alchemist Daphne of the Hollow"
+    }, {
+        "id": "6214",
+        "name": "Geomancer Amir of the Hollow"
+    }, {
+        "id": "6292",
+        "name": "Witch Ivy of the Hollow"
+    }, {
+        "id": "6343",
+        "name": "Alchemist Shizu of the Hollow"
+    }, {
+        "id": "6379",
+        "name": "Archmagus Lux of the Hollow"
+    }, {
+        "id": "6421",
+        "name": "Witch Shivra of the Hollow"
+    }, {
+        "id": "6493",
+        "name": "Shadow Mage Lenora of the Hollow"
+    }, {
+        "id": "6504",
+        "name": "Enchanter Atlanta of the Hollow"
+    }, {
+        "id": "6532",
+        "name": "Arcanist Crowley of the Hollow"
+    }, {
+        "id": "6557",
+        "name": "Conjurer Solomon of the Hollow"
+    }, {
+        "id": "6562",
+        "name": "Hedge Wizard Pepo of the Hollow"
+    }, {
+        "id": "6611",
+        "name": "Hydromancer Larissa of the Hollow"
+    }, {
+        "id": "6638",
+        "name": "Geomancer Calypso of the Hollow"
+    }, {
+        "id": "6720",
+        "name": "Galatea of the Hollow"
+    }, {
+        "id": "6752",
+        "name": "Archmagus Jeldor of the Hollow"
+    }, {
+        "id": "6809",
+        "name": "Cosmic Mage Rowena of the Hollow"
+    }, {
+        "id": "6933",
+        "name": "Illusionist Chu Hua of the Hollow"
+    }, {
+        "id": "6948",
+        "name": "Archmagus Azahl of the Hollow"
+    }, {
+        "id": "6955",
+        "name": "Katherine of the Hollow"
+    }, {
+        "id": "6960",
+        "name": "Charmer Devon of the Hollow"
+    }, {
+        "id": "7126",
+        "name": "Battle Mage Ulysse of the Hollow"
+    }, {
+        "id": "7146",
+        "name": "Druid Hugo of the Hollow"
+    }, {
+        "id": "7157",
+        "name": "Alchemist Rita of the Hollow"
+    }, {
+        "id": "7187",
+        "name": "Magus Rumpleskin of the Hollow"
+    }, {
+        "id": "7349",
+        "name": "Adept Cedric of the Hollow"
+    }, {
+        "id": "7362",
+        "name": "Enchanter Asphodel of the Hollow"
+    }, {
+        "id": "7436",
+        "name": "Artificer Davos of the Hollow"
+    }, {
+        "id": "7445",
+        "name": "Magus Alessar of the Hollow"
+    }, {
+        "id": "7586",
+        "name": "Magus Allistair of the Hollow"
+    }, {
+        "id": "7587",
+        "name": "Carly of the Hollow"
+    }, {
+        "id": "7711",
+        "name": "Electromancer Althea of the Hollow"
+    }, {
+        "id": "7738",
+        "name": "Battle Mage Tundror of the Hollow"
+    }, {
+        "id": "7886",
+        "name": "Battle Mage Thor of the Hollow"
+    }, {
+        "id": "7993",
+        "name": "Summoner Tengu of the Hollow"
+    }, {
+        "id": "8010",
+        "name": "Druid Cassiopeia of the Hollow"
+    }, {
+        "id": "8055",
+        "name": "Adrienne of the Hollow"
+    }, {
+        "id": "8078",
+        "name": "Isaac of the Hollow"
+    }, {
+        "id": "8125",
+        "name": "Battle Mage Horace of the Hollow"
+    }, {
+        "id": "8147",
+        "name": "Sage Shivra of the Hollow"
+    }, {
+        "id": "8312",
+        "name": "Katherine of the Hollow"
+    }, {
+        "id": "8352",
+        "name": "Sage Cybele of the Hollow"
+    }, {
+        "id": "8418",
+        "name": "Enchanter Arabella of the Hollow"
+    }, {
+        "id": "8422",
+        "name": "Hedge Wizard Mina of the Hollow"
+    }, {
+        "id": "8534",
+        "name": "Shaman Lumos of the Hollow"
+    }, {
+        "id": "8537",
+        "name": "Druid Rita of the Hollow"
+    }, {
+        "id": "8691",
+        "name": "Archmagus Basil of the Hollow"
+    }, {
+        "id": "8709",
+        "name": "Shadow Mage Ofaris of the Hollow"
+    }, {
+        "id": "8752",
+        "name": "Witch Sabina of the Hollow"
+    }, {
+        "id": "8754",
+        "name": "Artificer Finn of the Hollow"
+    }, {
+        "id": "8853",
+        "name": "Cryptomancer Ambrosia of the Hollow"
+    }, {
+        "id": "9037",
+        "name": "Ghost Eater Jadis of the Hollow"
+    }, {
+        "id": "9107",
+        "name": "Magus Fark of the Hollow"
+    }, {
+        "id": "9116",
+        "name": "Cleric Alatar of the Hollow"
+    }, {
+        "id": "9144",
+        "name": "Archmagus Bojangles of the Hollow"
+    }, {
+        "id": "9166",
+        "name": "Enchanter Willow of the Hollow"
+    }, {
+        "id": "9325",
+        "name": "Scryer Jeldor of the Hollow"
+    }, {
+        "id": "9372",
+        "name": "Alchemist Devon of the Hollow"
+    }, {
+        "id": "9427",
+        "name": "Zaros of the Hollow"
+    }, {
+        "id": "9456",
+        "name": "Artificer Jiggs of the Hollow"
+    }, {
+        "id": "9475",
+        "name": "Druid Quddus of the Hollow"
+    }, {
+        "id": "9501",
+        "name": "Artificer Cedric of the Hollow"
+    }, {
+        "id": "9642",
+        "name": "Arch-Magician Merlon of the Hollow"
+    }, {
+        "id": "9693",
+        "name": "Magus Amanita of the Hollow"
+    }, {
+        "id": "9831",
+        "name": "Cleric Althea of the Hollow"
+    }, {
+        "id": "9930",
+        "name": "Battle Mage Baird of the Hollow"
+    }, {
+        "id": "9979",
+        "name": "Cryptomancer Samael of the Hollow"
+    }],
+    "Canyon": [{
+        "id": "192",
+        "name": "Conjurer Maia of the Canyon"
+    }, {
+        "id": "225",
+        "name": "Alchemist Robert of the Canyon"
+    }, {
+        "id": "419",
+        "name": "Shaman Malthus of the Canyon"
+    }, {
+        "id": "473",
+        "name": "Enchanter Beyna of the Canyon"
+    }, {
+        "id": "491",
+        "name": "Hedge Wizard Lamia of the Canyon"
+    }, {
+        "id": "616",
+        "name": "Hedge Wizard Amir of the Canyon"
+    }, {
+        "id": "797",
+        "name": "Enchanter Artis of the Canyon"
+    }, {
+        "id": "860",
+        "name": "Nikolas of the Canyon"
+    }, {
+        "id": "1235",
+        "name": "Archmagus Shizu of the Canyon"
+    }, {
+        "id": "1302",
+        "name": "Magus Sahir of the Canyon"
+    }, {
+        "id": "1325",
+        "name": "Hex Mage Asphodel of the Canyon"
+    }, {
+        "id": "1391",
+        "name": "Conjurer Alatar of the Canyon"
+    }, {
+        "id": "1434",
+        "name": "Charmer Althea of the Canyon"
+    }, {
+        "id": "1575",
+        "name": "Calliope of the Canyon"
+    }, {
+        "id": "1624",
+        "name": "Archmagus Crowley of the Canyon"
+    }, {
+        "id": "1826",
+        "name": "Arch-Magician Fumiko of the Canyon"
+    }, {
+        "id": "1977",
+        "name": "Conjurer Crackerjack of the Canyon"
+    }, {
+        "id": "2020",
+        "name": "Geomancer Poppy of the Canyon"
+    }, {
+        "id": "2109",
+        "name": "Geomancer Gunthor of the Canyon"
+    }, {
+        "id": "2184",
+        "name": "Cryptomancer Larissa of the Canyon"
+    }, {
+        "id": "2269",
+        "name": "Thaumaturge Rita of the Canyon"
+    }, {
+        "id": "2281",
+        "name": "Casper of the Canyon"
+    }, {
+        "id": "2325",
+        "name": "Diviner Larissa of the Canyon"
+    }, {
+        "id": "2455",
+        "name": "Sage Eric of the Canyon"
+    }, {
+        "id": "2588",
+        "name": "Battlemage Axel of the Canyon"
+    }, {
+        "id": "2645",
+        "name": "Enchanter Daria of the Canyon"
+    }, {
+        "id": "2704",
+        "name": "Druid Ravana of the Canyon"
+    }, {
+        "id": "2844",
+        "name": "Alchemist Milton of the Canyon"
+    }, {
+        "id": "2889",
+        "name": "Magus Sahir of the Canyon"
+    }, {
+        "id": "2913",
+        "name": "Enchanter Daria of the Canyon"
+    }, {
+        "id": "3016",
+        "name": "Charmer Arabella of the Canyon"
+    }, {
+        "id": "3019",
+        "name": "Runecaster Robert of the Canyon"
+    }, {
+        "id": "3046",
+        "name": "Charmer Sonja of the Canyon"
+    }, {
+        "id": "3058",
+        "name": "Archmagus Gino of the Canyon"
+    }, {
+        "id": "3107",
+        "name": "Arch-Magician Rowena of the Canyon"
+    }, {
+        "id": "3123",
+        "name": "Mina of the Canyon"
+    }, {
+        "id": "3130",
+        "name": "Aeromancer Lin of the Canyon"
+    }, {
+        "id": "3294",
+        "name": "Chronomancer Hagar of the Canyon"
+    }, {
+        "id": "3383",
+        "name": "Aeromancer Suyin of the Canyon"
+    }, {
+        "id": "3506",
+        "name": "Thaumaturge Fark of the Canyon"
+    }, {
+        "id": "3699",
+        "name": "Arcanist Poppy of the Canyon"
+    }, {
+        "id": "3748",
+        "name": "Chaos Mage Angus of the Canyon"
+    }, {
+        "id": "3962",
+        "name": "Archmagus Ofaris of the Canyon"
+    }, {
+        "id": "3973",
+        "name": "Archmagus Aden of the Canyon"
+    }, {
+        "id": "4062",
+        "name": "Witch Rita of the Canyon"
+    }, {
+        "id": "4131",
+        "name": "Hedge Wizard Lin of the Canyon"
+    }, {
+        "id": "4321",
+        "name": "Ozohr of the Canyon"
+    }, {
+        "id": "4831",
+        "name": "Archmagus Aleister of the Canyon"
+    }, {
+        "id": "4833",
+        "name": "Sage Titania of the Canyon"
+    }, {
+        "id": "5022",
+        "name": "Sorcerer Remus of the Canyon"
+    }, {
+        "id": "5197",
+        "name": "Diabolist Reza of the Canyon"
+    }, {
+        "id": "5230",
+        "name": "Ghost Eater Godfrey of the Canyon"
+    }, {
+        "id": "5373",
+        "name": "Bard Pezo of the Canyon"
+    }, {
+        "id": "5437",
+        "name": "Wizard Aiko of the Canyon"
+    }, {
+        "id": "5492",
+        "name": "Battle Mage Nicolas of the Canyon"
+    }, {
+        "id": "5525",
+        "name": "Alchemist Melanzana of the Canyon"
+    }, {
+        "id": "5531",
+        "name": "Illusionist Larissa of the Canyon"
+    }, {
+        "id": "5580",
+        "name": "Enchanter Daria of the Canyon"
+    }, {
+        "id": "5595",
+        "name": "Alchemist Delilah of the Canyon"
+    }, {
+        "id": "5609",
+        "name": "Enchanter Sondra of the Canyon"
+    }, {
+        "id": "5690",
+        "name": "Artificer Patch of the Canyon"
+    }, {
+        "id": "5700",
+        "name": "Alchemist Ravana of the Canyon"
+    }, {
+        "id": "5710",
+        "name": "Battle Mage Axel of the Canyon"
+    }, {
+        "id": "5757",
+        "name": "Shaman Alizam of the Canyon"
+    }, {
+        "id": "5803",
+        "name": "Illusionist Galatea of the Canyon"
+    }, {
+        "id": "5954",
+        "name": "Hex Mage Sylvia of the Canyon"
+    }, {
+        "id": "6056",
+        "name": "Iprix of the Canyon"
+    }, {
+        "id": "6125",
+        "name": "Enchanter Willow of the Canyon"
+    }, {
+        "id": "6224",
+        "name": "Witch Gwendolin of the Canyon"
+    }, {
+        "id": "6785",
+        "name": "Archmagus Alatar of the Canyon"
+    }, {
+        "id": "6850",
+        "name": "Magus Drusilla of the Canyon"
+    }, {
+        "id": "6975",
+        "name": "Hydromancer Toadstool of the Canyon"
+    }, {
+        "id": "7022",
+        "name": "Battle Mage Goliath of the Canyon"
+    }, {
+        "id": "7023",
+        "name": "Shaman Circe of the Canyon"
+    }, {
+        "id": "7037",
+        "name": "Oberon of the Canyon"
+    }, {
+        "id": "7395",
+        "name": "Sage Lamia of the Canyon"
+    }, {
+        "id": "7603",
+        "name": "Arch-Magician Hecate of the Canyon"
+    }, {
+        "id": "7702",
+        "name": "Shaman Goliath of the Canyon"
+    }, {
+        "id": "7742",
+        "name": "Conjurer Larissa of the Canyon"
+    }, {
+        "id": "7772",
+        "name": "Archmagus Lenora of the Canyon"
+    }, {
+        "id": "7887",
+        "name": "Alchemist Daria of the Canyon"
+    }, {
+        "id": "8376",
+        "name": "Shadow Mage Fark of the Canyon"
+    }, {
+        "id": "8437",
+        "name": "Battle Mage Samuel of the Canyon"
+    }, {
+        "id": "8555",
+        "name": "Magus Qasim of the Canyon"
+    }, {
+        "id": "8607",
+        "name": "Void Disciple Voidoth of the Canyon"
+    }, {
+        "id": "8680",
+        "name": "Illusionist Shroomer of the Canyon"
+    }, {
+        "id": "8750",
+        "name": "Wild Mage Darick of the Canyon"
+    }, {
+        "id": "8816",
+        "name": "Lunar Mage Rodolfo of the Canyon"
+    }, {
+        "id": "8885",
+        "name": "Wild Mage Katherine of the Canyon"
+    }, {
+        "id": "9017",
+        "name": "Sage Yumi of the Canyon"
+    }, {
+        "id": "9036",
+        "name": "Witch Diana of the Canyon"
+    }, {
+        "id": "9143",
+        "name": "Battle Mage Magnus of the Canyon"
+    }, {
+        "id": "9267",
+        "name": "Wizard Peppy of the Canyon"
+    }, {
+        "id": "9343",
+        "name": "Arch-Magician Silas of the Canyon"
+    }, {
+        "id": "9370",
+        "name": "Artificer  of the Canyon"
+    }, {
+        "id": "9476",
+        "name": "Enchanter Leah of the Canyon"
+    }, {
+        "id": "9564",
+        "name": "Battle Mage Baird of the Canyon"
+    }, {
+        "id": "9610",
+        "name": "Pyromancer Faye of the Canyon"
+    }, {
+        "id": "9614",
+        "name": "Alchemist Soya of the Canyon"
+    }, {
+        "id": "9666",
+        "name": "Diabolist Cybele of the Canyon"
+    }, {
+        "id": "9766",
+        "name": "Sorcerer Casper of the Canyon"
+    }],
+    "Crag": [{
+        "id": "942",
+        "name": "Augurer Borak of the Crag"
+    }, {
+        "id": "2123",
+        "name": "Arch-Magician Voidoth of the Crag"
+    }, {
+        "id": "2345",
+        "name": "Ice Mage Soya of the Crag"
+    }, {
+        "id": "3129",
+        "name": "Diviner Eric of the Crag"
+    }, {
+        "id": "5450",
+        "name": "Zelroth of the Crag"
+    }, {
+        "id": "5571",
+        "name": "Artificer Faye of the Crag"
+    }, {
+        "id": "6134",
+        "name": "Chronomancer Gunthor of the Crag"
+    }, {
+        "id": "6263",
+        "name": "Ice Mage Luther of the Crag"
+    }, {
+        "id": "6295",
+        "name": "Shaman Hothor of the Crag"
+    }, {
+        "id": "6409",
+        "name": "Ice Mage Aleister of the Crag"
+    }, {
+        "id": "7224",
+        "name": "Hex Mage  of the Crag"
+    }, {
+        "id": "7664",
+        "name": "Battle Mage Ulysse of the Crag"
+    }, {
+        "id": "7798",
+        "name": "Ice Mage Buttons of the Crag"
+    }, {
+        "id": "7815",
+        "name": "Magus Impy of the Crag"
+    }, {
+        "id": "9059",
+        "name": "Augurer George of the Crag"
+    }, {
+        "id": "9327",
+        "name": "Ice Mage Chiyo of the Crag"
+    }],
+    "Gnostics": [{
+        "id": "57",
+        "name": "Void Disciple Magpie of the Gnostics"
+    }, {
+        "id": "68",
+        "name": "Wild Mage Soya of the Gnostics"
+    }, {
+        "id": "92",
+        "name": "Sky Master Jagger of the Gnostics"
+    }, {
+        "id": "162",
+        "name": "Hex Mage Atlas of the Gnostics"
+    }, {
+        "id": "562",
+        "name": "Scryer Isaac of the Gnostics"
+    }, {
+        "id": "782",
+        "name": "Druid Lilith of the Gnostics"
+    }, {
+        "id": "831",
+        "name": "Archmagus Milo of the Gnostics"
+    }, {
+        "id": "849",
+        "name": "Chronomancer Zaros of the Gnostics"
+    }, {
+        "id": "862",
+        "name": "Archmagus Charlord of the Gnostics"
+    }, {
+        "id": "966",
+        "name": "Mystic Apollo of the Gnostics"
+    }, {
+        "id": "1110",
+        "name": "Battlemage Eizo of the Gnostics"
+    }, {
+        "id": "1177",
+        "name": "Adept Baptiste of the Gnostics"
+    }, {
+        "id": "1255",
+        "name": "Pyromancer Rita of the Gnostics"
+    }, {
+        "id": "1282",
+        "name": "Witch Rita of the Gnostics"
+    }, {
+        "id": "1338",
+        "name": "Oberon of the Gnostics"
+    }, {
+        "id": "1701",
+        "name": "Magus Ixar of the Gnostics"
+    }, {
+        "id": "1732",
+        "name": "Artificer Magpie of the Gnostics"
+    }, {
+        "id": "1921",
+        "name": "Artis of the Gnostics"
+    }, {
+        "id": "2196",
+        "name": "Enchanter  of the Gnostics"
+    }, {
+        "id": "2222",
+        "name": "Battle Mage Cromwell of the Gnostics"
+    }, {
+        "id": "2226",
+        "name": "Runecaster Solomon of the Gnostics"
+    }, {
+        "id": "2296",
+        "name": "Adept Zelroth of the Gnostics"
+    }, {
+        "id": "2371",
+        "name": "Necromancer Scratch of the Gnostics"
+    }, {
+        "id": "2708",
+        "name": "Archmagus Casper of the Gnostics"
+    }, {
+        "id": "2722",
+        "name": "Crowley of the Gnostics"
+    }, {
+        "id": "2858",
+        "name": "Runecaster Ixar of the Gnostics"
+    }, {
+        "id": "2912",
+        "name": "Voodoo Priest Hothor of the Gnostics"
+    }, {
+        "id": "2935",
+        "name": "Sorcerer Nassif of the Gnostics"
+    }, {
+        "id": "2980",
+        "name": "Bard Molek of the Gnostics"
+    }, {
+        "id": "3168",
+        "name": "Artificer Raul of the Gnostics"
+    }, {
+        "id": "3170",
+        "name": "Basil of the Gnostics"
+    }, {
+        "id": "3201",
+        "name": "Mystic Onaxx of the Gnostics"
+    }, {
+        "id": "3406",
+        "name": "Sage Ofaris of the Gnostics"
+    }, {
+        "id": "3529",
+        "name": "Alchemist Demos of the Gnostics"
+    }, {
+        "id": "3554",
+        "name": "Arch-Magician Salvatore of the Gnostics"
+    }, {
+        "id": "3594",
+        "name": "Pyromancer Alice of the Gnostics"
+    }, {
+        "id": "3651",
+        "name": "Necromancer Burnside of the Gnostics"
+    }, {
+        "id": "3691",
+        "name": "Sorcerer Alessar of the Gnostics"
+    }, {
+        "id": "3732",
+        "name": "Void Disciple Jeldor of the Gnostics"
+    }, {
+        "id": "3878",
+        "name": "Battle Mage Tundror of the Gnostics"
+    }, {
+        "id": "3903",
+        "name": "Voodoo Priest Victor of the Gnostics"
+    }, {
+        "id": "3939",
+        "name": "Sorcerer Nazim of the Gnostics"
+    }, {
+        "id": "3985",
+        "name": "Shaman Milton of the Gnostics"
+    }, {
+        "id": "4044",
+        "name": "Druid Froggy of the Gnostics"
+    }, {
+        "id": "4085",
+        "name": "Summoner  of the Gnostics"
+    }, {
+        "id": "4118",
+        "name": "Archmagus Onaxx of the Gnostics"
+    }, {
+        "id": "4272",
+        "name": "Lumos of the Gnostics"
+    }, {
+        "id": "4373",
+        "name": "Magus Behemoth of the Gnostics"
+    }, {
+        "id": "4476",
+        "name": "Adept Merlon of the Gnostics"
+    }, {
+        "id": "4477",
+        "name": "Evil Arcanist Black Phillip of the Gnostics"
+    }, {
+        "id": "4560",
+        "name": "Archmagus Oberon of the Gnostics"
+    }, {
+        "id": "4575",
+        "name": "Illusionist Ixar of the Gnostics"
+    }, {
+        "id": "4797",
+        "name": "Augurer Atlas of the Gnostics"
+    }, {
+        "id": "4886",
+        "name": "Atlanta of the Gnostics"
+    }, {
+        "id": "4890",
+        "name": "Electromancer Yookoo of the Gnostics"
+    }, {
+        "id": "4996",
+        "name": "Void Disciple Arcus of the Gnostics"
+    }, {
+        "id": "5012",
+        "name": "Archmagus Jeldor of the Gnostics"
+    }, {
+        "id": "5127",
+        "name": "Cleric George of the Gnostics"
+    }, {
+        "id": "5212",
+        "name": "Battle Mage Nolan of the Gnostics"
+    }, {
+        "id": "5232",
+        "name": "Sage Aleister of the Gnostics"
+    }, {
+        "id": "5288",
+        "name": "Sage Hanataka of the Gnostics"
+    }, {
+        "id": "5392",
+        "name": "Artificer Setsuko of the Gnostics"
+    }, {
+        "id": "5394",
+        "name": "Cleric Jeldor of the Gnostics"
+    }, {
+        "id": "5422",
+        "name": "Sage Jerret of the Gnostics"
+    }, {
+        "id": "5534",
+        "name": "Illusionist Lumos of the Gnostics"
+    }, {
+        "id": "5895",
+        "name": "Alchemist Cedric of the Gnostics"
+    }, {
+        "id": "6114",
+        "name": "Spellsinger Lumos of the Gnostics"
+    }, {
+        "id": "6158",
+        "name": "Sorcerer Merlon of the Gnostics"
+    }, {
+        "id": "6170",
+        "name": "Adept Fire Eater of the Gnostics"
+    }, {
+        "id": "6228",
+        "name": "Shaman Asmodeus of the Gnostics"
+    }, {
+        "id": "6238",
+        "name": "Archmagus Angus of the Gnostics"
+    }, {
+        "id": "6314",
+        "name": "Druid Vadim of the Gnostics"
+    }, {
+        "id": "6357",
+        "name": "Adept Reza of the Gnostics"
+    }, {
+        "id": "6413",
+        "name": "Cleric Lumos of the Gnostics"
+    }, {
+        "id": "6535",
+        "name": "Basil of the Gnostics"
+    }, {
+        "id": "6644",
+        "name": "Artificer Cromwell of the Gnostics"
+    }, {
+        "id": "6666",
+        "name": "Archmagus Aldus of the Gnostics"
+    }, {
+        "id": "6674",
+        "name": "Sage Celah of the Gnostics"
+    }, {
+        "id": "6676",
+        "name": "Ghost Eater Edge of the Gnostics"
+    }, {
+        "id": "6824",
+        "name": "Void Disciple Zeromus of the Gnostics"
+    }, {
+        "id": "6860",
+        "name": "Hex Mage Nikolas of the Gnostics"
+    }, {
+        "id": "6939",
+        "name": "Druid Merlon of the Gnostics"
+    }, {
+        "id": "7185",
+        "name": "Archmagus Alatar of the Gnostics"
+    }, {
+        "id": "7380",
+        "name": "Witch Ambrosia of the Gnostics"
+    }, {
+        "id": "7413",
+        "name": "Battle Mage Sturgis of the Gnostics"
+    }, {
+        "id": "7461",
+        "name": "Runecaster Basil of the Gnostics"
+    }, {
+        "id": "7555",
+        "name": "Evoker Casper of the Gnostics"
+    }, {
+        "id": "7746",
+        "name": "Archmagus Milton of the Gnostics"
+    }, {
+        "id": "7880",
+        "name": "Shaman Pozzik of the Gnostics"
+    }, {
+        "id": "7896",
+        "name": "Nikolas of the Gnostics"
+    }, {
+        "id": "7939",
+        "name": "Aleister of the Gnostics"
+    }, {
+        "id": "7977",
+        "name": "Chaos Mage Beyna of the Gnostics"
+    }, {
+        "id": "8070",
+        "name": "Sorcerer Jasper of the Gnostics"
+    }, {
+        "id": "8192",
+        "name": "Archmagus Milton of the Gnostics"
+    }, {
+        "id": "8193",
+        "name": "Archmagus Lumos of the Gnostics"
+    }, {
+        "id": "8357",
+        "name": "Lumos of the Gnostics"
+    }, {
+        "id": "8365",
+        "name": "Evoker Nikolas of the Gnostics"
+    }, {
+        "id": "8420",
+        "name": "Holy Monk Digby of the Gnostics"
+    }, {
+        "id": "8494",
+        "name": "Hedge Wizard Samuel of the Gnostics"
+    }, {
+        "id": "8506",
+        "name": "Arch-Magician Allistair of the Gnostics"
+    }, {
+        "id": "8530",
+        "name": "Enchanter Sharx of the Gnostics"
+    }, {
+        "id": "8564",
+        "name": "Archmagus Darby of the Gnostics"
+    }, {
+        "id": "8654",
+        "name": "Shaman Pumlo of the Gnostics"
+    }, {
+        "id": "8682",
+        "name": "Alchemist Hishoken of the Gnostics"
+    }, {
+        "id": "8807",
+        "name": "Hedge Wizard Sharx of the Gnostics"
+    }, {
+        "id": "9033",
+        "name": "Pyromancer Soya of the Gnostics"
+    }, {
+        "id": "9376",
+        "name": "Zelroth of the Gnostics"
+    }, {
+        "id": "9470",
+        "name": "Sorcerer Bolin of the Gnostics"
+    }, {
+        "id": "9528",
+        "name": "Summoner Alatar of the Gnostics"
+    }, {
+        "id": "9680",
+        "name": "Thaumaturge Ofaris of the Gnostics"
+    }, {
+        "id": "9899",
+        "name": "Ghost Eater Wazir of the Gnostics"
+    }, {
+        "id": "9909",
+        "name": "Fortune Teller Eden of the Gnostics"
+    }, {
+        "id": "9986",
+        "name": "Battle Mage Angus of the Gnostics"
+    }],
+    "Cold": [{
+        "id": "100",
+        "name": "Arcanist Porto of the Cold"
+    }, {
+        "id": "322",
+        "name": "Shaman Mushy of the Cold"
+    }, {
+        "id": "326",
+        "name": "Ice Mage Marceau of the Cold"
+    }, {
+        "id": "735",
+        "name": "Ice Mage Milo of the Cold"
+    }, {
+        "id": "835",
+        "name": "Mystic Oxnard of the Cold"
+    }, {
+        "id": "852",
+        "name": "Ice Mage Flynn of the Cold"
+    }, {
+        "id": "1007",
+        "name": "Archmagus Alessar of the Cold"
+    }, {
+        "id": "1487",
+        "name": "Druid Nicolas of the Cold"
+    }, {
+        "id": "1588",
+        "name": "Ice Mage Baptiste of the Cold"
+    }, {
+        "id": "1667",
+        "name": "Magus  of the Cold"
+    }, {
+        "id": "1840",
+        "name": "Charmer Daria of the Cold"
+    }, {
+        "id": "2064",
+        "name": "Adept Requiem of the Cold"
+    }, {
+        "id": "2289",
+        "name": "Davos of the Cold"
+    }, {
+        "id": "3421",
+        "name": "Mystic Aslan of the Cold"
+    }, {
+        "id": "3805",
+        "name": "Oracle Horace of the Cold"
+    }, {
+        "id": "4494",
+        "name": "Ice Mage Angus of the Cold"
+    }, {
+        "id": "4902",
+        "name": "Sage Zelda of the Cold"
+    }, {
+        "id": "5633",
+        "name": "Ice Mage Hagar of the Cold"
+    }, {
+        "id": "5979",
+        "name": "Charmer Faye of the Cold"
+    }, {
+        "id": "6089",
+        "name": "Archmagus Alatar of the Cold"
+    }, {
+        "id": "6359",
+        "name": "Hedge Wizard Nolan of the Cold"
+    }, {
+        "id": "6482",
+        "name": "Jadis of the Cold"
+    }, {
+        "id": "7624",
+        "name": "Illusionist Jerret of the Cold"
+    }, {
+        "id": "7673",
+        "name": "Sorcerer Ofaris of the Cold"
+    }, {
+        "id": "8191",
+        "name": "Ice Mage Flamos of the Cold"
+    }, {
+        "id": "9055",
+        "name": "Adept Soya of the Cold"
+    }, {
+        "id": "9105",
+        "name": "Pyromancer Basil of the Cold"
+    }, {
+        "id": "9852",
+        "name": "Magus Blaise of the Cold"
+    }, {
+        "id": "9943",
+        "name": "Archmagus Ozohr of the Cold"
+    }, {
+        "id": "9994",
+        "name": "Ice Mage Gwendolin of the Cold"
+    }],
+    "Mist": [{
+        "id": "94",
+        "name": "Sorcerer Jahid of the Mist"
+    }, {
+        "id": "179",
+        "name": "Arch-Magician Silas of the Mist"
+    }, {
+        "id": "291",
+        "name": "Shaman Celah of the Mist"
+    }, {
+        "id": "302",
+        "name": "Artificer Aldus of the Mist"
+    }, {
+        "id": "424",
+        "name": "Chronomancer Milton of the Mist"
+    }, {
+        "id": "503",
+        "name": "Archmagus Oberon of the Mist"
+    }, {
+        "id": "587",
+        "name": "Hedge Wizard Iprix of the Mist"
+    }, {
+        "id": "600",
+        "name": "Cosmic Mage Fugh of the Mist"
+    }, {
+        "id": "609",
+        "name": "Scryer Allistair of the Mist"
+    }, {
+        "id": "665",
+        "name": "Arcanist Carly of the Mist"
+    }, {
+        "id": "814",
+        "name": "Alessar of the Mist"
+    }, {
+        "id": "833",
+        "name": "Druid Silas of the Mist"
+    }, {
+        "id": "867",
+        "name": "Sorcerer Alizam of the Mist"
+    }, {
+        "id": "975",
+        "name": "Sorcerer Casper of the Mist"
+    }, {
+        "id": "1024",
+        "name": "Transmuter Magpie of the Mist"
+    }, {
+        "id": "1063",
+        "name": "Electromancer Soran of the Mist"
+    }, {
+        "id": "1310",
+        "name": "Artificer Toby of the Mist"
+    }, {
+        "id": "1384",
+        "name": "Vampyre Vlad of the Mist"
+    }, {
+        "id": "1573",
+        "name": "Shaman Talbot of the Mist"
+    }, {
+        "id": "1652",
+        "name": "Magus Duzzle of the Mist"
+    }, {
+        "id": "1758",
+        "name": "Arcanist Amir of the Mist"
+    }, {
+        "id": "1794",
+        "name": "Pyromancer Samuel of the Mist"
+    }, {
+        "id": "1841",
+        "name": "Geomancer Muntjac of the Mist"
+    }, {
+        "id": "1871",
+        "name": "Druid Talbot of the Mist"
+    }, {
+        "id": "2016",
+        "name": "Battle Mage Malthus of the Mist"
+    }, {
+        "id": "2022",
+        "name": "Sage Nicolas of the Mist"
+    }, {
+        "id": "2181",
+        "name": "Artificer Damien of the Mist"
+    }, {
+        "id": "2256",
+        "name": "Augurer Duzzle of the Mist"
+    }, {
+        "id": "2356",
+        "name": "Hedge Wizard Daria of the Mist"
+    }, {
+        "id": "2369",
+        "name": "Archmagus Soran of the Mist"
+    }, {
+        "id": "2430",
+        "name": "Geomancer Aslan of the Mist"
+    }, {
+        "id": "2442",
+        "name": "Shadow Mage Iprix of the Mist"
+    }, {
+        "id": "2472",
+        "name": "Evoker Nassif of the Mist"
+    }, {
+        "id": "2488",
+        "name": "Hex Mage Kazud of the Mist"
+    }, {
+        "id": "2618",
+        "name": "Cleric Crowley of the Mist"
+    }, {
+        "id": "2799",
+        "name": "Witch Rita of the Mist"
+    }, {
+        "id": "2857",
+        "name": "Alchemist Finn of the Mist"
+    }, {
+        "id": "2871",
+        "name": "Conjurer Lavinia of the Mist"
+    }, {
+        "id": "2898",
+        "name": "Evoker Merlon of the Mist"
+    }, {
+        "id": "2906",
+        "name": "Magus Basil of the Mist"
+    }, {
+        "id": "2929",
+        "name": "Hedge Wizard Bartholomew of the Mist"
+    }, {
+        "id": "2958",
+        "name": "Archmagus Armstrong of the Mist"
+    }, {
+        "id": "3099",
+        "name": "Shadow Mage Xiaobo of the Mist"
+    }, {
+        "id": "3120",
+        "name": "Electromancer Zelda of the Mist"
+    }, {
+        "id": "3137",
+        "name": "Adept Enigma of the Mist"
+    }, {
+        "id": "3198",
+        "name": "Artificer George of the Mist"
+    }, {
+        "id": "3202",
+        "name": "Cryptomancer Jastor of the Mist"
+    }, {
+        "id": "3208",
+        "name": "Necromancer Vossler of the Mist"
+    }, {
+        "id": "3225",
+        "name": "Pyromancer Eden of the Mist"
+    }, {
+        "id": "3309",
+        "name": "Sage Argus of the Mist"
+    }, {
+        "id": "3346",
+        "name": "Magus Kang of the Mist"
+    }, {
+        "id": "3444",
+        "name": "Enchanter Beyna of the Mist"
+    }, {
+        "id": "3452",
+        "name": "Enchanter Diana of the Mist"
+    }, {
+        "id": "3504",
+        "name": "Magus Talbot of the Mist"
+    }, {
+        "id": "3521",
+        "name": "Geomancer Sahir of the Mist"
+    }, {
+        "id": "3601",
+        "name": "Adept Aleister of the Mist"
+    }, {
+        "id": "3661",
+        "name": "Runecaster  of the Mist"
+    }, {
+        "id": "3662",
+        "name": "Battle Mage Flynn of the Mist"
+    }, {
+        "id": "3666",
+        "name": "Archmagus Drokore of the Mist"
+    }, {
+        "id": "3682",
+        "name": "Archmagus Soya of the Mist"
+    }, {
+        "id": "3736",
+        "name": "Sorcerer Kazem of the Mist"
+    }, {
+        "id": "3799",
+        "name": "Archmagus Lumos of the Mist"
+    }, {
+        "id": "4009",
+        "name": "Sorcerer Jiang of the Mist"
+    }, {
+        "id": "4147",
+        "name": "Arcanist Apollo of the Mist"
+    }, {
+        "id": "4212",
+        "name": "Battle Mage Ethan of the Mist"
+    }, {
+        "id": "4287",
+        "name": "Battle Mage Hansel of the Mist"
+    }, {
+        "id": "4306",
+        "name": "Hedge Wizard Molek of the Mist"
+    }, {
+        "id": "4341",
+        "name": "Clairvoyant Durm of the Mist"
+    }, {
+        "id": "4504",
+        "name": "Witch Shivra of the Mist"
+    }, {
+        "id": "4545",
+        "name": "Adept Nolan of the Mist"
+    }, {
+        "id": "4632",
+        "name": "Void Disciple Anton of the Mist"
+    }, {
+        "id": "4702",
+        "name": "Sorcerer Aleister of the Mist"
+    }, {
+        "id": "4753",
+        "name": "Illusionist Salvatore of the Mist"
+    }, {
+        "id": "4823",
+        "name": "Aleister of the Mist"
+    }, {
+        "id": "4832",
+        "name": "Alchemist Aleister of the Mist"
+    }, {
+        "id": "4960",
+        "name": "Alchemist Alessar of the Mist"
+    }, {
+        "id": "5027",
+        "name": "Adept Daria of the Mist"
+    }, {
+        "id": "5028",
+        "name": "Arch-Magician Qasim of the Mist"
+    }, {
+        "id": "5032",
+        "name": "Hedge Wizard Ofaris of the Mist"
+    }, {
+        "id": "5056",
+        "name": "Sorcerer Taqi of the Mist"
+    }, {
+        "id": "5118",
+        "name": "Cosmic Mage Amir of the Mist"
+    }, {
+        "id": "5174",
+        "name": "Artificer Agapito of the Mist"
+    }, {
+        "id": "5291",
+        "name": "Voodoo Priest Louis of the Mist"
+    }, {
+        "id": "5306",
+        "name": "Witch Shivra of the Mist"
+    }, {
+        "id": "5344",
+        "name": "Archmagus Ali of the Mist"
+    }, {
+        "id": "5377",
+        "name": "Druid Davos of the Mist"
+    }, {
+        "id": "5607",
+        "name": "Magus Soya of the Mist"
+    }, {
+        "id": "5799",
+        "name": "Sage Nolan of the Mist"
+    }, {
+        "id": "5804",
+        "name": "Sorcerer Jabir of the Mist"
+    }, {
+        "id": "5902",
+        "name": "Electromancer Azahl of the Mist"
+    }, {
+        "id": "5906",
+        "name": "Battlemage Mushy of the Mist"
+    }, {
+        "id": "5917",
+        "name": "Shaman Shigenjo of the Mist"
+    }, {
+        "id": "5968",
+        "name": "Chronomancer Dante of the Mist"
+    }, {
+        "id": "6002",
+        "name": "Archmagus Celah of the Mist"
+    }, {
+        "id": "6178",
+        "name": "Archmagus Apollo of the Mist"
+    }, {
+        "id": "6317",
+        "name": "Adept Rita of the Mist"
+    }, {
+        "id": "6362",
+        "name": "Archmagus Milton of the Mist"
+    }, {
+        "id": "6389",
+        "name": "Battle Mage Khudalf of the Mist"
+    }, {
+        "id": "6390",
+        "name": "Druid Solomon of the Mist"
+    }, {
+        "id": "6424",
+        "name": "Runecaster Caligula of the Mist"
+    }, {
+        "id": "6573",
+        "name": "Void Disciple Voidoth of the Mist"
+    }, {
+        "id": "6655",
+        "name": "Archmagus Lumos of the Mist"
+    }, {
+        "id": "6833",
+        "name": "Cleric Angus of the Mist"
+    }, {
+        "id": "6866",
+        "name": "Nikolas of the Mist"
+    }, {
+        "id": "6880",
+        "name": "Artificer Pumlo of the Mist"
+    }, {
+        "id": "7017",
+        "name": "Sage Rita of the Mist"
+    }, {
+        "id": "7071",
+        "name": "Void Disciple Ilyas of the Mist"
+    }, {
+        "id": "7101",
+        "name": "Wild Mage Hagar of the Mist"
+    }, {
+        "id": "7272",
+        "name": "Archmagus Jerret of the Mist"
+    }, {
+        "id": "7325",
+        "name": "Archmagus Amir of the Mist"
+    }, {
+        "id": "7327",
+        "name": "Arch-Magician Eizo of the Mist"
+    }, {
+        "id": "7344",
+        "name": "Hedge Wizard Reza of the Mist"
+    }, {
+        "id": "7358",
+        "name": "Celeste of the Mist"
+    }, {
+        "id": "7472",
+        "name": "Sorcerer Ifran of the Mist"
+    }, {
+        "id": "7526",
+        "name": "Archmagus Ixar of the Mist"
+    }, {
+        "id": "7561",
+        "name": "Arch-Magician Duzzle of the Mist"
+    }, {
+        "id": "7756",
+        "name": "Sage Jabir of the Mist"
+    }, {
+        "id": "7874",
+        "name": "Archmagus Sisk of the Mist"
+    }, {
+        "id": "7980",
+        "name": "Oracle Talon of the Mist"
+    }, {
+        "id": "8042",
+        "name": "Sage  of the Mist"
+    }, {
+        "id": "8053",
+        "name": "Hedge Wizard Tundror of the Mist"
+    }, {
+        "id": "8054",
+        "name": "Archmagus Casper of the Mist"
+    }, {
+        "id": "8063",
+        "name": "Alchemist Suki of the Mist"
+    }, {
+        "id": "8090",
+        "name": "Archmagus Ofaris of the Mist"
+    }, {
+        "id": "8247",
+        "name": "Archmagus Aleister of the Mist"
+    }, {
+        "id": "8326",
+        "name": "Aleister of the Mist"
+    }, {
+        "id": "8407",
+        "name": "Arch-Magician Shukri of the Mist"
+    }, {
+        "id": "8547",
+        "name": "Druid Eden of the Mist"
+    }, {
+        "id": "8574",
+        "name": "Adept Salvatore of the Mist"
+    }, {
+        "id": "8583",
+        "name": "Battle Mage Hothor of the Mist"
+    }, {
+        "id": "8656",
+        "name": "Archmagus Jerret of the Mist"
+    }, {
+        "id": "8672",
+        "name": "Sorcerer Silas of the Mist"
+    }, {
+        "id": "8714",
+        "name": "Illusionist Merlon of the Mist"
+    }, {
+        "id": "8829",
+        "name": "Electromancer Solomon of the Mist"
+    }, {
+        "id": "8921",
+        "name": "Archmagus Jerret of the Mist"
+    }, {
+        "id": "8955",
+        "name": "Adept Kazem of the Mist"
+    }, {
+        "id": "8970",
+        "name": "Conjurer Magnus of the Mist"
+    }, {
+        "id": "8971",
+        "name": "Sorcerer Aleister of the Mist"
+    }, {
+        "id": "9012",
+        "name": "Shaman Thor of the Mist"
+    }, {
+        "id": "9094",
+        "name": "Sorcerer Uvlius of the Mist"
+    }, {
+        "id": "9131",
+        "name": "Druid Victoria of the Mist"
+    }, {
+        "id": "9145",
+        "name": "Archmagus Hadrien of the Mist"
+    }, {
+        "id": "9540",
+        "name": "Alchemist Cosmo of the Mist"
+    }, {
+        "id": "9648",
+        "name": "Archmagus George of the Mist"
+    }, {
+        "id": "9974",
+        "name": "Chronomancer Lin of the Mist"
+    }],
+    "Realm": [{
+        "id": "81",
+        "name": "Evoker Otto of the Realm"
+    }, {
+        "id": "196",
+        "name": "Conjurer Isaac of the Realm"
+    }, {
+        "id": "271",
+        "name": "Shaman Xerxes of the Realm"
+    }, {
+        "id": "316",
+        "name": "Fortune Teller Takao of the Realm"
+    }, {
+        "id": "319",
+        "name": "Alchemist Victoria of the Realm"
+    }, {
+        "id": "397",
+        "name": "Chronomancer Azahl of the Realm"
+    }, {
+        "id": "556",
+        "name": "Summoner Seth of the Realm"
+    }, {
+        "id": "719",
+        "name": "Stellar Mage Cybele of the Realm"
+    }, {
+        "id": "766",
+        "name": "Magus Danny of the Realm"
+    }, {
+        "id": "785",
+        "name": "Enchanter Circe of the Realm"
+    }, {
+        "id": "787",
+        "name": "Sorcerer Lumos of the Realm"
+    }, {
+        "id": "869",
+        "name": "Illusionist Dutorn of the Realm"
+    }, {
+        "id": "896",
+        "name": "Archmagus Alatar of the Realm"
+    }, {
+        "id": "970",
+        "name": "Arcanist Casper of the Realm"
+    }, {
+        "id": "1067",
+        "name": "Battle Mage Bartholomew of the Realm"
+    }, {
+        "id": "1090",
+        "name": "Archmagus Allistair of the Realm"
+    }, {
+        "id": "1126",
+        "name": "Archmagus Casper of the Realm"
+    }, {
+        "id": "1167",
+        "name": "Solomon of the Realm"
+    }, {
+        "id": "1189",
+        "name": "Arch-Magician Atlas of the Realm"
+    }, {
+        "id": "1297",
+        "name": "Void Disciple Norix of the Realm"
+    }, {
+        "id": "1321",
+        "name": "Archmagus Adium of the Realm"
+    }, {
+        "id": "1345",
+        "name": "Transmuter Peppy of the Realm"
+    }, {
+        "id": "1398",
+        "name": "Druid Chooki of the Realm"
+    }, {
+        "id": "1418",
+        "name": "Druid Jameel of the Realm"
+    }, {
+        "id": "1771",
+        "name": "Adept Merlon of the Realm"
+    }, {
+        "id": "1955",
+        "name": "Battle Mage Ratko of the Realm"
+    }, {
+        "id": "1978",
+        "name": "Arcanist Azahl of the Realm"
+    }, {
+        "id": "2205",
+        "name": "Arcanist Celah of the Realm"
+    }, {
+        "id": "2327",
+        "name": "Runecaster Rita of the Realm"
+    }, {
+        "id": "2576",
+        "name": "Pumlo of the Realm"
+    }, {
+        "id": "2629",
+        "name": "Jerret of the Realm"
+    }, {
+        "id": "2834",
+        "name": "Artificer Alessar of the Realm"
+    }, {
+        "id": "2905",
+        "name": "Archmagus Jerret of the Realm"
+    }, {
+        "id": "2943",
+        "name": "Spellsinger Baird of the Realm"
+    }, {
+        "id": "3004",
+        "name": "Enchanter Calliope of the Realm"
+    }, {
+        "id": "3013",
+        "name": "Sorcerer Orpheus of the Realm"
+    }, {
+        "id": "3101",
+        "name": "Cleric Milton of the Realm"
+    }, {
+        "id": "3196",
+        "name": "Sage Aslan of the Realm"
+    }, {
+        "id": "3260",
+        "name": "Archmagus Fark of the Realm"
+    }, {
+        "id": "3503",
+        "name": "Evoker Pozzik of the Realm"
+    }, {
+        "id": "3674",
+        "name": "Arcanist Asphodel of the Realm"
+    }, {
+        "id": "3722",
+        "name": "Sorcerer Allistair of the Realm"
+    }, {
+        "id": "3760",
+        "name": "Shadow Mage Magpie of the Realm"
+    }, {
+        "id": "3876",
+        "name": "Alchemist Godfrey of the Realm"
+    }, {
+        "id": "3949",
+        "name": "Artificer Udor of the Realm"
+    }, {
+        "id": "3967",
+        "name": "Pyromancer Carly of the Realm"
+    }, {
+        "id": "4070",
+        "name": "Artificer Uvlius of the Realm"
+    }, {
+        "id": "4171",
+        "name": "Shaman Soran of the Realm"
+    }, {
+        "id": "4255",
+        "name": "Archmagus Orpheus of the Realm"
+    }, {
+        "id": "4377",
+        "name": "Magus Jahid of the Realm"
+    }, {
+        "id": "4641",
+        "name": "Illusionist Tabitha of the Realm"
+    }, {
+        "id": "4709",
+        "name": "Hedge Wizard Lenora of the Realm"
+    }, {
+        "id": "4799",
+        "name": "Sage Enigma of the Realm"
+    }, {
+        "id": "4956",
+        "name": "Illusionist Ai of the Realm"
+    }, {
+        "id": "5051",
+        "name": "Archmagus Iprix of the Realm"
+    }, {
+        "id": "5117",
+        "name": "Cleric Jabir of the Realm"
+    }, {
+        "id": "5326",
+        "name": "Arch-Magician Remus of the Realm"
+    }, {
+        "id": "5730",
+        "name": "Druid Lumos of the Realm"
+    }, {
+        "id": "5759",
+        "name": "Battle Mage Nolan of the Realm"
+    }, {
+        "id": "5764",
+        "name": "Enchanter Alex of the Realm"
+    }, {
+        "id": "5857",
+        "name": "Sorcerer Qasim of the Realm"
+    }, {
+        "id": "5890",
+        "name": "Druid Requiem of the Realm"
+    }, {
+        "id": "5923",
+        "name": "Sage Bogey of the Realm"
+    }, {
+        "id": "5978",
+        "name": "Witch Enigma of the Realm"
+    }, {
+        "id": "6252",
+        "name": "Artificer Yookoo of the Realm"
+    }, {
+        "id": "6305",
+        "name": "Artificer Zaros of the Realm"
+    }, {
+        "id": "6319",
+        "name": "Nikolas of the Realm"
+    }, {
+        "id": "6355",
+        "name": "Magus Sahir of the Realm"
+    }, {
+        "id": "6547",
+        "name": "Sorcerer Milton of the Realm"
+    }, {
+        "id": "6697",
+        "name": "Alchemist Aldus of the Realm"
+    }, {
+        "id": "6756",
+        "name": "Enchanter Celeste of the Realm"
+    }, {
+        "id": "6870",
+        "name": "Voodoo Priest Caligari of the Realm"
+    }, {
+        "id": "6887",
+        "name": "Sage Bolin of the Realm"
+    }, {
+        "id": "6907",
+        "name": "Magus Diana of the Realm"
+    }, {
+        "id": "6963",
+        "name": "Arch-Magician Alatar of the Realm"
+    }, {
+        "id": "7086",
+        "name": "Shaman Ifran of the Realm"
+    }, {
+        "id": "7141",
+        "name": "Geomancer Milton of the Realm"
+    }, {
+        "id": "7211",
+        "name": "Medium Dutorn of the Realm"
+    }, {
+        "id": "7228",
+        "name": "Holy Monk Aldo of the Realm"
+    }, {
+        "id": "7289",
+        "name": "Voodoo Priest Requiem of the Realm"
+    }, {
+        "id": "7363",
+        "name": "Pyromancer Jabir of the Realm"
+    }, {
+        "id": "7377",
+        "name": "Colormancer Rainman of the Realm"
+    }, {
+        "id": "7572",
+        "name": "Druid Lamia of the Realm"
+    }, {
+        "id": "7620",
+        "name": "Magus Reza of the Realm"
+    }, {
+        "id": "7701",
+        "name": "Ixar of the Realm"
+    }, {
+        "id": "7804",
+        "name": "Shadow Mage Hagar of the Realm"
+    }, {
+        "id": "7888",
+        "name": "Archmagus Zelroth of the Realm"
+    }, {
+        "id": "8088",
+        "name": "Adept Adium of the Realm"
+    }, {
+        "id": "8091",
+        "name": "Battle Mage Hothor of the Realm"
+    }, {
+        "id": "8156",
+        "name": "Enchanter Daphne of the Realm"
+    }, {
+        "id": "8232",
+        "name": "Arcanist Milo of the Realm"
+    }, {
+        "id": "8359",
+        "name": "Sorcerer Zafar of the Realm"
+    }, {
+        "id": "8369",
+        "name": "Druid Merlon of the Realm"
+    }, {
+        "id": "8568",
+        "name": "Cosmic Mage Herne of the Realm"
+    }, {
+        "id": "8749",
+        "name": "Charmer Diana of the Realm"
+    }, {
+        "id": "8799",
+        "name": "Sorcerer Artis of the Realm"
+    }, {
+        "id": "9064",
+        "name": "Sorcerer Apollo of the Realm"
+    }, {
+        "id": "9152",
+        "name": "Electromancer Alex of the Realm"
+    }, {
+        "id": "9337",
+        "name": "Enchanter Lenora of the Realm"
+    }, {
+        "id": "9415",
+        "name": "Shadow Mage Basil of the Realm"
+    }, {
+        "id": "9591",
+        "name": "Arch-Magician Goober of the Realm"
+    }, {
+        "id": "9631",
+        "name": "Spellsinger Aldus of the Realm"
+    }, {
+        "id": "9778",
+        "name": "Adept Moloch of the Realm"
+    }, {
+        "id": "9927",
+        "name": "Larissa of the Realm"
+    }, {
+        "id": "9940",
+        "name": "Chaos Mage Aleister of the Realm"
+    }, {
+        "id": "9953",
+        "name": "Ghost Eater Robin of the Realm"
+    }, {
+        "id": "9991",
+        "name": "Magus Daria of the Realm"
+    }],
+    "West": [{
+        "id": "1939",
+        "name": "The Witch of the West"
+    }],
+    "Lake": [{
+        "id": "156",
+        "name": "Magus Nixie of the Lake"
+    }, {
+        "id": "189",
+        "name": "Daria of the Lake"
+    }, {
+        "id": "237",
+        "name": "Battlemage Faye of the Lake"
+    }, {
+        "id": "341",
+        "name": "Mystic Caligula of the Lake"
+    }, {
+        "id": "384",
+        "name": "Enchanter Diana of the Lake"
+    }, {
+        "id": "408",
+        "name": "Alchemist Atlanta of the Lake"
+    }, {
+        "id": "509",
+        "name": "Illusionist Leah of the Lake"
+    }, {
+        "id": "611",
+        "name": "Isaac of the Lake"
+    }, {
+        "id": "754",
+        "name": "Enchanter Tundror of the Lake"
+    }, {
+        "id": "998",
+        "name": "Cleric Astrid of the Lake"
+    }, {
+        "id": "1026",
+        "name": "Cosmic Mage Spore Boy of the Lake"
+    }, {
+        "id": "1042",
+        "name": "Druid Reza of the Lake"
+    }, {
+        "id": "1079",
+        "name": "Archmagus Ofaris of the Lake"
+    }, {
+        "id": "1104",
+        "name": "Arcanist Casper of the Lake"
+    }, {
+        "id": "1354",
+        "name": "Sage Hothor of the Lake"
+    }, {
+        "id": "1367",
+        "name": "Hedge Wizard Umber of the Lake"
+    }, {
+        "id": "1409",
+        "name": "Shaman Cromwell of the Lake"
+    }, {
+        "id": "1571",
+        "name": "Sorcerer Azazel of the Lake"
+    }, {
+        "id": "1617",
+        "name": "Sorcerer Cairon of the Lake"
+    }, {
+        "id": "1877",
+        "name": "Enchanter Jadis of the Lake"
+    }, {
+        "id": "1930",
+        "name": "Enchanter Althea of the Lake"
+    }, {
+        "id": "2118",
+        "name": "Sorcerer Crowley of the Lake"
+    }, {
+        "id": "2254",
+        "name": "Druid Pan of the Lake"
+    }, {
+        "id": "2309",
+        "name": "Sage Carly of the Lake"
+    }, {
+        "id": "2391",
+        "name": "Geomancer Huizhong of the Lake"
+    }, {
+        "id": "2412",
+        "name": "Alchemist Xue of the Lake"
+    }, {
+        "id": "2497",
+        "name": "Arcanist Cromwell of the Lake"
+    }, {
+        "id": "2845",
+        "name": "Spellsinger Karasu of the Lake"
+    }, {
+        "id": "2989",
+        "name": "Artificer Iris of the Lake"
+    }, {
+        "id": "3162",
+        "name": "Archmagus Zaros of the Lake"
+    }, {
+        "id": "3240",
+        "name": "Geomancer Poppy of the Lake"
+    }, {
+        "id": "3522",
+        "name": "Illusionist Blaise of the Lake"
+    }, {
+        "id": "3646",
+        "name": "Archmagus Solomon of the Lake"
+    }, {
+        "id": "3701",
+        "name": "Arch-Magician Silas of the Lake"
+    }, {
+        "id": "3819",
+        "name": "Battle Mage Cromwell of the Lake"
+    }, {
+        "id": "3844",
+        "name": "Battle Mage Blaise of the Lake"
+    }, {
+        "id": "3846",
+        "name": "Shaman Cassiopeia of the Lake"
+    }, {
+        "id": "4033",
+        "name": "Cleric Blaise of the Lake"
+    }, {
+        "id": "4092",
+        "name": "Spellsinger George of the Lake"
+    }, {
+        "id": "4203",
+        "name": "Hedge Wizard Sylvia of the Lake"
+    }, {
+        "id": "4230",
+        "name": "Archmagus Alatar of the Lake"
+    }, {
+        "id": "4263",
+        "name": "Cryptomancer Shroomer of the Lake"
+    }, {
+        "id": "4418",
+        "name": "Basil of the Lake"
+    }, {
+        "id": "4645",
+        "name": "Sorcerer Iprix of the Lake"
+    }, {
+        "id": "4703",
+        "name": "Diana of the Lake"
+    }, {
+        "id": "4796",
+        "name": "Sage Oberon of the Lake"
+    }, {
+        "id": "4861",
+        "name": "Battle Mage Nicolas of the Lake"
+    }, {
+        "id": "4909",
+        "name": "Hedge Wizard Arabella of the Lake"
+    }, {
+        "id": "5255",
+        "name": "Thaumaturge Vadim of the Lake"
+    }, {
+        "id": "5262",
+        "name": "Witch Shivra of the Lake"
+    }, {
+        "id": "5376",
+        "name": "Nikolas of the Lake"
+    }, {
+        "id": "5513",
+        "name": "Artificer Oiq of the Lake"
+    }, {
+        "id": "5545",
+        "name": "Scryer Sahir of the Lake"
+    }, {
+        "id": "5677",
+        "name": "Battle Mage Dutorn of the Lake"
+    }, {
+        "id": "5872",
+        "name": "Battle Mage Rodolfo of the Lake"
+    }, {
+        "id": "5932",
+        "name": "Magus Lenora of the Lake"
+    }, {
+        "id": "5949",
+        "name": "Sage Cybele of the Lake"
+    }, {
+        "id": "6204",
+        "name": "Sorcerer Nassif of the Lake"
+    }, {
+        "id": "6380",
+        "name": "Sorcerer Udor of the Lake"
+    }, {
+        "id": "6500",
+        "name": "Enchanter Cybele of the Lake"
+    }, {
+        "id": "6698",
+        "name": "Sage Calypso of the Lake"
+    }, {
+        "id": "6913",
+        "name": "Enchanter Faye of the Lake"
+    }, {
+        "id": "7053",
+        "name": "Medium Ali of the Lake"
+    }, {
+        "id": "7059",
+        "name": "Archmagus Salvatore of the Lake"
+    }, {
+        "id": "7072",
+        "name": "Battle Mage Baird of the Lake"
+    }, {
+        "id": "7168",
+        "name": "Archmagus Eden of the Lake"
+    }, {
+        "id": "7215",
+        "name": "Archmagus Udor of the Lake"
+    }, {
+        "id": "7410",
+        "name": "Runecaster Jadis of the Lake"
+    }, {
+        "id": "7439",
+        "name": "Shaman Horace of the Lake"
+    }, {
+        "id": "7469",
+        "name": "Solomon of the Lake"
+    }, {
+        "id": "7539",
+        "name": "Electromancer Malthus of the Lake"
+    }, {
+        "id": "7654",
+        "name": "Wild Mage Asmodeus of the Lake"
+    }, {
+        "id": "7659",
+        "name": "Spellsinger Iprix of the Lake"
+    }, {
+        "id": "7736",
+        "name": "Circe of the Lake"
+    }, {
+        "id": "7844",
+        "name": "Evoker Celah of the Lake"
+    }, {
+        "id": "7867",
+        "name": "Chronomancer Daria of the Lake"
+    }, {
+        "id": "8009",
+        "name": "Alchemist Eric of the Lake"
+    }, {
+        "id": "8100",
+        "name": "Archmagus Jerret of the Lake"
+    }, {
+        "id": "8273",
+        "name": "Adept Tenguyama of the Lake"
+    }, {
+        "id": "8341",
+        "name": "Sage Bathsheba of the Lake"
+    }, {
+        "id": "8700",
+        "name": "Cairon of the Lake"
+    }, {
+        "id": "8767",
+        "name": "Archmagus Rita of the Lake"
+    }, {
+        "id": "8855",
+        "name": "Pyromancer Brown Cow of the Lake"
+    }, {
+        "id": "8876",
+        "name": "Archmagus Uvlius of the Lake"
+    }, {
+        "id": "9004",
+        "name": "Shaman Quddus of the Lake"
+    }, {
+        "id": "9236",
+        "name": "Druid Kang of the Lake"
+    }, {
+        "id": "9444",
+        "name": "Alchemist Amanita of the Lake"
+    }, {
+        "id": "9452",
+        "name": "Druid Cassandra of the Lake"
+    }, {
+        "id": "9463",
+        "name": "Battle Mage Rodolfo of the Lake"
+    }, {
+        "id": "9505",
+        "name": "Druid Elena of the Lake"
+    }, {
+        "id": "9530",
+        "name": "Sage Flamos of the Lake"
+    }, {
+        "id": "9565",
+        "name": "Battle Mage Gunthor of the Lake"
+    }, {
+        "id": "9605",
+        "name": "Druid Danny of the Lake"
+    }, {
+        "id": "9768",
+        "name": "Magus Uur'lok of the Lake"
+    }, {
+        "id": "9782",
+        "name": "Cybele of the Lake"
+    }, {
+        "id": "9871",
+        "name": "Sage Adrienne of the Lake"
+    }],
+    "Ice": [{
+        "id": "336",
+        "name": "Holy Magus Ilu of the Ice"
+    }, {
+        "id": "474",
+        "name": "Arcanist Soya of the Ice"
+    }, {
+        "id": "606",
+        "name": "Battle Mage Blaise of the Ice"
+    }, {
+        "id": "629",
+        "name": "Ice Mage Apollo of the Ice"
+    }, {
+        "id": "726",
+        "name": "Ice Mage Homer of the Ice"
+    }, {
+        "id": "775",
+        "name": "Ice Mage Pezo of the Ice"
+    }, {
+        "id": "1064",
+        "name": "Ice Mage Nicolas of the Ice"
+    }, {
+        "id": "1464",
+        "name": "Ice Mage Nikolas of the Ice"
+    }, {
+        "id": "1540",
+        "name": "Oracle Hind of the Ice"
+    }, {
+        "id": "1605",
+        "name": "Ice Mage Jerret of the Ice"
+    }, {
+        "id": "1857",
+        "name": "Ice Mage Bullock of the Ice"
+    }, {
+        "id": "1947",
+        "name": "Sage Bullock of the Ice"
+    }, {
+        "id": "2026",
+        "name": "Alchemist Shroomer of the Ice"
+    }, {
+        "id": "2204",
+        "name": "Ice Mage Milo of the Ice"
+    }, {
+        "id": "2441",
+        "name": "Ice Mage Orpheus of the Ice"
+    }, {
+        "id": "2473",
+        "name": "Archmagus Oberon of the Ice"
+    }, {
+        "id": "2616",
+        "name": "Archmagus Zaros of the Ice"
+    }, {
+        "id": "2749",
+        "name": "Geomancer  of the Ice"
+    }, {
+        "id": "2813",
+        "name": "Artificer Bobbin of the Ice"
+    }, {
+        "id": "2843",
+        "name": "Arch-Magician Ixar of the Ice"
+    }, {
+        "id": "3065",
+        "name": "Sorcerer Alatar of the Ice"
+    }, {
+        "id": "3115",
+        "name": "Battlemage Jeldor of the Ice"
+    }, {
+        "id": "3512",
+        "name": "Shadow Mage Gunthor of the Ice"
+    }, {
+        "id": "3584",
+        "name": "Sorcerer Merlon of the Ice"
+    }, {
+        "id": "3700",
+        "name": "Ice Mage Mushy of the Ice"
+    }, {
+        "id": "3880",
+        "name": "Shaman Otto of the Ice"
+    }, {
+        "id": "4008",
+        "name": "Battle Mage Horace of the Ice"
+    }, {
+        "id": "4165",
+        "name": "Sorcerer Allistair of the Ice"
+    }, {
+        "id": "4264",
+        "name": "Cleric Caligula of the Ice"
+    }, {
+        "id": "4525",
+        "name": "Hydromancer Jiang of the Ice"
+    }, {
+        "id": "4609",
+        "name": "Ice Mage Drusilla of the Ice"
+    }, {
+        "id": "4653",
+        "name": "Ice Mage Aiko of the Ice"
+    }, {
+        "id": "4728",
+        "name": "Ice Mage Zubin of the Ice"
+    }, {
+        "id": "4733",
+        "name": "Ice Mage Flynn of the Ice"
+    }, {
+        "id": "4749",
+        "name": "Shaman Rita of the Ice"
+    }, {
+        "id": "4750",
+        "name": "Voodoo Priest Hugo of the Ice"
+    }, {
+        "id": "4777",
+        "name": "Ice Mage Lin of the Ice"
+    }, {
+        "id": "4914",
+        "name": "Ghost Eater Apollo of the Ice"
+    }, {
+        "id": "5112",
+        "name": "Fortune Teller Nolan of the Ice"
+    }, {
+        "id": "5301",
+        "name": "Electromancer Bullock of the Ice"
+    }, {
+        "id": "5469",
+        "name": "Ice Mage Angus of the Ice"
+    }, {
+        "id": "5632",
+        "name": "Battle Mage Ethan of the Ice"
+    }, {
+        "id": "6246",
+        "name": "Ice Mage Merlon of the Ice"
+    }, {
+        "id": "6331",
+        "name": "Hedge Wizard Rita of the Ice"
+    }, {
+        "id": "6580",
+        "name": "Shaman Aiko of the Ice"
+    }, {
+        "id": "6965",
+        "name": "Ice Mage Jastor of the Ice"
+    }, {
+        "id": "7208",
+        "name": "Summoner David of the Ice"
+    }, {
+        "id": "7237",
+        "name": "Ice Mage Armstrong of the Ice"
+    }, {
+        "id": "7343",
+        "name": "Ice Mage Talon of the Ice"
+    }, {
+        "id": "7534",
+        "name": "Sondra of the Ice"
+    }, {
+        "id": "7582",
+        "name": "Cryptomancer Hashim of the Ice"
+    }, {
+        "id": "7679",
+        "name": "Azahl of the Ice"
+    }, {
+        "id": "7998",
+        "name": "Shaman Rodolfo of the Ice"
+    }, {
+        "id": "8019",
+        "name": "Ice Mage Devon of the Ice"
+    }, {
+        "id": "8143",
+        "name": "Ice Mage Bane of the Ice"
+    }, {
+        "id": "8152",
+        "name": "Adept Rita of the Ice"
+    }, {
+        "id": "8308",
+        "name": "Druid Lenora of the Ice"
+    }, {
+        "id": "9084",
+        "name": "Light Mage Vatar of the Ice"
+    }, {
+        "id": "9307",
+        "name": "Ice Mage Gary of the Ice"
+    }, {
+        "id": "9552",
+        "name": "Enchanter Carly of the Ice"
+    }, {
+        "id": "9905",
+        "name": "Ice Mage Gorgana of the Ice"
+    }],
+    "Field": [{
+        "id": "167",
+        "name": "Faye of the Field"
+    }, {
+        "id": "176",
+        "name": "Enchanter Mina of the Field"
+    }, {
+        "id": "395",
+        "name": "Battle Mage Talon of the Field"
+    }, {
+        "id": "462",
+        "name": "Scryer Tundror of the Field"
+    }, {
+        "id": "495",
+        "name": "Mystic Atlanta of the Field"
+    }, {
+        "id": "501",
+        "name": "Hex Mage Konoha of the Field"
+    }, {
+        "id": "553",
+        "name": "Alchemist Celeste of the Field"
+    }, {
+        "id": "643",
+        "name": "Charmer Calliope of the Field"
+    }, {
+        "id": "681",
+        "name": "Thaumaturge Rocco of the Field"
+    }, {
+        "id": "943",
+        "name": "Hedge Wizard Angus of the Field"
+    }, {
+        "id": "979",
+        "name": "Hydromancer Merlon of the Field"
+    }, {
+        "id": "1292",
+        "name": "Artificer Fungi of the Field"
+    }, {
+        "id": "1433",
+        "name": "Magus Lamia of the Field"
+    }, {
+        "id": "1478",
+        "name": "Magus Celah of the Field"
+    }, {
+        "id": "1521",
+        "name": "Enchanter Adrienne of the Field"
+    }, {
+        "id": "1537",
+        "name": "Illusionist Artis of the Field"
+    }, {
+        "id": "1551",
+        "name": "Atlanta of the Field"
+    }, {
+        "id": "1673",
+        "name": "Alchemist Axis of the Field"
+    }, {
+        "id": "1699",
+        "name": "Enchanter Sondra of the Field"
+    }, {
+        "id": "1717",
+        "name": "Arch-Magician Victoria of the Field"
+    }, {
+        "id": "1750",
+        "name": "Witch Drusilla of the Field"
+    }, {
+        "id": "1878",
+        "name": "Conjurer Peppy of the Field"
+    }, {
+        "id": "1904",
+        "name": "Aeromancer Lumos of the Field"
+    }, {
+        "id": "2017",
+        "name": "Hedge Wizard Rita of the Field"
+    }, {
+        "id": "2219",
+        "name": "Artificer Ethan of the Field"
+    }, {
+        "id": "2310",
+        "name": "Enchanter Sondra of the Field"
+    }, {
+        "id": "2374",
+        "name": "Arcanist Galatea of the Field"
+    }, {
+        "id": "2420",
+        "name": "Ghost Eater Sonja of the Field"
+    }, {
+        "id": "2446",
+        "name": "Archmagus Eden of the Field"
+    }, {
+        "id": "2571",
+        "name": "Battlemage Nicolas of the Field"
+    }, {
+        "id": "2628",
+        "name": "Archmagus Jerret of the Field"
+    }, {
+        "id": "2725",
+        "name": "Archmagus Bolin of the Field"
+    }, {
+        "id": "2727",
+        "name": "Archmagus Zane of the Field"
+    }, {
+        "id": "2729",
+        "name": "Clairvoyant Danny of the Field"
+    }, {
+        "id": "2959",
+        "name": "Geomancer Poppy of the Field"
+    }, {
+        "id": "2971",
+        "name": "Mystic Daria of the Field"
+    }, {
+        "id": "2991",
+        "name": "Voodoo Priest Suki of the Field"
+    }, {
+        "id": "3241",
+        "name": "Magus Malthus of the Field"
+    }, {
+        "id": "3317",
+        "name": "Necromancer Isaac of the Field"
+    }, {
+        "id": "3454",
+        "name": "Alchemist Trollin of the Field"
+    }, {
+        "id": "3459",
+        "name": "Witch Rowena of the Field"
+    }, {
+        "id": "3501",
+        "name": "Witch Drusilla of the Field"
+    }, {
+        "id": "3546",
+        "name": "Druid Malthus of the Field"
+    }, {
+        "id": "3556",
+        "name": "Udor of the Field"
+    }, {
+        "id": "3581",
+        "name": "Hadrien of the Field"
+    }, {
+        "id": "3677",
+        "name": "Magus Uvlius of the Field"
+    }, {
+        "id": "3696",
+        "name": "Alchemist Angus of the Field"
+    }, {
+        "id": "3763",
+        "name": "Lumos of the Field"
+    }, {
+        "id": "3920",
+        "name": "Hydromancer Louis of the Field"
+    }, {
+        "id": "3925",
+        "name": "Stellar Mage Kalo of the Field"
+    }, {
+        "id": "3990",
+        "name": "Mystic Ofaris of the Field"
+    }, {
+        "id": "4107",
+        "name": "Charmer Artis of the Field"
+    }, {
+        "id": "4202",
+        "name": "Arcanist Artis of the Field"
+    }, {
+        "id": "4253",
+        "name": "Hedge Wizard Oxnard of the Field"
+    }, {
+        "id": "4330",
+        "name": "Arch-Magician Faiz of the Field"
+    }, {
+        "id": "4400",
+        "name": "Enchanter Celeste of the Field"
+    }, {
+        "id": "4426",
+        "name": "Daria of the Field"
+    }, {
+        "id": "4443",
+        "name": "Battle Mage Homer of the Field"
+    }, {
+        "id": "4501",
+        "name": "Cleric Carly of the Field"
+    }, {
+        "id": "4521",
+        "name": "Solomon of the Field"
+    }, {
+        "id": "4533",
+        "name": "Battle Mage Baird of the Field"
+    }, {
+        "id": "4600",
+        "name": "Geomancer Bullock of the Field"
+    }, {
+        "id": "4621",
+        "name": "Artificer Daria of the Field"
+    }, {
+        "id": "4779",
+        "name": "Chronomancer Herne of the Field"
+    }, {
+        "id": "4857",
+        "name": "Holy Monk  of the Field"
+    }, {
+        "id": "5024",
+        "name": "Shadow Mage Cassandra of the Field"
+    }, {
+        "id": "5184",
+        "name": "Enchanter Victoria of the Field"
+    }, {
+        "id": "5236",
+        "name": "Druid Amir of the Field"
+    }, {
+        "id": "5294",
+        "name": "Witch Sylvia of the Field"
+    }, {
+        "id": "5629",
+        "name": "Archmagus Uvlius of the Field"
+    }, {
+        "id": "5688",
+        "name": "Battle Mage Thor of the Field"
+    }, {
+        "id": "5725",
+        "name": "Hedge Wizard Epher of the Field"
+    }, {
+        "id": "5998",
+        "name": "Archmagus Qasim of the Field"
+    }, {
+        "id": "6281",
+        "name": "Arcanist Corky of the Field"
+    }, {
+        "id": "6285",
+        "name": "Shaman Ilyas of the Field"
+    }, {
+        "id": "6401",
+        "name": "Charmer Devon of the Field"
+    }, {
+        "id": "6450",
+        "name": "Archmagus Zafar of the Field"
+    }, {
+        "id": "6528",
+        "name": "Oracle Umber of the Field"
+    }, {
+        "id": "6636",
+        "name": "Magus Damien of the Field"
+    }, {
+        "id": "6668",
+        "name": "Archmagus Sharx of the Field"
+    }, {
+        "id": "6685",
+        "name": "Aeromancer Poppy of the Field"
+    }, {
+        "id": "6691",
+        "name": "Magus Bobbin of the Field"
+    }, {
+        "id": "6764",
+        "name": "Conjurer Hadrien of the Field"
+    }, {
+        "id": "6768",
+        "name": "Diabolist Poppy of the Field"
+    }, {
+        "id": "7277",
+        "name": "Cryptomancer Goober of the Field"
+    }, {
+        "id": "7291",
+        "name": "Archmagus Ali of the Field"
+    }, {
+        "id": "7318",
+        "name": "Druid Venga of the Field"
+    }, {
+        "id": "7367",
+        "name": "Geomancer Angus of the Field"
+    }, {
+        "id": "7602",
+        "name": "Magus Asphodel of the Field"
+    }, {
+        "id": "7625",
+        "name": "Remus of the Field"
+    }, {
+        "id": "7637",
+        "name": "Battle Mage Khudalf of the Field"
+    }, {
+        "id": "7656",
+        "name": "Alchemist Devon of the Field"
+    }, {
+        "id": "7737",
+        "name": "Augurer Darby of the Field"
+    }, {
+        "id": "7752",
+        "name": "Archmagus Astrid of the Field"
+    }, {
+        "id": "7778",
+        "name": "Geomancer Cromwell of the Field"
+    }, {
+        "id": "7821",
+        "name": "Hedge Wizard Sylvia of the Field"
+    }, {
+        "id": "8033",
+        "name": "Battle Mage Bayard of the Field"
+    }, {
+        "id": "8215",
+        "name": "Battle Mage Tundror of the Field"
+    }, {
+        "id": "8234",
+        "name": "Archmagus Eden of the Field"
+    }, {
+        "id": "8264",
+        "name": "Archmagus Cassius of the Field"
+    }, {
+        "id": "8271",
+        "name": "Wild Mage Anubis of the Field"
+    }, {
+        "id": "8337",
+        "name": "Archmagus Orpheus of the Field"
+    }, {
+        "id": "8525",
+        "name": "Archmagus Ilyas of the Field"
+    }, {
+        "id": "8632",
+        "name": "Arcanist Hagar of the Field"
+    }, {
+        "id": "8673",
+        "name": "Illusionist Ophelia of the Field"
+    }, {
+        "id": "8743",
+        "name": "Battlemage Ming of the Field"
+    }, {
+        "id": "8762",
+        "name": "Sage Crobas of the Field"
+    }, {
+        "id": "8790",
+        "name": "Druid Flynn of the Field"
+    }, {
+        "id": "8832",
+        "name": "Alchemist Celeste of the Field"
+    }, {
+        "id": "8854",
+        "name": "Alchemist Merlon of the Field"
+    }, {
+        "id": "8856",
+        "name": "Battle Mage Ulysse of the Field"
+    }, {
+        "id": "8892",
+        "name": "Witch Liliana of the Field"
+    }, {
+        "id": "9056",
+        "name": "Hedge Wizard Homer of the Field"
+    }, {
+        "id": "9123",
+        "name": "Hedge Wizard Devon of the Field"
+    }, {
+        "id": "9331",
+        "name": "Wild Mage Borak of the Field"
+    }, {
+        "id": "9405",
+        "name": "Shadow Mage Larissa of the Field"
+    }, {
+        "id": "9409",
+        "name": "Battle Mage Homer of the Field"
+    }, {
+        "id": "9509",
+        "name": "Summoner Atlanta of the Field"
+    }, {
+        "id": "9584",
+        "name": "Archmagus Chandler of the Field"
+    }, {
+        "id": "9593",
+        "name": "Battle Mage Magnus of the Field"
+    }, {
+        "id": "9753",
+        "name": "Archmagus Iprix of the Field"
+    }, {
+        "id": "9755",
+        "name": "Enchanter Circe of the Field"
+    }, {
+        "id": "9803",
+        "name": "Nikolas of the Field"
+    }, {
+        "id": "9903",
+        "name": "Archmagus Jerret of the Field"
+    }, {
+        "id": "9935",
+        "name": "Magus Jahid of the Field"
+    }, {
+        "id": "9946",
+        "name": "Augurer Nolan of the Field"
+    }, {
+        "id": "9983",
+        "name": "Evoker Oberon of the Field"
+    }, {
+        "id": "9985",
+        "name": "Shadow Mage Celeste of the Field"
+    }, {
+        "id": "9990",
+        "name": "Pyromancer Eizo of the Field"
+    }],
+    "Wood": [{
+        "id": "1",
+        "name": "Evil Arcanist Black Goat of the Wood"
+    }, {
+        "id": "32",
+        "name": "Adept Carly of the Wood"
+    }, {
+        "id": "103",
+        "name": "Sondra of the Wood"
+    }, {
+        "id": "165",
+        "name": "Witch Carmilla of the Wood"
+    }, {
+        "id": "173",
+        "name": "Arch-Magician Gwendolin of the Wood"
+    }, {
+        "id": "175",
+        "name": "Sage Larissa of the Wood"
+    }, {
+        "id": "264",
+        "name": "Magus Hothor of the Wood"
+    }, {
+        "id": "266",
+        "name": "Witch Shivra of the Wood"
+    }, {
+        "id": "275",
+        "name": "Alchemist Axel of the Wood"
+    }, {
+        "id": "282",
+        "name": "Charmer Bathsheba of the Wood"
+    }, {
+        "id": "294",
+        "name": "Sage Ariadne of the Wood"
+    }, {
+        "id": "314",
+        "name": "Pyromancer Burnside of the Wood"
+    }, {
+        "id": "343",
+        "name": "Witch Marceline of the Wood"
+    }, {
+        "id": "359",
+        "name": "Enchanter Daria of the Wood"
+    }, {
+        "id": "368",
+        "name": "Calista of the Wood"
+    }, {
+        "id": "387",
+        "name": "Illusionist Venga of the Wood"
+    }, {
+        "id": "433",
+        "name": "Alchemist Yog-Sothoth of the Wood"
+    }, {
+        "id": "444",
+        "name": "Arch-Magician Diana of the Wood"
+    }, {
+        "id": "465",
+        "name": "Milo of the Wood"
+    }, {
+        "id": "469",
+        "name": "Geomancer Woomba of the Wood"
+    }, {
+        "id": "529",
+        "name": "Shaman Ulysse of the Wood"
+    }, {
+        "id": "551",
+        "name": "Geomancer Fumiko of the Wood"
+    }, {
+        "id": "570",
+        "name": "Cryptomancer Cedric of the Wood"
+    }, {
+        "id": "583",
+        "name": "Runecaster George of the Wood"
+    }, {
+        "id": "593",
+        "name": "Sage Rita of the Wood"
+    }, {
+        "id": "594",
+        "name": "Geomancer Behemoth of the Wood"
+    }, {
+        "id": "624",
+        "name": "Arch-Magician Enigma of the Wood"
+    }, {
+        "id": "627",
+        "name": "Enchanter Durm of the Wood"
+    }, {
+        "id": "675",
+        "name": "Druid Elizabeth of the Wood"
+    }, {
+        "id": "703",
+        "name": "Necromancer Zelda of the Wood"
+    }, {
+        "id": "712",
+        "name": "Daria of the Wood"
+    }, {
+        "id": "730",
+        "name": "Scryer Liliana of the Wood"
+    }, {
+        "id": "733",
+        "name": "Alchemist Epher of the Wood"
+    }, {
+        "id": "756",
+        "name": "Alchemist Min of the Wood"
+    }, {
+        "id": "784",
+        "name": "Battle Mage Wolfram of the Wood"
+    }, {
+        "id": "805",
+        "name": "Amir of the Wood"
+    }, {
+        "id": "820",
+        "name": "Bard Milo of the Wood"
+    }, {
+        "id": "825",
+        "name": "Archmagus Jerret of the Wood"
+    }, {
+        "id": "854",
+        "name": "Arcanist Hothor of the Wood"
+    }, {
+        "id": "858",
+        "name": "Larissa of the Wood"
+    }, {
+        "id": "971",
+        "name": "Enchanter Jadis of the Wood"
+    }, {
+        "id": "982",
+        "name": "Enchanter Konoha of the Wood"
+    }, {
+        "id": "1059",
+        "name": "Hedge Wizard Wolfram of the Wood"
+    }, {
+        "id": "1117",
+        "name": "Aleister of the Wood"
+    }, {
+        "id": "1131",
+        "name": "Null Mage Hue of the Wood"
+    }, {
+        "id": "1193",
+        "name": "Magus Setsuko of the Wood"
+    }, {
+        "id": "1204",
+        "name": "Lunar Mage Eliphas of the Wood"
+    }, {
+        "id": "1238",
+        "name": "Arcanist Cassius of the Wood"
+    }, {
+        "id": "1243",
+        "name": "Battle Mage Dante of the Wood"
+    }, {
+        "id": "1280",
+        "name": "Battle Mage Angus of the Wood"
+    }, {
+        "id": "1322",
+        "name": "Spellsinger Darick of the Wood"
+    }, {
+        "id": "1337",
+        "name": "Magus Diana of the Wood"
+    }, {
+        "id": "1364",
+        "name": "Alchemist Baird of the Wood"
+    }, {
+        "id": "1406",
+        "name": "Geomancer Lenora of the Wood"
+    }, {
+        "id": "1438",
+        "name": "Thaumaturge Mace of the Wood"
+    }, {
+        "id": "1493",
+        "name": "Witch Ambrosia of the Wood"
+    }, {
+        "id": "1500",
+        "name": "Oracle Asphodel of the Wood"
+    }, {
+        "id": "1502",
+        "name": "Sage Robert of the Wood"
+    }, {
+        "id": "1590",
+        "name": "Archmagus Aden of the Wood"
+    }, {
+        "id": "1601",
+        "name": "Alchemist Oberon of the Wood"
+    }, {
+        "id": "1632",
+        "name": "Archmagus Apollo of the Wood"
+    }, {
+        "id": "1651",
+        "name": "Archmagus Ozohr of the Wood"
+    }, {
+        "id": "1687",
+        "name": "Arch-Magician Lumos of the Wood"
+    }, {
+        "id": "1740",
+        "name": "Sorcerer David of the Wood"
+    }, {
+        "id": "1776",
+        "name": "Conjurer Cromwell of the Wood"
+    }, {
+        "id": "1789",
+        "name": "Battle Mage Cromwell of the Wood"
+    }, {
+        "id": "1816",
+        "name": "Druid Sonja of the Wood"
+    }, {
+        "id": "1839",
+        "name": "Archmagus Soran of the Wood"
+    }, {
+        "id": "1874",
+        "name": "Battle Mage Talbot of the Wood"
+    }, {
+        "id": "1887",
+        "name": "Magus Layla of the Wood"
+    }, {
+        "id": "1888",
+        "name": "Sage Ekmira of the Wood"
+    }, {
+        "id": "1903",
+        "name": "Arch-Magician Malcom of the Wood"
+    }, {
+        "id": "1919",
+        "name": "Arcanist Thana of the Wood"
+    }, {
+        "id": "1933",
+        "name": "Magus Merlon of the Wood"
+    }, {
+        "id": "1937",
+        "name": "Charmer Pandora of the Wood"
+    }, {
+        "id": "1943",
+        "name": "Druid Daria of the Wood"
+    }, {
+        "id": "1952",
+        "name": "Magus Goomer of the Wood"
+    }, {
+        "id": "1963",
+        "name": "Artificer Rita of the Wood"
+    }, {
+        "id": "2011",
+        "name": "Chaos Mage Beyna of the Wood"
+    }, {
+        "id": "2024",
+        "name": "Archmagus Hothor of the Wood"
+    }, {
+        "id": "2030",
+        "name": "Shaman Brown Cow of the Wood"
+    }, {
+        "id": "2032",
+        "name": "Adept Ramiz of the Wood"
+    }, {
+        "id": "2073",
+        "name": "Charmer Jadis of the Wood"
+    }, {
+        "id": "2079",
+        "name": "Illusionist Xue of the Wood"
+    }, {
+        "id": "2084",
+        "name": "Null Mage Aleister of the Wood"
+    }, {
+        "id": "2092",
+        "name": "Arch-Magician Enzo of the Wood"
+    }, {
+        "id": "2096",
+        "name": "Alchemist Rita of the Wood"
+    }, {
+        "id": "2110",
+        "name": "Alchemist Chiyo of the Wood"
+    }, {
+        "id": "2127",
+        "name": "Druid Gully of the Wood"
+    }, {
+        "id": "2157",
+        "name": "Adept Eden of the Wood"
+    }, {
+        "id": "2209",
+        "name": "Electromancer Aden of the Wood"
+    }, {
+        "id": "2223",
+        "name": "Artificer Jack of the Wood"
+    }, {
+        "id": "2282",
+        "name": "Hedge Wizard Homer of the Wood"
+    }, {
+        "id": "2298",
+        "name": "Enchanter Devon of the Wood"
+    }, {
+        "id": "2368",
+        "name": "Sorcerer Wazir of the Wood"
+    }, {
+        "id": "2397",
+        "name": "Battle Mage Tundror of the Wood"
+    }, {
+        "id": "2460",
+        "name": "Arch-Magician Ixar of the Wood"
+    }, {
+        "id": "2465",
+        "name": "Chronomancer Lin of the Wood"
+    }, {
+        "id": "2466",
+        "name": "Druid Sarah of the Wood"
+    }, {
+        "id": "2468",
+        "name": "Charmer Circe of the Wood"
+    }, {
+        "id": "2555",
+        "name": "Druid Circe of the Wood"
+    }, {
+        "id": "2599",
+        "name": "Magus Iris of the Wood"
+    }, {
+        "id": "2610",
+        "name": "Sorcerer Davos of the Wood"
+    }, {
+        "id": "2673",
+        "name": "Hedge Wizard Apollo of the Wood"
+    }, {
+        "id": "2690",
+        "name": "Enchanter Astrid of the Wood"
+    }, {
+        "id": "2714",
+        "name": "Illusionist Shizu of the Wood"
+    }, {
+        "id": "2723",
+        "name": "Enchanter Asphodel of the Wood"
+    }, {
+        "id": "2745",
+        "name": "Archmagus Zelda of the Wood"
+    }, {
+        "id": "2751",
+        "name": "Geomancer Jasper of the Wood"
+    }, {
+        "id": "2824",
+        "name": "Cleric Yan of the Wood"
+    }, {
+        "id": "2937",
+        "name": "Druid Cromwell of the Wood"
+    }, {
+        "id": "2946",
+        "name": "Enchanter Sonja of the Wood"
+    }, {
+        "id": "2976",
+        "name": "Hex Mage Goober of the Wood"
+    }, {
+        "id": "2986",
+        "name": "Remus of the Wood"
+    }, {
+        "id": "2998",
+        "name": "Eden of the Wood"
+    }, {
+        "id": "3003",
+        "name": "Artificer Merlon of the Wood"
+    }, {
+        "id": "3057",
+        "name": "Battle Mage Homer of the Wood"
+    }, {
+        "id": "3111",
+        "name": "Thaumaturge Amir of the Wood"
+    }, {
+        "id": "3112",
+        "name": "Arcanist Aubergine of the Wood"
+    }, {
+        "id": "3113",
+        "name": "Mystic Toka of the Wood"
+    }, {
+        "id": "3185",
+        "name": "Casper of the Wood"
+    }, {
+        "id": "3272",
+        "name": "Hedge Wizard Zelda of the Wood"
+    }, {
+        "id": "3281",
+        "name": "Arcanist Beyna of the Wood"
+    }, {
+        "id": "3313",
+        "name": "Necromancer Diabolos of the Wood"
+    }, {
+        "id": "3329",
+        "name": "Atlanta of the Wood"
+    }, {
+        "id": "3363",
+        "name": "Witch Sylvia of the Wood"
+    }, {
+        "id": "3375",
+        "name": "Archmagus Allistair of the Wood"
+    }, {
+        "id": "3402",
+        "name": "Illusionist Ofaris of the Wood"
+    }, {
+        "id": "3511",
+        "name": "Battle Mage Otto of the Wood"
+    }, {
+        "id": "3517",
+        "name": "Electromancer Nixie of the Wood"
+    }, {
+        "id": "3539",
+        "name": "Enchanter Circe of the Wood"
+    }, {
+        "id": "3573",
+        "name": "Necromancer Gomorrah of the Wood"
+    }, {
+        "id": "3586",
+        "name": "Enchanter Circe of the Wood"
+    }, {
+        "id": "3587",
+        "name": "Magus Faiz of the Wood"
+    }, {
+        "id": "3598",
+        "name": "of the Wood"
+    }, {
+        "id": "3612",
+        "name": "Mystic Willow of the Wood"
+    }, {
+        "id": "3647",
+        "name": "Enchanter Ratko of the Wood"
+    }, {
+        "id": "3771",
+        "name": "Archmagus Fark of the Wood"
+    }, {
+        "id": "3870",
+        "name": "Sage Spore Boy of the Wood"
+    }, {
+        "id": "3882",
+        "name": "Silas of the Wood"
+    }, {
+        "id": "3986",
+        "name": "Magus Adrienne of the Wood"
+    }, {
+        "id": "4053",
+        "name": "Necromancer Asmodeus of the Wood"
+    }, {
+        "id": "4055",
+        "name": "Battle Mage Darick of the Wood"
+    }, {
+        "id": "4104",
+        "name": "Magus Kingsley of the Wood"
+    }, {
+        "id": "4124",
+        "name": "Arch-Magician Lumos of the Wood"
+    }, {
+        "id": "4168",
+        "name": "Battle Mage Sturgis of the Wood"
+    }, {
+        "id": "4169",
+        "name": "Battle Mage Dante of the Wood"
+    }, {
+        "id": "4257",
+        "name": "Pyromancer Apollo of the Wood"
+    }, {
+        "id": "4262",
+        "name": "Sorcerer Alatar of the Wood"
+    }, {
+        "id": "4339",
+        "name": "Druid Circe of the Wood"
+    }, {
+        "id": "4343",
+        "name": "Alchemist Asphodel of the Wood"
+    }, {
+        "id": "4368",
+        "name": "Conjurer Faye of the Wood"
+    }, {
+        "id": "4399",
+        "name": "Arch-Magician Naoki of the Wood"
+    }, {
+        "id": "4417",
+        "name": "Magus Shizu of the Wood"
+    }, {
+        "id": "4419",
+        "name": "Eden of the Wood"
+    }, {
+        "id": "4435",
+        "name": "Witch Calypso of the Wood"
+    }, {
+        "id": "4451",
+        "name": "Shadow Mage Pandora of the Wood"
+    }, {
+        "id": "4456",
+        "name": "Archmagus Argus of the Wood"
+    }, {
+        "id": "4484",
+        "name": "Sorcerer Alizam of the Wood"
+    }, {
+        "id": "4517",
+        "name": "Adept Umber of the Wood"
+    }, {
+        "id": "4532",
+        "name": "Archmagus Jerret of the Wood"
+    }, {
+        "id": "4556",
+        "name": "Arcanist Miyo of the Wood"
+    }, {
+        "id": "4562",
+        "name": "Archmagus Norix of the Wood"
+    }, {
+        "id": "4565",
+        "name": "Mystic Rita of the Wood"
+    }, {
+        "id": "4574",
+        "name": "Alchemist Baozhai of the Wood"
+    }, {
+        "id": "4602",
+        "name": "Shaman Godfrey of the Wood"
+    }, {
+        "id": "4618",
+        "name": "Hedge Wizard Marceline of the Wood"
+    }, {
+        "id": "4620",
+        "name": "Witch Shivra of the Wood"
+    }, {
+        "id": "4636",
+        "name": "Arcanist Voidoth of the Wood"
+    }, {
+        "id": "4644",
+        "name": "Pyromancer Dante of the Wood"
+    }, {
+        "id": "4657",
+        "name": "Pyromancer Celeste of the Wood"
+    }, {
+        "id": "4668",
+        "name": "Runecaster Aden of the Wood"
+    }, {
+        "id": "4718",
+        "name": "Sorcerer Merlon of the Wood"
+    }, {
+        "id": "4744",
+        "name": "Magus Delilah of the Wood"
+    }, {
+        "id": "4752",
+        "name": "Sage Yan of the Wood"
+    }, {
+        "id": "4761",
+        "name": "Arcanist Rumpleskin of the Wood"
+    }, {
+        "id": "4771",
+        "name": "Arch-Magician Aleister of the Wood"
+    }, {
+        "id": "4774",
+        "name": "Archmagus Crowley of the Wood"
+    }, {
+        "id": "4805",
+        "name": "Sage Aiko of the Wood"
+    }, {
+        "id": "4808",
+        "name": "Shadow Mage Shukri of the Wood"
+    }, {
+        "id": "4809",
+        "name": "Pyromancer Brutus of the Wood"
+    }, {
+        "id": "4850",
+        "name": "Pyromancer Ofaris of the Wood"
+    }, {
+        "id": "4905",
+        "name": "Arcanist Casper of the Wood"
+    }, {
+        "id": "4936",
+        "name": "Mystic Samuel of the Wood"
+    }, {
+        "id": "4961",
+        "name": "Geomancer Mina of the Wood"
+    }, {
+        "id": "4972",
+        "name": "Druid Cairon of the Wood"
+    }, {
+        "id": "4984",
+        "name": "Battle Mage Homer of the Wood"
+    }, {
+        "id": "5018",
+        "name": "Magus Min of the Wood"
+    }, {
+        "id": "5021",
+        "name": "Alchemist Woomba of the Wood"
+    }, {
+        "id": "5064",
+        "name": "Artificer Salvatore of the Wood"
+    }, {
+        "id": "5191",
+        "name": "Shaman Hobbs of the Wood"
+    }, {
+        "id": "5202",
+        "name": "Magus Atlanta of the Wood"
+    }, {
+        "id": "5271",
+        "name": "Charmer Victoria of the Wood"
+    }, {
+        "id": "5275",
+        "name": "Druid Bathsheba of the Wood"
+    }, {
+        "id": "5280",
+        "name": "Shaman Galatea of the Wood"
+    }, {
+        "id": "5296",
+        "name": "Sorcerer Lumos of the Wood"
+    }, {
+        "id": "5338",
+        "name": "Archmagus Anton of the Wood"
+    }, {
+        "id": "5358",
+        "name": "Magus Solomon of the Wood"
+    }, {
+        "id": "5390",
+        "name": "Adept Daria of the Wood"
+    }, {
+        "id": "5408",
+        "name": "Geomancer Zeromus of the Wood"
+    }, {
+        "id": "5473",
+        "name": "Charmer Layla of the Wood"
+    }, {
+        "id": "5485",
+        "name": "Cosmic Mage Min of the Wood"
+    }, {
+        "id": "5505",
+        "name": "Hydromancer Qasim of the Wood"
+    }, {
+        "id": "5511",
+        "name": "Enchanter Maia of the Wood"
+    }, {
+        "id": "5557",
+        "name": "Charmer Carly of the Wood"
+    }, {
+        "id": "5563",
+        "name": "Witch Imeena of the Wood"
+    }, {
+        "id": "5570",
+        "name": "Sorcerer David of the Wood"
+    }, {
+        "id": "5585",
+        "name": "Conjurer Lilith of the Wood"
+    }, {
+        "id": "5593",
+        "name": "Layla of the Wood"
+    }, {
+        "id": "5601",
+        "name": "Witch Esme of the Wood"
+    }, {
+        "id": "5692",
+        "name": "Mystic Godfrey of the Wood"
+    }, {
+        "id": "5712",
+        "name": "Zane of the Wood"
+    }, {
+        "id": "5743",
+        "name": "Arch-Magician Pandora of the Wood"
+    }, {
+        "id": "5762",
+        "name": "Ghost Eater Pandora of the Wood"
+    }, {
+        "id": "5777",
+        "name": "Arcanist Baird of the Wood"
+    }, {
+        "id": "5810",
+        "name": "Pyromancer Aiko of the Wood"
+    }, {
+        "id": "5830",
+        "name": "Adept Flynn of the Wood"
+    }, {
+        "id": "5837",
+        "name": "Artificer Angus of the Wood"
+    }, {
+        "id": "5840",
+        "name": "Shaman Eliphas of the Wood"
+    }, {
+        "id": "5860",
+        "name": "Electromancer Ixar of the Wood"
+    }, {
+        "id": "5881",
+        "name": "Artificer Celeste of the Wood"
+    }, {
+        "id": "5908",
+        "name": "Magus Homer of the Wood"
+    }, {
+        "id": "5981",
+        "name": "Archmagus Alessar of the Wood"
+    }, {
+        "id": "6019",
+        "name": "Hex Mage Adrienne of the Wood"
+    }, {
+        "id": "6031",
+        "name": "Arcanist  of the Wood"
+    }, {
+        "id": "6032",
+        "name": "Artificer Gwendolin of the Wood"
+    }, {
+        "id": "6054",
+        "name": "Shaman Ariadne of the Wood"
+    }, {
+        "id": "6085",
+        "name": "Battlemage Rita of the Wood"
+    }, {
+        "id": "6102",
+        "name": "Shadow Mage Milton of the Wood"
+    }, {
+        "id": "6107",
+        "name": "Sorcerer David of the Wood"
+    }, {
+        "id": "6108",
+        "name": "Battle Mage Angus of the Wood"
+    }, {
+        "id": "6117",
+        "name": "Conjurer Jerret of the Wood"
+    }, {
+        "id": "6149",
+        "name": "Charmer Victoria of the Wood"
+    }, {
+        "id": "6161",
+        "name": "Charmer Daria of the Wood"
+    }, {
+        "id": "6182",
+        "name": "Augurer Qasim of the Wood"
+    }, {
+        "id": "6231",
+        "name": "Hedge Wizard Ratko of the Wood"
+    }, {
+        "id": "6235",
+        "name": "Runecaster Flamos of the Wood"
+    }, {
+        "id": "6289",
+        "name": "Shaman Isaac of the Wood"
+    }, {
+        "id": "6344",
+        "name": "Enchanter Pandora of the Wood"
+    }, {
+        "id": "6356",
+        "name": "Celeste of the Wood"
+    }, {
+        "id": "6363",
+        "name": "Archmagus Crowley of the Wood"
+    }, {
+        "id": "6396",
+        "name": "Alchemist Atlanta of the Wood"
+    }, {
+        "id": "6398",
+        "name": "Hedge Wizard Evangeline of the Wood"
+    }, {
+        "id": "6445",
+        "name": "Charmer Asphodel of the Wood"
+    }, {
+        "id": "6465",
+        "name": "Artificer Drusilla of the Wood"
+    }, {
+        "id": "6481",
+        "name": "Sorcerer Orpheus of the Wood"
+    }, {
+        "id": "6499",
+        "name": "Enchanter Hestia of the Wood"
+    }, {
+        "id": "6505",
+        "name": "Alchemist Victoria of the Wood"
+    }, {
+        "id": "6515",
+        "name": "Chaos Mage Ophelia of the Wood"
+    }, {
+        "id": "6516",
+        "name": "Augurer Rowena of the Wood"
+    }, {
+        "id": "6539",
+        "name": "Alchemist Beyna of the Wood"
+    }, {
+        "id": "6566",
+        "name": "Archmagus Layla of the Wood"
+    }, {
+        "id": "6591",
+        "name": "Aeromancer Xue of the Wood"
+    }, {
+        "id": "6662",
+        "name": "Druid Godfrey of the Wood"
+    }, {
+        "id": "6758",
+        "name": "Adept Lin of the Wood"
+    }, {
+        "id": "6765",
+        "name": "Diabolist Talbot of the Wood"
+    }, {
+        "id": "6797",
+        "name": "Artificer Bayard of the Wood"
+    }, {
+        "id": "6810",
+        "name": "Artis of the Wood"
+    }, {
+        "id": "6836",
+        "name": "Battle Mage Bayard of the Wood"
+    }, {
+        "id": "6865",
+        "name": "Arcanist Zelda of the Wood"
+    }, {
+        "id": "6959",
+        "name": "Celeste of the Wood"
+    }, {
+        "id": "6993",
+        "name": "Magus Sondra of the Wood"
+    }, {
+        "id": "7001",
+        "name": "Druid Mei of the Wood"
+    }, {
+        "id": "7003",
+        "name": "Druid Diana of the Wood"
+    }, {
+        "id": "7051",
+        "name": "Aeromancer Lucien of the Wood"
+    }, {
+        "id": "7058",
+        "name": "Azahl of the Wood"
+    }, {
+        "id": "7065",
+        "name": "Milton of the Wood"
+    }, {
+        "id": "7091",
+        "name": "Magus Kazem of the Wood"
+    }, {
+        "id": "7095",
+        "name": "Battle Mage Blaise of the Wood"
+    }, {
+        "id": "7147",
+        "name": "Celah of the Wood"
+    }, {
+        "id": "7217",
+        "name": "Clairvoyant Durm of the Wood"
+    }, {
+        "id": "7219",
+        "name": "Witch Shivra of the Wood"
+    }, {
+        "id": "7242",
+        "name": "Arch-Magician Keziah of the Wood"
+    }, {
+        "id": "7306",
+        "name": "Hedge Wizard Robert of the Wood"
+    }, {
+        "id": "7316",
+        "name": "Battle Mage Darick of the Wood"
+    }, {
+        "id": "7369",
+        "name": "Archmagus Remus of the Wood"
+    }, {
+        "id": "7474",
+        "name": "Battlemage Zubin of the Wood"
+    }, {
+        "id": "7492",
+        "name": "Runecaster Iris of the Wood"
+    }, {
+        "id": "7493",
+        "name": "Enchanter Pandora of the Wood"
+    }, {
+        "id": "7494",
+        "name": "Wild Mage Dante of the Wood"
+    }, {
+        "id": "7520",
+        "name": "Hedge Wizard Moloch of the Wood"
+    }, {
+        "id": "7680",
+        "name": "Archmagus Alex of the Wood"
+    }, {
+        "id": "7686",
+        "name": "Shaman Peppy of the Wood"
+    }, {
+        "id": "7689",
+        "name": "Arcanist Milo of the Wood"
+    }, {
+        "id": "7754",
+        "name": "Magus Izible of the Wood"
+    }, {
+        "id": "7774",
+        "name": "Alchemist Esme of the Wood"
+    }, {
+        "id": "7779",
+        "name": "Hedge Wizard Yumi of the Wood"
+    }, {
+        "id": "7785",
+        "name": "Sage Huizhong of the Wood"
+    }, {
+        "id": "7802",
+        "name": "Druid Victoria of the Wood"
+    }, {
+        "id": "7827",
+        "name": "Enchanter Thana of the Wood"
+    }, {
+        "id": "7833",
+        "name": "Druid Hecate of the Wood"
+    }, {
+        "id": "7846",
+        "name": "Sky Master Hank of the Wood"
+    }, {
+        "id": "7884",
+        "name": "Battle Mage Eric of the Wood"
+    }, {
+        "id": "7903",
+        "name": "Geomancer Tengukensei of the Wood"
+    }, {
+        "id": "7913",
+        "name": "Adept Epher of the Wood"
+    }, {
+        "id": "7947",
+        "name": "Mystic Shanyuan of the Wood"
+    }, {
+        "id": "7983",
+        "name": "Hedge Wizard Florah of the Wood"
+    }, {
+        "id": "7987",
+        "name": "Archmagus Allistair of the Wood"
+    }, {
+        "id": "7990",
+        "name": "Enchanter Faye of the Wood"
+    }, {
+        "id": "7995",
+        "name": "Hedge Wizard Althea of the Wood"
+    }, {
+        "id": "7996",
+        "name": "Alchemist Thana of the Wood"
+    }, {
+        "id": "8031",
+        "name": "Alchemist Ekmira of the Wood"
+    }, {
+        "id": "8046",
+        "name": "Sage  of the Wood"
+    }, {
+        "id": "8058",
+        "name": "Aeromancer Nikolas of the Wood"
+    }, {
+        "id": "8104",
+        "name": "Battle Mage Magnus of the Wood"
+    }, {
+        "id": "8165",
+        "name": "Clairvoyant Daphne of the Wood"
+    }, {
+        "id": "8225",
+        "name": "Aeromancer Jameel of the Wood"
+    }, {
+        "id": "8239",
+        "name": "Battle Mage Cromwell of the Wood"
+    }, {
+        "id": "8255",
+        "name": "Magus Larissa of the Wood"
+    }, {
+        "id": "8256",
+        "name": "Alchemist Properpine of the Wood"
+    }, {
+        "id": "8286",
+        "name": "Voodoo Priest Solomon of the Wood"
+    }, {
+        "id": "8301",
+        "name": "Magus Zelroth of the Wood"
+    }, {
+        "id": "8419",
+        "name": "Alchemist Alessar of the Wood"
+    }, {
+        "id": "8425",
+        "name": "Magus Gogol of the Wood"
+    }, {
+        "id": "8426",
+        "name": "Hex Mage Remus of the Wood"
+    }, {
+        "id": "8441",
+        "name": "Electromancer Suc'Naath of the Wood"
+    }, {
+        "id": "8457",
+        "name": "Adept Caligula of the Wood"
+    }, {
+        "id": "8464",
+        "name": "Augurer Goliath of the Wood"
+    }, {
+        "id": "8540",
+        "name": "Hydromancer Angus of the Wood"
+    }, {
+        "id": "8543",
+        "name": "Witch Rita of the Wood"
+    }, {
+        "id": "8626",
+        "name": "Ofaris of the Wood"
+    }, {
+        "id": "8660",
+        "name": "Hedge Wizard Carmilla of the Wood"
+    }, {
+        "id": "8704",
+        "name": "Battlemage Eric of the Wood"
+    }, {
+        "id": "8711",
+        "name": "Chaos Mage Miyo of the Wood"
+    }, {
+        "id": "8734",
+        "name": "Ghost Eater Oil Seed of the Wood"
+    }, {
+        "id": "8755",
+        "name": "Artificer Uvlius of the Wood"
+    }, {
+        "id": "8808",
+        "name": "Cybele of the Wood"
+    }, {
+        "id": "8818",
+        "name": "Battle Mage Baird of the Wood"
+    }, {
+        "id": "8831",
+        "name": "Battlemage Hansel of the Wood"
+    }, {
+        "id": "8847",
+        "name": "Archmagus Merlon of the Wood"
+    }, {
+        "id": "8870",
+        "name": "Battle Mage Nicolas of the Wood"
+    }, {
+        "id": "8946",
+        "name": "Shadow Mage Kang of the Wood"
+    }, {
+        "id": "8957",
+        "name": "Battle Mage Ulysse of the Wood"
+    }, {
+        "id": "8959",
+        "name": "Arcanist Kamil of the Wood"
+    }, {
+        "id": "8975",
+        "name": "Druid Shigenjo of the Wood"
+    }, {
+        "id": "8982",
+        "name": "Pyromancer Nolan of the Wood"
+    }, {
+        "id": "9009",
+        "name": "Aeromancer Samuel of the Wood"
+    }, {
+        "id": "9025",
+        "name": "Thana of the Wood"
+    }, {
+        "id": "9042",
+        "name": "Necromancer Toka of the Wood"
+    }, {
+        "id": "9080",
+        "name": "Magus Diggory of the Wood"
+    }, {
+        "id": "9088",
+        "name": "Magus Aleister of the Wood"
+    }, {
+        "id": "9110",
+        "name": "Alchemist Chooki of the Wood"
+    }, {
+        "id": "9122",
+        "name": "Mystic Faye of the Wood"
+    }, {
+        "id": "9126",
+        "name": "Lunar Mage Misumi of the Wood"
+    }, {
+        "id": "9139",
+        "name": "Diabolist Gully of the Wood"
+    }, {
+        "id": "9184",
+        "name": "Hedge Wizard Otto of the Wood"
+    }, {
+        "id": "9201",
+        "name": "Cosmic Mage Layla of the Wood"
+    }, {
+        "id": "9210",
+        "name": "Shadow Mage Rowena of the Wood"
+    }, {
+        "id": "9214",
+        "name": "Witch Rita of the Wood"
+    }, {
+        "id": "9229",
+        "name": "Wild Mage Velorina of the Wood"
+    }, {
+        "id": "9234",
+        "name": "Aeromancer Tengukensei of the Wood"
+    }, {
+        "id": "9289",
+        "name": "Artificer Axel of the Wood"
+    }, {
+        "id": "9292",
+        "name": "Battle Mage Cromwell of the Wood"
+    }, {
+        "id": "9313",
+        "name": "Lumos of the Wood"
+    }, {
+        "id": "9347",
+        "name": "Sorcerer Rafiq of the Wood"
+    }, {
+        "id": "9391",
+        "name": "Druid Chiyo of the Wood"
+    }, {
+        "id": "9393",
+        "name": "Witch Elena of the Wood"
+    }, {
+        "id": "9402",
+        "name": "Archmagus Ixar of the Wood"
+    }, {
+        "id": "9420",
+        "name": "Alchemist Shivra of the Wood"
+    }, {
+        "id": "9423",
+        "name": "Summoner Baozhai of the Wood"
+    }, {
+        "id": "9438",
+        "name": "Sorcerer George of the Wood"
+    }, {
+        "id": "9469",
+        "name": "Adept Lin of the Wood"
+    }, {
+        "id": "9496",
+        "name": "Artificer  of the Wood"
+    }, {
+        "id": "9558",
+        "name": "Arcanist Basil of the Wood"
+    }, {
+        "id": "9571",
+        "name": "Witch Shivra of the Wood"
+    }, {
+        "id": "9585",
+        "name": "Carly of the Wood"
+    }, {
+        "id": "9615",
+        "name": "Witch Zelda of the Wood"
+    }, {
+        "id": "9663",
+        "name": "Chaos Mage Kobold of the Wood"
+    }, {
+        "id": "9731",
+        "name": "Magus Ulysse of the Wood"
+    }, {
+        "id": "9739",
+        "name": "Druid Ethan of the Wood"
+    }, {
+        "id": "9741",
+        "name": "Archmagus Zaros of the Wood"
+    }, {
+        "id": "9780",
+        "name": "Void Disciple Atlas of the Wood"
+    }, {
+        "id": "9789",
+        "name": "Runecaster Bathsheba of the Wood"
+    }, {
+        "id": "9819",
+        "name": "Augurer Chu Hua of the Wood"
+    }, {
+        "id": "9878",
+        "name": "Summoner Althea of the Wood"
+    }, {
+        "id": "9885",
+        "name": "Sorcerer Celah of the Wood"
+    }, {
+        "id": "9887",
+        "name": "Archmagus  of the Wood"
+    }, {
+        "id": "9916",
+        "name": "Magus  of the Wood"
+    }, {
+        "id": "9939",
+        "name": "Battle Mage Hagar of the Wood"
+    }, {
+        "id": "9948",
+        "name": "Void Disciple Vossler of the Wood"
+    }, {
+        "id": "9952",
+        "name": "Battle Mage Axel of the Wood"
+    }, {
+        "id": "9958",
+        "name": "Alchemist George of the Wood"
+    }, {
+        "id": "9966",
+        "name": "Magus Eric of the Wood"
+    }, {
+        "id": "9969",
+        "name": "Null Mage Jiggs of the Wood"
+    }, {
+        "id": "9992",
+        "name": "Hydromancer Cromwell of the Wood"
+    }],
+    "Capital": [{
+        "id": "166",
+        "name": "Enchanter Bayard of the Capital"
+    }, {
+        "id": "374",
+        "name": "Sorcerer Remus of the Capital"
+    }, {
+        "id": "401",
+        "name": "Hedge Wizard Kalo of the Capital"
+    }, {
+        "id": "427",
+        "name": "Enchanter Lamia of the Capital"
+    }, {
+        "id": "455",
+        "name": "Enchanter Adrienne of the Capital"
+    }, {
+        "id": "510",
+        "name": "Hedge Wizard Merlon of the Capital"
+    }, {
+        "id": "554",
+        "name": "Hydromancer Crowley of the Capital"
+    }, {
+        "id": "768",
+        "name": "Druid Zane of the Capital"
+    }, {
+        "id": "778",
+        "name": "Enchanter Arabella of the Capital"
+    }, {
+        "id": "826",
+        "name": "Runecaster Voidoth of the Capital"
+    }, {
+        "id": "847",
+        "name": "Colormancer Colorman of the Capital"
+    }, {
+        "id": "937",
+        "name": "Enchanter Althea of the Capital"
+    }, {
+        "id": "1066",
+        "name": "Sage Lux of the Capital"
+    }, {
+        "id": "1153",
+        "name": "Chaos Mage Bathsheba of the Capital"
+    }, {
+        "id": "1209",
+        "name": "Archmagus Isaac of the Capital"
+    }, {
+        "id": "1405",
+        "name": "Archmagus Allistair of the Capital"
+    }, {
+        "id": "1851",
+        "name": "Arcanist Aleister of the Capital"
+    }, {
+        "id": "1924",
+        "name": "Magus Rodolfo of the Capital"
+    }, {
+        "id": "1959",
+        "name": "Aeromancer Pan of the Capital"
+    }, {
+        "id": "2174",
+        "name": "Conjurer Cromwell of the Capital"
+    }, {
+        "id": "2189",
+        "name": "Voodoo Priest Victor of the Capital"
+    }, {
+        "id": "2206",
+        "name": "Witch Juniper of the Capital"
+    }, {
+        "id": "2319",
+        "name": "Witch Marceline of the Capital"
+    }, {
+        "id": "2340",
+        "name": "Archmagus Amir of the Capital"
+    }, {
+        "id": "2425",
+        "name": "Sage Carly of the Capital"
+    }, {
+        "id": "2558",
+        "name": "Enchanter Allistair of the Capital"
+    }, {
+        "id": "2584",
+        "name": "Battle Mage Gunthor of the Capital"
+    }, {
+        "id": "2604",
+        "name": "Magus Charlord of the Capital"
+    }, {
+        "id": "2627",
+        "name": "Sage Zeromus of the Capital"
+    }, {
+        "id": "2638",
+        "name": "Electromancer Fallow of the Capital"
+    }, {
+        "id": "2800",
+        "name": "Alessar of the Capital"
+    }, {
+        "id": "2823",
+        "name": "Void Disciple Gogol of the Capital"
+    }, {
+        "id": "2952",
+        "name": "Alchemist Dutorn of the Capital"
+    }, {
+        "id": "3215",
+        "name": "Archmagus Ixar of the Capital"
+    }, {
+        "id": "3229",
+        "name": "Conjurer Samael of the Capital"
+    }, {
+        "id": "3243",
+        "name": "Mystic Reza of the Capital"
+    }, {
+        "id": "3253",
+        "name": "Allistair of the Capital"
+    }, {
+        "id": "3259",
+        "name": "Archmagus Sharx of the Capital"
+    }, {
+        "id": "3347",
+        "name": "Magus Bojangles of the Capital"
+    }, {
+        "id": "3414",
+        "name": "Arch-Magician Alessar of the Capital"
+    }, {
+        "id": "3741",
+        "name": "Necromancer Godfrey of the Capital"
+    }, {
+        "id": "3868",
+        "name": "Battle Mage Homer of the Capital"
+    }, {
+        "id": "3873",
+        "name": "Pyromancer Mycho of the Capital"
+    }, {
+        "id": "3997",
+        "name": "Charmer Jadis of the Capital"
+    }, {
+        "id": "4047",
+        "name": "Medium Basil of the Capital"
+    }, {
+        "id": "4285",
+        "name": "Diabolist Rumpleskin of the Capital"
+    }, {
+        "id": "4353",
+        "name": "Mystic Ravana of the Capital"
+    }, {
+        "id": "4457",
+        "name": "Enchanter Calista of the Capital"
+    }, {
+        "id": "4665",
+        "name": "David of the Capital"
+    }, {
+        "id": "4827",
+        "name": "Diana of the Capital"
+    }, {
+        "id": "4919",
+        "name": "Sorcerer Azahl of the Capital"
+    }, {
+        "id": "4923",
+        "name": "Illusionist Solomon of the Capital"
+    }, {
+        "id": "5014",
+        "name": "Sorcerer Idris of the Capital"
+    }, {
+        "id": "5046",
+        "name": "Diabolist Aden of the Capital"
+    }, {
+        "id": "5144",
+        "name": "Chronomancer Aleister of the Capital"
+    }, {
+        "id": "5266",
+        "name": "Sorcerer Alizam of the Capital"
+    }, {
+        "id": "5416",
+        "name": "Alchemist Duzzle of the Capital"
+    }, {
+        "id": "5455",
+        "name": "Mystic Ozohr of the Capital"
+    }, {
+        "id": "5458",
+        "name": "Shaman Ethan of the Capital"
+    }, {
+        "id": "5462",
+        "name": "Sorcerer Zaim of the Capital"
+    }, {
+        "id": "5621",
+        "name": "Ghost Eater Quddus of the Capital"
+    }, {
+        "id": "5627",
+        "name": "Archmagus Milo of the Capital"
+    }, {
+        "id": "5654",
+        "name": "Electromancer Kobold of the Capital"
+    }, {
+        "id": "5674",
+        "name": "Druid Orpheus of the Capital"
+    }, {
+        "id": "6004",
+        "name": "Archmagus Solomon of the Capital"
+    }, {
+        "id": "6135",
+        "name": "Adept Damien of the Capital"
+    }, {
+        "id": "6338",
+        "name": "Void Disciple Chu Hua of the Capital"
+    }, {
+        "id": "6384",
+        "name": "Battle Mage Talon of the Capital"
+    }, {
+        "id": "6483",
+        "name": "Hydromancer Crackerjack of the Capital"
+    }, {
+        "id": "6721",
+        "name": "Shaman  of the Capital"
+    }, {
+        "id": "6774",
+        "name": "Shaman Flamos of the Capital"
+    }, {
+        "id": "6800",
+        "name": "Archmagus Aldus of the Capital"
+    }, {
+        "id": "6889",
+        "name": "Hydromancer Peppy of the Capital"
+    }, {
+        "id": "6956",
+        "name": "Clairvoyant Iluzor of the Capital"
+    }, {
+        "id": "7011",
+        "name": "Archmagus Eronin of the Capital"
+    }, {
+        "id": "7088",
+        "name": "Artificer Bayard of the Capital"
+    }, {
+        "id": "7096",
+        "name": "Arcanist Zelroth of the Capital"
+    }, {
+        "id": "7181",
+        "name": "Maia of the Capital"
+    }, {
+        "id": "7393",
+        "name": "Hedge Wizard Milton of the Capital"
+    }, {
+        "id": "7535",
+        "name": "Milton of the Capital"
+    }, {
+        "id": "7540",
+        "name": "Druid Ratko of the Capital"
+    }, {
+        "id": "7557",
+        "name": "Pyromancer Tengu of the Capital"
+    }, {
+        "id": "7630",
+        "name": "Sorcerer Apollo of the Capital"
+    }, {
+        "id": "7793",
+        "name": "Necromancer Scratch of the Capital"
+    }, {
+        "id": "7858",
+        "name": "Archmagus Ixar of the Capital"
+    }, {
+        "id": "7870",
+        "name": "Sorcerer Aleister of the Capital"
+    }, {
+        "id": "7918",
+        "name": "Sorcerer Zaros of the Capital"
+    }, {
+        "id": "8027",
+        "name": "Necromancer Ozohr of the Capital"
+    }, {
+        "id": "8045",
+        "name": "Archmagus Eric of the Capital"
+    }, {
+        "id": "8057",
+        "name": "Bathsheba of the Capital"
+    }, {
+        "id": "8161",
+        "name": "Alchemist Apollo of the Capital"
+    }, {
+        "id": "8174",
+        "name": "Alchemist Lumos of the Capital"
+    }, {
+        "id": "8222",
+        "name": "Battle Mage Malthus of the Capital"
+    }, {
+        "id": "8254",
+        "name": "Augurer Milton of the Capital"
+    }, {
+        "id": "8403",
+        "name": "Alchemist  of the Capital"
+    }, {
+        "id": "8468",
+        "name": "Witch Hagatha of the Capital"
+    }, {
+        "id": "8485",
+        "name": "Alchemist Ratko of the Capital"
+    }, {
+        "id": "8655",
+        "name": "Alchemist Uvlius of the Capital"
+    }, {
+        "id": "8830",
+        "name": "Sky Master Magpie of the Capital"
+    }, {
+        "id": "8930",
+        "name": "Clairvoyant Blaise of the Capital"
+    }, {
+        "id": "9249",
+        "name": "Magus Salvatore of the Capital"
+    }, {
+        "id": "9250",
+        "name": "Enchanter Jerret of the Capital"
+    }, {
+        "id": "9324",
+        "name": "Archmagus Crowley of the Capital"
+    }, {
+        "id": "9336",
+        "name": "Carly of the Capital"
+    }, {
+        "id": "9428",
+        "name": "Necromancer Arcus of the Capital"
+    }, {
+        "id": "9545",
+        "name": "Battle Mage Horace of the Capital"
+    }, {
+        "id": "9607",
+        "name": "Wild Mage Bayard of the Capital"
+    }, {
+        "id": "9652",
+        "name": "Alchemist Hagar of the Capital"
+    }, {
+        "id": "9685",
+        "name": "Thaumaturge Goober of the Capital"
+    }, {
+        "id": "9764",
+        "name": "Necromancer Vossler of the Capital"
+    }, {
+        "id": "9839",
+        "name": "Archmagus Soya of the Capital"
+    }, {
+        "id": "9841",
+        "name": "Archmagus Max of the Capital"
+    }, {
+        "id": "9897",
+        "name": "Enchanter Hugo of the Capital"
+    }, {
+        "id": "9936",
+        "name": "Artificer Eric of the Capital"
+    }],
+    "Valley": [{
+        "id": "56",
+        "name": "Archmagus Baird of the Valley"
+    }, {
+        "id": "82",
+        "name": "Shadow Mage Dante of the Valley"
+    }, {
+        "id": "112",
+        "name": "Artificer Axel of the Valley"
+    }, {
+        "id": "122",
+        "name": "Battle Mage Atlas of the Valley"
+    }, {
+        "id": "157",
+        "name": "Archmagus Hadrien of the Valley"
+    }, {
+        "id": "203",
+        "name": "Battle Mage Angus of the Valley"
+    }, {
+        "id": "222",
+        "name": "Shaman Molek of the Valley"
+    }, {
+        "id": "254",
+        "name": "Sorcerer Casper of the Valley"
+    }, {
+        "id": "320",
+        "name": "Augurer Hagatha of the Valley"
+    }, {
+        "id": "383",
+        "name": "Shaman Devon of the Valley"
+    }, {
+        "id": "425",
+        "name": "Alchemist David of the Valley"
+    }, {
+        "id": "499",
+        "name": "Battle Mage Axel of the Valley"
+    }, {
+        "id": "507",
+        "name": "Leah of the Valley"
+    }, {
+        "id": "513",
+        "name": "Hedge Wizard Chu Hua of the Valley"
+    }, {
+        "id": "519",
+        "name": "Cryptomancer Caligula of the Valley"
+    }, {
+        "id": "543",
+        "name": "Archmagus Aslan of the Valley"
+    }, {
+        "id": "582",
+        "name": "Shaman Magnus of the Valley"
+    }, {
+        "id": "621",
+        "name": "Hex Mage Ethan of the Valley"
+    }, {
+        "id": "650",
+        "name": "Arch-Magician Azahl of the Valley"
+    }, {
+        "id": "678",
+        "name": "Charmer Lamia of the Valley"
+    }, {
+        "id": "696",
+        "name": "Battle Mage Hagar of the Valley"
+    }, {
+        "id": "786",
+        "name": "Oracle Circe of the Valley"
+    }, {
+        "id": "802",
+        "name": "Electromancer Lucinda of the Valley"
+    }, {
+        "id": "818",
+        "name": "Enchanter Victoria of the Valley"
+    }, {
+        "id": "879",
+        "name": "Titania of the Valley"
+    }, {
+        "id": "1125",
+        "name": "Archmagus David of the Valley"
+    }, {
+        "id": "1140",
+        "name": "Witch Rita of the Valley"
+    }, {
+        "id": "1195",
+        "name": "Adept Lamia of the Valley"
+    }, {
+        "id": "1228",
+        "name": "Aeromancer Astrid of the Valley"
+    }, {
+        "id": "1260",
+        "name": "Transmuter Dutorn of the Valley"
+    }, {
+        "id": "1299",
+        "name": "Sorcerer Soya of the Valley"
+    }, {
+        "id": "1316",
+        "name": "Witch Rita of the Valley"
+    }, {
+        "id": "1359",
+        "name": "Enchanter Nicolas of the Valley"
+    }, {
+        "id": "1395",
+        "name": "Artificer Godfrey of the Valley"
+    }, {
+        "id": "1449",
+        "name": "Battle Mage Nicolas of the Valley"
+    }, {
+        "id": "1501",
+        "name": "Witch Velorina of the Valley"
+    }, {
+        "id": "1516",
+        "name": "Archmagus Ronald of the Valley"
+    }, {
+        "id": "1542",
+        "name": "Aeromancer Duzzle of the Valley"
+    }, {
+        "id": "1596",
+        "name": "Ghost Eater Hypnos of the Valley"
+    }, {
+        "id": "1627",
+        "name": "Arcanist Daria of the Valley"
+    }, {
+        "id": "1674",
+        "name": "Alchemist Delilah of the Valley"
+    }, {
+        "id": "1755",
+        "name": "Sorcerer Jahid of the Valley"
+    }, {
+        "id": "1783",
+        "name": "Runecaster Jastor of the Valley"
+    }, {
+        "id": "1842",
+        "name": "Oracle Lamia of the Valley"
+    }, {
+        "id": "1859",
+        "name": "Archmagus Aleister of the Valley"
+    }, {
+        "id": "1890",
+        "name": "Sorcerer Ofaris of the Valley"
+    }, {
+        "id": "1898",
+        "name": "Battle Mage Robert of the Valley"
+    }, {
+        "id": "1949",
+        "name": "Alchemist Chiyo of the Valley"
+    }, {
+        "id": "1990",
+        "name": "Charmer Larissa of the Valley"
+    }, {
+        "id": "1993",
+        "name": "Battle Mage Dutorn of the Valley"
+    }, {
+        "id": "2155",
+        "name": "Chaos Mage Wolfram of the Valley"
+    }, {
+        "id": "2229",
+        "name": "Hedge Wizard Astrid of the Valley"
+    }, {
+        "id": "2331",
+        "name": "Diabolist Titania of the Valley"
+    }, {
+        "id": "2395",
+        "name": "Artificer Aldo of the Valley"
+    }, {
+        "id": "2398",
+        "name": "Lux of the Valley"
+    }, {
+        "id": "2415",
+        "name": "Archmagus  of the Valley"
+    }, {
+        "id": "2479",
+        "name": "Oracle Celah of the Valley"
+    }, {
+        "id": "2481",
+        "name": "Witch Enigma of the Valley"
+    }, {
+        "id": "2587",
+        "name": "Artificer Armstrong of the Valley"
+    }, {
+        "id": "2667",
+        "name": "Pyromancer Galatea of the Valley"
+    }, {
+        "id": "2668",
+        "name": "Adept Daria of the Valley"
+    }, {
+        "id": "2712",
+        "name": "Archmagus Ivy of the Valley"
+    }, {
+        "id": "2777",
+        "name": "Magus Apollo of the Valley"
+    }, {
+        "id": "2792",
+        "name": "Geomancer Samuel of the Valley"
+    }, {
+        "id": "2832",
+        "name": "Shadow Mage Calista of the Valley"
+    }, {
+        "id": "2909",
+        "name": "Battlemage Milton of the Valley"
+    }, {
+        "id": "2915",
+        "name": "Alchemist Gunthor of the Valley"
+    }, {
+        "id": "2995",
+        "name": "Hedge Wizard Ming of the Valley"
+    }, {
+        "id": "3002",
+        "name": "Charmer Devon of the Valley"
+    }, {
+        "id": "3039",
+        "name": "Enchanter Artis of the Valley"
+    }, {
+        "id": "3048",
+        "name": "Arch-Magician Bathsheba of the Valley"
+    }, {
+        "id": "3071",
+        "name": "Sage Soya of the Valley"
+    }, {
+        "id": "3127",
+        "name": "Layla of the Valley"
+    }, {
+        "id": "3174",
+        "name": "Battle Mage Malthus of the Valley"
+    }, {
+        "id": "3249",
+        "name": "Charmer Maia of the Valley"
+    }, {
+        "id": "3304",
+        "name": "Druid Uvlius of the Valley"
+    }, {
+        "id": "3306",
+        "name": "Archmagus Jerret of the Valley"
+    }, {
+        "id": "3407",
+        "name": "Diabolist Marceline of the Valley"
+    }, {
+        "id": "3499",
+        "name": "Hedge Wizard Eden of the Valley"
+    }, {
+        "id": "3509",
+        "name": "Augurer Darick of the Valley"
+    }, {
+        "id": "3555",
+        "name": "Artificer Goliath of the Valley"
+    }, {
+        "id": "3570",
+        "name": "Thaumaturge Hagar of the Valley"
+    }, {
+        "id": "3673",
+        "name": "Druid Hugo of the Valley"
+    }, {
+        "id": "3676",
+        "name": "Druid Enigma of the Valley"
+    }, {
+        "id": "3684",
+        "name": "Shaman Magnus of the Valley"
+    }, {
+        "id": "3932",
+        "name": "Magus Thana of the Valley"
+    }, {
+        "id": "3978",
+        "name": "Sage Jianyu of the Valley"
+    }, {
+        "id": "3983",
+        "name": "Arch-Magician Silas of the Valley"
+    }, {
+        "id": "3984",
+        "name": "Adept Froggy of the Valley"
+    }, {
+        "id": "4038",
+        "name": "Transmuter Aldus of the Valley"
+    }, {
+        "id": "4064",
+        "name": "Witch Lenora of the Valley"
+    }, {
+        "id": "4094",
+        "name": "Cleric Tengu of the Valley"
+    }, {
+        "id": "4097",
+        "name": "Thaumaturge Ilyas of the Valley"
+    }, {
+        "id": "4161",
+        "name": "Fortune Teller Liliana of the Valley"
+    }, {
+        "id": "4173",
+        "name": "Hedge Wizard Cromwell of the Valley"
+    }, {
+        "id": "4200",
+        "name": "Ghost Eater Allistair of the Valley"
+    }, {
+        "id": "4301",
+        "name": "Thaumaturge Godfrey of the Valley"
+    }, {
+        "id": "4384",
+        "name": "Pyromancer Yan of the Valley"
+    }, {
+        "id": "4423",
+        "name": "Magus Solomon of the Valley"
+    }, {
+        "id": "4474",
+        "name": "Alchemist Iprix of the Valley"
+    }, {
+        "id": "4499",
+        "name": "Magus Althea of the Valley"
+    }, {
+        "id": "4500",
+        "name": "Wizard Nixie of the Valley"
+    }, {
+        "id": "4511",
+        "name": "Hadrien of the Valley"
+    }, {
+        "id": "4514",
+        "name": "Magus Angus of the Valley"
+    }, {
+        "id": "4680",
+        "name": "Magus Faiz of the Valley"
+    }, {
+        "id": "4730",
+        "name": "Charmer Daria of the Valley"
+    }, {
+        "id": "4731",
+        "name": "Sorcerer Tumbaj of the Valley"
+    }, {
+        "id": "4743",
+        "name": "Alchemist Thor of the Valley"
+    }, {
+        "id": "4787",
+        "name": "Archmagus Hadrien of the Valley"
+    }, {
+        "id": "4898",
+        "name": "Archmagus Winter Squash of the Valley"
+    }, {
+        "id": "4900",
+        "name": "Druid Galatea of the Valley"
+    }, {
+        "id": "4937",
+        "name": "Necromancer Chiron of the Valley"
+    }, {
+        "id": "4973",
+        "name": "Enchanter Leah of the Valley"
+    }, {
+        "id": "5042",
+        "name": "Druid Titania of the Valley"
+    }, {
+        "id": "5139",
+        "name": "Runecaster Axel of the Valley"
+    }, {
+        "id": "5213",
+        "name": "Lumos of the Valley"
+    }, {
+        "id": "5370",
+        "name": "Evoker Borak of the Valley"
+    }, {
+        "id": "5385",
+        "name": "Pyromancer Bao of the Valley"
+    }, {
+        "id": "5389",
+        "name": "Charmer Layla of the Valley"
+    }, {
+        "id": "5406",
+        "name": "Archmagus Gellert of the Valley"
+    }, {
+        "id": "5514",
+        "name": "Mystic Oberon of the Valley"
+    }, {
+        "id": "5543",
+        "name": "Battle Mage Eric of the Valley"
+    }, {
+        "id": "5619",
+        "name": "Archmagus Lux of the Valley"
+    }, {
+        "id": "5713",
+        "name": "Mystic Hagar of the Valley"
+    }, {
+        "id": "5726",
+        "name": "Hedge Wizard Fungi of the Valley"
+    }, {
+        "id": "5735",
+        "name": "Enchanter Bathsheba of the Valley"
+    }, {
+        "id": "5737",
+        "name": "Magus Wazir of the Valley"
+    }, {
+        "id": "5739",
+        "name": "Alchemist Artis of the Valley"
+    }, {
+        "id": "5781",
+        "name": "Sorcerer Carly of the Valley"
+    }, {
+        "id": "5788",
+        "name": "Magus Qaid of the Valley"
+    }, {
+        "id": "5800",
+        "name": "Witch Properpine of the Valley"
+    }, {
+        "id": "5972",
+        "name": "Lunar Mage Nadeem of the Valley"
+    }, {
+        "id": "5983",
+        "name": "Battle Mage Hagar of the Valley"
+    }, {
+        "id": "5985",
+        "name": "Bard Aldus of the Valley"
+    }, {
+        "id": "6090",
+        "name": "Magus Setsuko of the Valley"
+    }, {
+        "id": "6096",
+        "name": "Summoner Crowley of the Valley"
+    }, {
+        "id": "6144",
+        "name": "Magus Rowena of the Valley"
+    }, {
+        "id": "6157",
+        "name": "Enchanter Willow of the Valley"
+    }, {
+        "id": "6400",
+        "name": "Lunar Mage Astrid of the Valley"
+    }, {
+        "id": "6497",
+        "name": "Zelroth of the Valley"
+    }, {
+        "id": "6510",
+        "name": "Sage Homer of the Valley"
+    }, {
+        "id": "6519",
+        "name": "Enchanter Daphne of the Valley"
+    }, {
+        "id": "6555",
+        "name": "Sorcerer Wazir of the Valley"
+    }, {
+        "id": "6586",
+        "name": "Enchanter Artis of the Valley"
+    }, {
+        "id": "6596",
+        "name": "Adept Corvin of the Valley"
+    }, {
+        "id": "6622",
+        "name": "Illusionist Mina of the Valley"
+    }, {
+        "id": "6667",
+        "name": "Pyromancer Hellspawn of the Valley"
+    }, {
+        "id": "6727",
+        "name": "Shaman Titania of the Valley"
+    }, {
+        "id": "6739",
+        "name": "Aeromancer Aiko of the Valley"
+    }, {
+        "id": "6745",
+        "name": "Voodoo Priest Lucien of the Valley"
+    }, {
+        "id": "6767",
+        "name": "Alchemist Ambrosia of the Valley"
+    }, {
+        "id": "6775",
+        "name": "Mystic Carly of the Valley"
+    }, {
+        "id": "6777",
+        "name": "Necromancer Sondra of the Valley"
+    }, {
+        "id": "6791",
+        "name": "Witch Zolona of the Valley"
+    }, {
+        "id": "6801",
+        "name": "Sonja of the Valley"
+    }, {
+        "id": "6811",
+        "name": "Shaman Robert of the Valley"
+    }, {
+        "id": "6885",
+        "name": "Battle Mage Angus of the Valley"
+    }, {
+        "id": "6977",
+        "name": "Archmagus Isaac of the Valley"
+    }, {
+        "id": "7008",
+        "name": "Enchanter Artis of the Valley"
+    }, {
+        "id": "7104",
+        "name": "Transmuter Hothor of the Valley"
+    }, {
+        "id": "7229",
+        "name": "Runecaster Soya of the Valley"
+    }, {
+        "id": "7233",
+        "name": "Alchemist Aleister of the Valley"
+    }, {
+        "id": "7249",
+        "name": "Maia of the Valley"
+    }, {
+        "id": "7252",
+        "name": "Illusionist Sharx of the Valley"
+    }, {
+        "id": "7269",
+        "name": "Electromancer Circe of the Valley"
+    }, {
+        "id": "7350",
+        "name": "Druid Hansel of the Valley"
+    }, {
+        "id": "7424",
+        "name": "Battle Mage Flynn of the Valley"
+    }, {
+        "id": "7452",
+        "name": "Thaumaturge Gorgana of the Valley"
+    }, {
+        "id": "7486",
+        "name": "Pyromancer Mei of the Valley"
+    }, {
+        "id": "7552",
+        "name": "Hedge Wizard Keziah of the Valley"
+    }, {
+        "id": "7556",
+        "name": "Cleric Otto of the Valley"
+    }, {
+        "id": "7571",
+        "name": "Hedge Wizard Althea of the Valley"
+    }, {
+        "id": "7627",
+        "name": "Wild Mage Hansel of the Valley"
+    }, {
+        "id": "7648",
+        "name": "Archmagus Alessar of the Valley"
+    }, {
+        "id": "7715",
+        "name": "Chaos Mage Pumlo of the Valley"
+    }, {
+        "id": "7835",
+        "name": "Arcanist Celeste of the Valley"
+    }, {
+        "id": "7838",
+        "name": "Hydromancer Lavinia of the Valley"
+    }, {
+        "id": "7860",
+        "name": "Witch Rowena of the Valley"
+    }, {
+        "id": "7872",
+        "name": "Magus Adrienne of the Valley"
+    }, {
+        "id": "7930",
+        "name": "Geomancer Iris of the Valley"
+    }, {
+        "id": "7955",
+        "name": "Sondra of the Valley"
+    }, {
+        "id": "8011",
+        "name": "Shaman Qaid of the Valley"
+    }, {
+        "id": "8022",
+        "name": "Battle Mage Horace of the Valley"
+    }, {
+        "id": "8036",
+        "name": "Arch-Magician Basil of the Valley"
+    }, {
+        "id": "8059",
+        "name": "Arcanist Lumos of the Valley"
+    }, {
+        "id": "8065",
+        "name": "Artificer Ratko of the Valley"
+    }, {
+        "id": "8079",
+        "name": "Enchanter Thana of the Valley"
+    }, {
+        "id": "8145",
+        "name": "Witch Rita of the Valley"
+    }, {
+        "id": "8179",
+        "name": "Hedge Wizard Allistair of the Valley"
+    }, {
+        "id": "8186",
+        "name": "Sorcerer Merlon of the Valley"
+    }, {
+        "id": "8187",
+        "name": "Artificer Uvlius of the Valley"
+    }, {
+        "id": "8207",
+        "name": "Witch Sabina of the Valley"
+    }, {
+        "id": "8295",
+        "name": "Battle Mage Durm of the Valley"
+    }, {
+        "id": "8321",
+        "name": "Enchanter Sonja of the Valley"
+    }, {
+        "id": "8347",
+        "name": "Alchemist Silas of the Valley"
+    }, {
+        "id": "8350",
+        "name": "Cleric Zane of the Valley"
+    }, {
+        "id": "8362",
+        "name": "Diabolist Hobbs of the Valley"
+    }, {
+        "id": "8404",
+        "name": "Witch Lilith of the Valley"
+    }, {
+        "id": "8405",
+        "name": "Enchanter Artis of the Valley"
+    }, {
+        "id": "8416",
+        "name": "Hadrien of the Valley"
+    }, {
+        "id": "8421",
+        "name": "Shaman Cromwell of the Valley"
+    }, {
+        "id": "8467",
+        "name": "Battle Mage Thor of the Valley"
+    }, {
+        "id": "8553",
+        "name": "Conjurer Sondra of the Valley"
+    }, {
+        "id": "8580",
+        "name": "Druid Artis of the Valley"
+    }, {
+        "id": "8591",
+        "name": "Witch Sylvia of the Valley"
+    }, {
+        "id": "8690",
+        "name": "Battle Mage Goliath of the Valley"
+    }, {
+        "id": "8730",
+        "name": "Evoker Gary of the Valley"
+    }, {
+        "id": "8753",
+        "name": "Hedge Wizard Trollin of the Valley"
+    }, {
+        "id": "8765",
+        "name": "Battle Mage Tundror of the Valley"
+    }, {
+        "id": "8798",
+        "name": "Archmagus Casper of the Valley"
+    }, {
+        "id": "8804",
+        "name": "Hydromancer Lenora of the Valley"
+    }, {
+        "id": "8874",
+        "name": "Magus Oiq of the Valley"
+    }, {
+        "id": "8911",
+        "name": "Arch-Magician Akron of the Valley"
+    }, {
+        "id": "8924",
+        "name": "Sage Thor of the Valley"
+    }, {
+        "id": "8944",
+        "name": "Electromancer Poppy of the Valley"
+    }, {
+        "id": "8976",
+        "name": "Magus Eric of the Valley"
+    }, {
+        "id": "9106",
+        "name": "Scryer George of the Valley"
+    }, {
+        "id": "9114",
+        "name": "Archmagus Ravana of the Valley"
+    }, {
+        "id": "9146",
+        "name": "Adept Allistair of the Valley"
+    }, {
+        "id": "9176",
+        "name": "Witch Rowena of the Valley"
+    }, {
+        "id": "9193",
+        "name": "Witch Lamia of the Valley"
+    }, {
+        "id": "9262",
+        "name": "Oberon of the Valley"
+    }, {
+        "id": "9271",
+        "name": "Cryptomancer Lux of the Valley"
+    }, {
+        "id": "9301",
+        "name": "Cryptomancer Talbot of the Valley"
+    }, {
+        "id": "9318",
+        "name": "Witch Elena of the Valley"
+    }, {
+        "id": "9328",
+        "name": "Victoria of the Valley"
+    }, {
+        "id": "9345",
+        "name": "Enchanter Wolfram of the Valley"
+    }, {
+        "id": "9431",
+        "name": "Magus Impy of the Valley"
+    }, {
+        "id": "9472",
+        "name": "Pyromancer Thana of the Valley"
+    }, {
+        "id": "9490",
+        "name": "Sorcerer Aldus of the Valley"
+    }, {
+        "id": "9562",
+        "name": "Magus Zelda of the Valley"
+    }, {
+        "id": "9641",
+        "name": "Druid Axis of the Valley"
+    }, {
+        "id": "9760",
+        "name": "Archmagus Orpheus of the Valley"
+    }, {
+        "id": "9775",
+        "name": "Archmagus Akron of the Valley"
+    }, {
+        "id": "9816",
+        "name": "Diviner Remus of the Valley"
+    }, {
+        "id": "9857",
+        "name": "Artificer Raul of the Valley"
+    }, {
+        "id": "9860",
+        "name": "Sorcerer George of the Valley"
+    }, {
+        "id": "9861",
+        "name": "Witch Properpine of the Valley"
+    }, {
+        "id": "9921",
+        "name": "Voodoo Priest Jean Leon of the Valley"
+    }, {
+        "id": "9978",
+        "name": "Victoria of the Valley"
+    }, {
+        "id": "9987",
+        "name": "Druid Angus of the Valley"
+    }],
+    "Atlantis": [{
+        "id": "274",
+        "name": "Hydromancer Zaros of Atlantis"
+    }, {
+        "id": "301",
+        "name": "Battle Mage Homer of Atlantis"
+    }, {
+        "id": "451",
+        "name": "Battle Mage Bartholomew of Atlantis"
+    }, {
+        "id": "771",
+        "name": "Alchemist Giuseppe of Atlantis"
+    }, {
+        "id": "1386",
+        "name": "Arcanist Udor of Atlantis"
+    }, {
+        "id": "1591",
+        "name": "Archmagus Argus of Atlantis"
+    }, {
+        "id": "1683",
+        "name": "Bard Celah of Atlantis"
+    }, {
+        "id": "1806",
+        "name": "Arcanist Onaxx of Atlantis"
+    }, {
+        "id": "2308",
+        "name": "Hedge Wizard Moloch of Atlantis"
+    }, {
+        "id": "2662",
+        "name": "Sorcerer Tumbaj of Atlantis"
+    }, {
+        "id": "2754",
+        "name": "Sorcerer Salah of Atlantis"
+    }, {
+        "id": "2776",
+        "name": "Runecaster Azahl of Atlantis"
+    }, {
+        "id": "3121",
+        "name": "Augurer Corvin of Atlantis"
+    }, {
+        "id": "4692",
+        "name": "Summoner Aslan of Atlantis"
+    }, {
+        "id": "4722",
+        "name": "Druid Zane of Atlantis"
+    }, {
+        "id": "4726",
+        "name": "Alchemist Udor of Atlantis"
+    }, {
+        "id": "4924",
+        "name": "Conjurer Axis of Atlantis"
+    }, {
+        "id": "4934",
+        "name": "Carly of Atlantis"
+    }, {
+        "id": "5193",
+        "name": "Archmagus Salah of Atlantis"
+    }, {
+        "id": "5276",
+        "name": "Adept Aleister of Atlantis"
+    }, {
+        "id": "5687",
+        "name": "Casper of Atlantis"
+    }, {
+        "id": "5911",
+        "name": "Archmagus Alessar of Atlantis"
+    }, {
+        "id": "5993",
+        "name": "Fortune Teller Sarah of Atlantis"
+    }, {
+        "id": "6131",
+        "name": "Archmagus Crowley of Atlantis"
+    }, {
+        "id": "6299",
+        "name": "Witch Enigma of Atlantis"
+    }, {
+        "id": "6980",
+        "name": "Artificer Aleister of Atlantis"
+    }, {
+        "id": "7342",
+        "name": "Archmagus Mina of Atlantis"
+    }, {
+        "id": "7370",
+        "name": "Sorcerer David of Atlantis"
+    }, {
+        "id": "7631",
+        "name": "Archmagus Zelroth of Atlantis"
+    }, {
+        "id": "7935",
+        "name": "Hydromancer Hagar of Atlantis"
+    }, {
+        "id": "8069",
+        "name": "Enchanter Cassiopeia of Atlantis"
+    }, {
+        "id": "8289",
+        "name": "Augurer Ixar of Atlantis"
+    }, {
+        "id": "8919",
+        "name": "Hydromancer Huizhong of Atlantis"
+    }, {
+        "id": "9308",
+        "name": "Sorcerer Zane of Atlantis"
+    }, {
+        "id": "9406",
+        "name": "Holy Monk Akron of Atlantis"
+    }, {
+        "id": "9686",
+        "name": "Mystic Milton of Atlantis"
+    }],
+    "Garden": [{
+        "id": "352",
+        "name": "Sage Zeromus of the Garden"
+    }, {
+        "id": "547",
+        "name": "Archmagus Crobas of the Garden"
+    }, {
+        "id": "694",
+        "name": "Alchemist Cassiopeia of the Garden"
+    }, {
+        "id": "916",
+        "name": "Arch-Magician Nicolas of the Garden"
+    }, {
+        "id": "1054",
+        "name": "Evoker Soran of the Garden"
+    }, {
+        "id": "1113",
+        "name": "Chaos Mage Gully of the Garden"
+    }, {
+        "id": "1119",
+        "name": "Conjurer Nazim of the Garden"
+    }, {
+        "id": "1175",
+        "name": "Archmagus Gellert of the Garden"
+    }, {
+        "id": "1192",
+        "name": "Charmer Celeste of the Garden"
+    }, {
+        "id": "1277",
+        "name": "Sage Cassius of the Garden"
+    }, {
+        "id": "1361",
+        "name": "Artificer Enzo of the Garden"
+    }, {
+        "id": "1442",
+        "name": "Hex Mage Jean Leon of the Garden"
+    }, {
+        "id": "2034",
+        "name": "Illusionist Meloogen of the Garden"
+    }, {
+        "id": "2142",
+        "name": "Cleric Woomba of the Garden"
+    }, {
+        "id": "2527",
+        "name": "Chronomancer Marius of the Garden"
+    }, {
+        "id": "2688",
+        "name": "Electromancer Lux of the Garden"
+    }, {
+        "id": "2781",
+        "name": "Holy Monk Finch of the Garden"
+    }, {
+        "id": "2999",
+        "name": "Arcanist Jerret of the Garden"
+    }, {
+        "id": "3278",
+        "name": "Allistair of the Garden"
+    }, {
+        "id": "4188",
+        "name": "Clairvoyant Pumlo of the Garden"
+    }, {
+        "id": "4585",
+        "name": "Charlord of the Garden"
+    }, {
+        "id": "4590",
+        "name": "Evoker Ratko of the Garden"
+    }, {
+        "id": "4679",
+        "name": "Oracle Purple Boy of the Garden"
+    }, {
+        "id": "4952",
+        "name": "Arch-Magician Lux of the Garden"
+    }, {
+        "id": "5098",
+        "name": "Ghost Eater Ali of the Garden"
+    }, {
+        "id": "5542",
+        "name": "Illusionist Alatar of the Garden"
+    }, {
+        "id": "6066",
+        "name": "Shadow Mage Twinkletoes of the Garden"
+    }, {
+        "id": "6382",
+        "name": "Cartomancer Hue of the Garden"
+    }, {
+        "id": "6508",
+        "name": "Stellar Mage Devon of the Garden"
+    }, {
+        "id": "6595",
+        "name": "Ozohr of the Garden"
+    }, {
+        "id": "6989",
+        "name": "Zaros of the Garden"
+    }, {
+        "id": "6990",
+        "name": "Archmagus Tundror of the Garden"
+    }, {
+        "id": "7476",
+        "name": "Archmagus Davos of the Garden"
+    }, {
+        "id": "7517",
+        "name": "Sorcerer Uvlius of the Garden"
+    }, {
+        "id": "7629",
+        "name": "Archmagus Azahl of the Garden"
+    }, {
+        "id": "7716",
+        "name": "Chronomancer Cosmo of the Garden"
+    }, {
+        "id": "7972",
+        "name": "Adept Liu of the Garden"
+    }, {
+        "id": "8429",
+        "name": "Wild Mage Zaim of the Garden"
+    }, {
+        "id": "8466",
+        "name": "Thaumaturge Twitch of the Garden"
+    }, {
+        "id": "8619",
+        "name": "Battle Mage Flynn of the Garden"
+    }, {
+        "id": "8668",
+        "name": "Cryptomancer Merlon of the Garden"
+    }, {
+        "id": "8803",
+        "name": "Pyromancer Diabolos of the Garden"
+    }, {
+        "id": "8845",
+        "name": "Shaman Jabir of the Garden"
+    }, {
+        "id": "9078",
+        "name": "Hedge Wizard Casper of the Garden"
+    }, {
+        "id": "9451",
+        "name": "Arch-Magician Alessar of the Garden"
+    }, {
+        "id": "9826",
+        "name": "Runecaster Daria of the Garden"
+    }, {
+        "id": "9912",
+        "name": "Cleric Basil of the Garden"
+    }, {
+        "id": "9918",
+        "name": "Eden of the Garden"
+    }],
+    "Sacred Pillars": [{
+        "id": "49",
+        "name": "Magus Ixar of the Sacred Pillars"
+    }, {
+        "id": "97",
+        "name": "Archmagus Apollo of the Sacred Pillars"
+    }, {
+        "id": "373",
+        "name": "Sorcerer David of the Sacred Pillars"
+    }, {
+        "id": "415",
+        "name": "Archmagus  of the Sacred Pillars"
+    }, {
+        "id": "607",
+        "name": "Enchanter Titania of the Sacred Pillars"
+    }, {
+        "id": "661",
+        "name": "Necromancer Dr. Death of the Sacred Pillars"
+    }, {
+        "id": "876",
+        "name": "Battle Mage Ulysse of the Sacred Pillars"
+    }, {
+        "id": "907",
+        "name": "Arcanist Goober of the Sacred Pillars"
+    }, {
+        "id": "987",
+        "name": "Shaman Angus of the Sacred Pillars"
+    }, {
+        "id": "1040",
+        "name": "Battlemage Twinkletoes of the Sacred Pillars"
+    }, {
+        "id": "1055",
+        "name": "Wild Mage Jabir of the Sacred Pillars"
+    }, {
+        "id": "1205",
+        "name": "Illusionist Blaise of the Sacred Pillars"
+    }, {
+        "id": "1215",
+        "name": "Witch Evangeline of the Sacred Pillars"
+    }, {
+        "id": "1336",
+        "name": "Shaman Jasper of the Sacred Pillars"
+    }, {
+        "id": "1341",
+        "name": "Battle Mage Goliath of the Sacred Pillars"
+    }, {
+        "id": "1378",
+        "name": "Magus Qasim of the Sacred Pillars"
+    }, {
+        "id": "1479",
+        "name": "Archmagus Aldus of the Sacred Pillars"
+    }, {
+        "id": "1508",
+        "name": "Geomancer Axel of the Sacred Pillars"
+    }, {
+        "id": "1538",
+        "name": "Battle Mage Brutus of the Sacred Pillars"
+    }, {
+        "id": "1765",
+        "name": "Sorcerer Cosmo of the Sacred Pillars"
+    }, {
+        "id": "1918",
+        "name": "Shaman Lenora of the Sacred Pillars"
+    }, {
+        "id": "2035",
+        "name": "Runecaster Jaffer of the Sacred Pillars"
+    }, {
+        "id": "2059",
+        "name": "Shaman Jastor of the Sacred Pillars"
+    }, {
+        "id": "2086",
+        "name": "Sorcerer Azahl of the Sacred Pillars"
+    }, {
+        "id": "2128",
+        "name": "Wild Mage Bayard of the Sacred Pillars"
+    }, {
+        "id": "2480",
+        "name": "Wild Mage Homer of the Sacred Pillars"
+    }, {
+        "id": "2491",
+        "name": "Sorcerer Basil of the Sacred Pillars"
+    }, {
+        "id": "2514",
+        "name": "Jerret of the Sacred Pillars"
+    }, {
+        "id": "2515",
+        "name": "Battle Mage Cassius of the Sacred Pillars"
+    }, {
+        "id": "2550",
+        "name": "Geomancer Esme of the Sacred Pillars"
+    }, {
+        "id": "2683",
+        "name": "Cryptomancer Artis of the Sacred Pillars"
+    }, {
+        "id": "2735",
+        "name": "Artificer Eizo of the Sacred Pillars"
+    }, {
+        "id": "2753",
+        "name": "Witch Ivy of the Sacred Pillars"
+    }, {
+        "id": "2849",
+        "name": "Pyromancer Trollin of the Sacred Pillars"
+    }, {
+        "id": "2918",
+        "name": "Adept Scorch of the Sacred Pillars"
+    }, {
+        "id": "2984",
+        "name": "Shaman Atlas of the Sacred Pillars"
+    }, {
+        "id": "2993",
+        "name": "Battle Mage Angus of the Sacred Pillars"
+    }, {
+        "id": "2996",
+        "name": "Archmagus Apollo of the Sacred Pillars"
+    }, {
+        "id": "3295",
+        "name": "Shaman George of the Sacred Pillars"
+    }, {
+        "id": "3461",
+        "name": "Sorcerer Cairon of the Sacred Pillars"
+    }, {
+        "id": "3514",
+        "name": "Witch Juniper of the Sacred Pillars"
+    }, {
+        "id": "3624",
+        "name": "Battle Mage Hagar of the Sacred Pillars"
+    }, {
+        "id": "3706",
+        "name": "Alchemist  of the Sacred Pillars"
+    }, {
+        "id": "3840",
+        "name": "Thaumaturge Tabitha of the Sacred Pillars"
+    }, {
+        "id": "3989",
+        "name": "Conjurer Galatea of the Sacred Pillars"
+    }, {
+        "id": "4103",
+        "name": "Voodoo Priest Hugo of the Sacred Pillars"
+    }, {
+        "id": "4141",
+        "name": "Archmagus Hadrien of the Sacred Pillars"
+    }, {
+        "id": "4296",
+        "name": "Adept Milo of the Sacred Pillars"
+    }, {
+        "id": "4329",
+        "name": "Arch-Magician Idris of the Sacred Pillars"
+    }, {
+        "id": "4625",
+        "name": "Evoker Armstrong of the Sacred Pillars"
+    }, {
+        "id": "4661",
+        "name": "Hedge Wizard Blaise of the Sacred Pillars"
+    }, {
+        "id": "4673",
+        "name": "Druid Soran of the Sacred Pillars"
+    }, {
+        "id": "4816",
+        "name": "Mystic Pumlo of the Sacred Pillars"
+    }, {
+        "id": "4877",
+        "name": "Sorcerer Jerret of the Sacred Pillars"
+    }, {
+        "id": "4993",
+        "name": "Sorcerer Faiz of the Sacred Pillars"
+    }, {
+        "id": "5030",
+        "name": "Artificer Angus of the Sacred Pillars"
+    }, {
+        "id": "5044",
+        "name": "Battle Mage Cromwell of the Sacred Pillars"
+    }, {
+        "id": "5061",
+        "name": "Hadrien of the Sacred Pillars"
+    }, {
+        "id": "5092",
+        "name": "Sky Master Corvin of the Sacred Pillars"
+    }, {
+        "id": "5108",
+        "name": "Battle Mage Robert of the Sacred Pillars"
+    }, {
+        "id": "5124",
+        "name": "Necromancer Anton of the Sacred Pillars"
+    }, {
+        "id": "5141",
+        "name": "Archmagus George of the Sacred Pillars"
+    }, {
+        "id": "5166",
+        "name": "Hedge Wizard Circe of the Sacred Pillars"
+    }, {
+        "id": "5265",
+        "name": "Sage Hu of the Sacred Pillars"
+    }, {
+        "id": "5335",
+        "name": "Adept Hellspawn of the Sacred Pillars"
+    }, {
+        "id": "5429",
+        "name": "Sorcerer Ozohr of the Sacred Pillars"
+    }, {
+        "id": "5521",
+        "name": "Spellsinger Nikolas of the Sacred Pillars"
+    }, {
+        "id": "5573",
+        "name": "Thaumaturge Maia of the Sacred Pillars"
+    }, {
+        "id": "5625",
+        "name": "Archmagus Argus of the Sacred Pillars"
+    }, {
+        "id": "5638",
+        "name": "Enchanter Daphne of the Sacred Pillars"
+    }, {
+        "id": "5671",
+        "name": "Magus Lamia of the Sacred Pillars"
+    }, {
+        "id": "5678",
+        "name": "Conjurer Cromwell of the Sacred Pillars"
+    }, {
+        "id": "5805",
+        "name": "Wild Mage David of the Sacred Pillars"
+    }, {
+        "id": "5813",
+        "name": "Jeldor of the Sacred Pillars"
+    }, {
+        "id": "5836",
+        "name": "Diviner Apollo of the Sacred Pillars"
+    }, {
+        "id": "6000",
+        "name": "Sorcerer Alessar of the Sacred Pillars"
+    }, {
+        "id": "6016",
+        "name": "Adept Axel of the Sacred Pillars"
+    }, {
+        "id": "6046",
+        "name": "Archmagus Aldus of the Sacred Pillars"
+    }, {
+        "id": "6070",
+        "name": "Isaac of the Sacred Pillars"
+    }, {
+        "id": "6152",
+        "name": "Adept Cairon of the Sacred Pillars"
+    }, {
+        "id": "6160",
+        "name": "Arch-Magician Udor of the Sacred Pillars"
+    }, {
+        "id": "6216",
+        "name": "Battle Mage Ethan of the Sacred Pillars"
+    }, {
+        "id": "6286",
+        "name": "Bard Orpheus of the Sacred Pillars"
+    }, {
+        "id": "6381",
+        "name": "Archmagus Jerret of the Sacred Pillars"
+    }, {
+        "id": "6423",
+        "name": "Cleric Crowley of the Sacred Pillars"
+    }, {
+        "id": "6460",
+        "name": "Adept Ifran of the Sacred Pillars"
+    }, {
+        "id": "6633",
+        "name": "Sage George of the Sacred Pillars"
+    }, {
+        "id": "6641",
+        "name": "Sage Rita of the Sacred Pillars"
+    }, {
+        "id": "6689",
+        "name": "Sage Armstrong of the Sacred Pillars"
+    }, {
+        "id": "6701",
+        "name": "Alatar of the Sacred Pillars"
+    }, {
+        "id": "6732",
+        "name": "Magus Ali of the Sacred Pillars"
+    }, {
+        "id": "6817",
+        "name": "Diabolist Bartholomew of the Sacred Pillars"
+    }, {
+        "id": "6893",
+        "name": "Sorcerer Salah of the Sacred Pillars"
+    }, {
+        "id": "6968",
+        "name": "Sorcerer Kazem of the Sacred Pillars"
+    }, {
+        "id": "6974",
+        "name": "Evoker Kalo of the Sacred Pillars"
+    }, {
+        "id": "7052",
+        "name": "Battle Mage Magnus of the Sacred Pillars"
+    }, {
+        "id": "7131",
+        "name": "Wild Mage Hagar of the Sacred Pillars"
+    }, {
+        "id": "7160",
+        "name": "Sky Master Crowley of the Sacred Pillars"
+    }, {
+        "id": "7203",
+        "name": "Illusionist Amir of the Sacred Pillars"
+    }, {
+        "id": "7246",
+        "name": "Magus Jabir of the Sacred Pillars"
+    }, {
+        "id": "7273",
+        "name": "Mystic Wolfram of the Sacred Pillars"
+    }, {
+        "id": "7287",
+        "name": "Witch Eric of the Sacred Pillars"
+    }, {
+        "id": "7435",
+        "name": "Druid Basil of the Sacred Pillars"
+    }, {
+        "id": "7607",
+        "name": "Battle Mage Angus of the Sacred Pillars"
+    }, {
+        "id": "7707",
+        "name": "Sorcerer Aleister of the Sacred Pillars"
+    }, {
+        "id": "8075",
+        "name": "Aleister of the Sacred Pillars"
+    }, {
+        "id": "8097",
+        "name": "Chaos Mage Ratko of the Sacred Pillars"
+    }, {
+        "id": "8154",
+        "name": "Katherine of the Sacred Pillars"
+    }, {
+        "id": "8275",
+        "name": "Battle Mage Godfrey of the Sacred Pillars"
+    }, {
+        "id": "8443",
+        "name": "Sage Salvatore of the Sacred Pillars"
+    }, {
+        "id": "8446",
+        "name": "Battle Mage Angus of the Sacred Pillars"
+    }, {
+        "id": "8590",
+        "name": "Magus Lux of the Sacred Pillars"
+    }, {
+        "id": "8766",
+        "name": "Ghost Eater Alatar of the Sacred Pillars"
+    }, {
+        "id": "8770",
+        "name": "Geomancer Isaac of the Sacred Pillars"
+    }, {
+        "id": "8779",
+        "name": "Magus Durm of the Sacred Pillars"
+    }, {
+        "id": "8927",
+        "name": "Druid Impy of the Sacred Pillars"
+    }, {
+        "id": "9077",
+        "name": "Zelroth of the Sacred Pillars"
+    }, {
+        "id": "9113",
+        "name": "Archmagus Jeldor of the Sacred Pillars"
+    }, {
+        "id": "9295",
+        "name": "Shaman Ravana of the Sacred Pillars"
+    }, {
+        "id": "9322",
+        "name": "Battle Mage Gunthor of the Sacred Pillars"
+    }, {
+        "id": "9424",
+        "name": "Archmagus Merlon of the Sacred Pillars"
+    }, {
+        "id": "9432",
+        "name": "Archmagus Silas of the Sacred Pillars"
+    }, {
+        "id": "9695",
+        "name": "Solomon of the Sacred Pillars"
+    }, {
+        "id": "9699",
+        "name": "Faye of the Sacred Pillars"
+    }, {
+        "id": "9725",
+        "name": "Archmagus Aleister of the Sacred Pillars"
+    }, {
+        "id": "9870",
+        "name": "Sorcerer Soran of the Sacred Pillars"
+    }, {
+        "id": "9967",
+        "name": "Sage Godfrey of the Sacred Pillars"
+    }],
+    "Void": [{
+        "id": "39",
+        "name": "Battle Mage Wolfram out of the Void"
+    }, {
+        "id": "132",
+        "name": "Arch-Magician Burnside out of the Void"
+    }, {
+        "id": "534",
+        "name": "Sorcerer Alatar out of the Void"
+    }, {
+        "id": "1101",
+        "name": "Hex Mage Lucinda out of the Void"
+    }, {
+        "id": "1377",
+        "name": "Sorcerer Silas out of the Void"
+    }, {
+        "id": "2747",
+        "name": "Magus Sahir out of the Void"
+    }, {
+        "id": "2752",
+        "name": "Zaros out of the Void"
+    }, {
+        "id": "3264",
+        "name": "Diabolist Konoha out of the Void"
+    }, {
+        "id": "3585",
+        "name": "Artificer Benito out of the Void"
+    }, {
+        "id": "4578",
+        "name": "Void Disciple Magpie out of the Void"
+    }, {
+        "id": "5424",
+        "name": "Archmagus Lumos out of the Void"
+    }, {
+        "id": "5553",
+        "name": "Archmagus Aldus out of the Void"
+    }, {
+        "id": "5768",
+        "name": "Artificer Oberon out of the Void"
+    }, {
+        "id": "5865",
+        "name": "Magus Ulysse out of the Void"
+    }, {
+        "id": "5933",
+        "name": "Archmagus Aleister out of the Void"
+    }, {
+        "id": "6012",
+        "name": "Necromancer Dario out of the Void"
+    }, {
+        "id": "6452",
+        "name": "Archmagus Aldus out of the Void"
+    }, {
+        "id": "7652",
+        "name": "Sage Casper out of the Void"
+    }, {
+        "id": "7849",
+        "name": "Medium Peppy out of the Void"
+    }, {
+        "id": "8126",
+        "name": "Pyromancer Xerxes out of the Void"
+    }, {
+        "id": "8267",
+        "name": "Witch Delilah out of the Void"
+    }, {
+        "id": "8399",
+        "name": "Thaumaturge Kazud out of the Void"
+    }, {
+        "id": "8548",
+        "name": "Arch-Magician Alatar out of the Void"
+    }, {
+        "id": "8676",
+        "name": "Hedge Wizard Lenora out of the Void"
+    }, {
+        "id": "8793",
+        "name": "Enchanter Jahid out of the Void"
+    }, {
+        "id": "8858",
+        "name": "Adept Azar out of the Void"
+    }, {
+        "id": "9051",
+        "name": "Arch-Magician Arabella out of the Void"
+    }, {
+        "id": "9351",
+        "name": "Alchemist Corvin out of the Void"
+    }, {
+        "id": "9473",
+        "name": "Ghost Eater Ravana out of the Void"
+    }, {
+        "id": "9557",
+        "name": "Conjurer Konoha out of the Void"
+    }],
+    "Reach": [{
+        "id": "31",
+        "name": "Sorcerer George of the Reach"
+    }, {
+        "id": "209",
+        "name": "Geomancer Merlon of the Reach"
+    }, {
+        "id": "220",
+        "name": "Chaos Mage Properpine of the Reach"
+    }, {
+        "id": "249",
+        "name": "Archmagus Allistair of the Reach"
+    }, {
+        "id": "348",
+        "name": "Shadow Mage Pandora of the Reach"
+    }, {
+        "id": "549",
+        "name": "Thaumaturge Milo of the Reach"
+    }, {
+        "id": "585",
+        "name": "Enchanter Daphne of the Reach"
+    }, {
+        "id": "679",
+        "name": "Hedge Wizard Moloch of the Reach"
+    }, {
+        "id": "699",
+        "name": "Arcanist Beyna of the Reach"
+    }, {
+        "id": "1009",
+        "name": "Hydromancer Nikolas of the Reach"
+    }, {
+        "id": "1058",
+        "name": "Chaos Mage Jerret of the Reach"
+    }, {
+        "id": "1561",
+        "name": "Scryer Talbot of the Reach"
+    }, {
+        "id": "1572",
+        "name": "Illusionist Aiko of the Reach"
+    }, {
+        "id": "1675",
+        "name": "Archmagus Crowley of the Reach"
+    }, {
+        "id": "1957",
+        "name": "Enchanter Lamia of the Reach"
+    }, {
+        "id": "2087",
+        "name": "Druid Orpheus of the Reach"
+    }, {
+        "id": "2139",
+        "name": "Sorcerer Gary of the Reach"
+    }, {
+        "id": "2303",
+        "name": "Sage Drusilla of the Reach"
+    }, {
+        "id": "2328",
+        "name": "Witch Rowena of the Reach"
+    }, {
+        "id": "2508",
+        "name": "Ghost Eater Carly of the Reach"
+    }, {
+        "id": "2825",
+        "name": "Necromancer Aiko of the Reach"
+    }, {
+        "id": "3035",
+        "name": "Archmagus Ofaris of the Reach"
+    }, {
+        "id": "3226",
+        "name": "Hedge Wizard Sturgis of the Reach"
+    }, {
+        "id": "3328",
+        "name": "Ofaris of the Reach"
+    }, {
+        "id": "3635",
+        "name": "Augurer Pumlo of the Reach"
+    }, {
+        "id": "3832",
+        "name": "Sage Danny of the Reach"
+    }, {
+        "id": "3929",
+        "name": "Arch-Magician Rowena of the Reach"
+    }, {
+        "id": "3964",
+        "name": "Aeromancer Celah of the Reach"
+    }, {
+        "id": "4037",
+        "name": "Hydromancer Poppy of the Reach"
+    }, {
+        "id": "4238",
+        "name": "Sage Pus Mother of the Reach"
+    }, {
+        "id": "4364",
+        "name": "Azahl of the Reach"
+    }, {
+        "id": "4549",
+        "name": "Shaman Aiko of the Reach"
+    }, {
+        "id": "4650",
+        "name": "Battle Mage Cromwell of the Reach"
+    }, {
+        "id": "4696",
+        "name": "Enchanter Victoria of the Reach"
+    }, {
+        "id": "4757",
+        "name": "Fortune Teller Xiaobo of the Reach"
+    }, {
+        "id": "5109",
+        "name": "Sorcerer Aleister of the Reach"
+    }, {
+        "id": "5128",
+        "name": "Fortune Teller Mina of the Reach"
+    }, {
+        "id": "5177",
+        "name": "Battle Mage Nolan of the Reach"
+    }, {
+        "id": "5354",
+        "name": "Magus Toka of the Reach"
+    }, {
+        "id": "5396",
+        "name": "Iprix of the Reach"
+    }, {
+        "id": "5425",
+        "name": "Necromancer Diana of the Reach"
+    }, {
+        "id": "5523",
+        "name": "Enchanter Galatea of the Reach"
+    }, {
+        "id": "5751",
+        "name": "Arcanist Yookoo of the Reach"
+    }, {
+        "id": "5852",
+        "name": "Archmagus Amanita of the Reach"
+    }, {
+        "id": "5873",
+        "name": "Runecaster Aden of the Reach"
+    }, {
+        "id": "5987",
+        "name": "Hedge Wizard Liliana of the Reach"
+    }, {
+        "id": "6037",
+        "name": "Mystic Mei of the Reach"
+    }, {
+        "id": "6139",
+        "name": "Clairvoyant Ming of the Reach"
+    }, {
+        "id": "6190",
+        "name": "Hedge Wizard Fungi of the Reach"
+    }, {
+        "id": "6251",
+        "name": "Druid Amir of the Reach"
+    }, {
+        "id": "6556",
+        "name": "Voodoo Priest Eliphas of the Reach"
+    }, {
+        "id": "6572",
+        "name": "Adept Katherine of the Reach"
+    }, {
+        "id": "6621",
+        "name": "Archmagus Apollo of the Reach"
+    }, {
+        "id": "6707",
+        "name": "Shaman Sondra of the Reach"
+    }, {
+        "id": "6740",
+        "name": "Witch Lamia of the Reach"
+    }, {
+        "id": "6750",
+        "name": "Enchanter Victoria of the Reach"
+    }, {
+        "id": "6868",
+        "name": "Merlon of the Reach"
+    }, {
+        "id": "6890",
+        "name": "Wild Mage Ravana of the Reach"
+    }, {
+        "id": "6942",
+        "name": "Ariadne of the Reach"
+    }, {
+        "id": "6973",
+        "name": "Charmer Thana of the Reach"
+    }, {
+        "id": "7078",
+        "name": "Geomancer Cassius of the Reach"
+    }, {
+        "id": "7143",
+        "name": "Archmagus Pumlo of the Reach"
+    }, {
+        "id": "7188",
+        "name": "Void Disciple Zeromus of the Reach"
+    }, {
+        "id": "7190",
+        "name": "Battle Mage Angus of the Reach"
+    }, {
+        "id": "7334",
+        "name": "Battle Mage Ethan of the Reach"
+    }, {
+        "id": "7373",
+        "name": "Oracle Yumi of the Reach"
+    }, {
+        "id": "7509",
+        "name": "Sage Merlon of the Reach"
+    }, {
+        "id": "7545",
+        "name": "Enchanter Diana of the Reach"
+    }, {
+        "id": "7615",
+        "name": "Enchanter Astrid of the Reach"
+    }, {
+        "id": "7727",
+        "name": "Sorcerer Eden of the Reach"
+    }, {
+        "id": "7733",
+        "name": "Enchanter Circe of the Reach"
+    }, {
+        "id": "7855",
+        "name": "Necromancer Devon of the Reach"
+    }, {
+        "id": "7976",
+        "name": "Archmagus David of the Reach"
+    }, {
+        "id": "8101",
+        "name": "Witch Shivra of the Reach"
+    }, {
+        "id": "8134",
+        "name": "Battle Mage Finn of the Reach"
+    }, {
+        "id": "8178",
+        "name": "Druid Cassius of the Reach"
+    }, {
+        "id": "8367",
+        "name": "Runecaster Samuel of the Reach"
+    }, {
+        "id": "8539",
+        "name": "Enchanter Atlanta of the Reach"
+    }, {
+        "id": "9001",
+        "name": "Wild Mage Goliath of the Reach"
+    }, {
+        "id": "9008",
+        "name": "Shadow Mage Rita of the Reach"
+    }, {
+        "id": "9035",
+        "name": "Enchanter Beyna of the Reach"
+    }, {
+        "id": "9058",
+        "name": "Scryer Rodolfo of the Reach"
+    }, {
+        "id": "9151",
+        "name": "Sorcerer Oberon of the Reach"
+    }, {
+        "id": "9329",
+        "name": "Summoner Yanlin of the Reach"
+    }, {
+        "id": "9497",
+        "name": "Magus Uvlius of the Reach"
+    }, {
+        "id": "9517",
+        "name": "Hedge Wizard Lin of the Reach"
+    }, {
+        "id": "9586",
+        "name": "Alchemist Circe of the Reach"
+    }, {
+        "id": "9596",
+        "name": "Pyromancer Arabella of the Reach"
+    }, {
+        "id": "9694",
+        "name": "Enchanter Sonja of the Reach"
+    }, {
+        "id": "9723",
+        "name": "Magus Qasim of the Reach"
+    }, {
+        "id": "9758",
+        "name": "Magus Impy of the Reach"
+    }],
+    "Toadstools": [{
+        "id": "96",
+        "name": "Clairvoyant Tundror of the Toadstools"
+    }, {
+        "id": "124",
+        "name": "Archmagus Salvatore of the Toadstools"
+    }, {
+        "id": "318",
+        "name": "Voodoo Priest Gaspard of the Toadstools"
+    }, {
+        "id": "390",
+        "name": "Pyromancer Helix of the Toadstools"
+    }, {
+        "id": "489",
+        "name": "Witch Cassandra of the Toadstools"
+    }, {
+        "id": "565",
+        "name": "Ghost Eater Durm of the Toadstools"
+    }, {
+        "id": "663",
+        "name": "Shadow Mage Nadeem of the Toadstools"
+    }, {
+        "id": "695",
+        "name": "Electromancer Davos of the Toadstools"
+    }, {
+        "id": "720",
+        "name": "Necromancer Chooki of the Toadstools"
+    }, {
+        "id": "781",
+        "name": "Sorcerer Robert of the Toadstools"
+    }, {
+        "id": "813",
+        "name": "Bard Diabolos of the Toadstools"
+    }, {
+        "id": "963",
+        "name": "Druid Khudalf of the Toadstools"
+    }, {
+        "id": "967",
+        "name": "Arch-Magician Aleister of the Toadstools"
+    }, {
+        "id": "1148",
+        "name": "Arch-Magician Solomon of the Toadstools"
+    }, {
+        "id": "1304",
+        "name": "Charmer Sarah of the Toadstools"
+    }, {
+        "id": "1404",
+        "name": "Archmagus Apollo of the Toadstools"
+    }, {
+        "id": "1453",
+        "name": "Magus Qianfan of the Toadstools"
+    }, {
+        "id": "1616",
+        "name": "Magus Jabir of the Toadstools"
+    }, {
+        "id": "2093",
+        "name": "Chaos Mage Samuel of the Toadstools"
+    }, {
+        "id": "2154",
+        "name": "Alchemist Flamos of the Toadstools"
+    }, {
+        "id": "2160",
+        "name": "Voodoo Priest Crowley of the Toadstools"
+    }, {
+        "id": "2232",
+        "name": "Cleric Cassiopeia of the Toadstools"
+    }, {
+        "id": "2358",
+        "name": "Shadow Mage Kalo of the Toadstools"
+    }, {
+        "id": "2456",
+        "name": "Hedge Wizard Pozzik of the Toadstools"
+    }, {
+        "id": "2528",
+        "name": "Sage Konoha of the Toadstools"
+    }, {
+        "id": "2582",
+        "name": "Hedge Wizard Aldo of the Toadstools"
+    }, {
+        "id": "2925",
+        "name": "Bard Solomon of the Toadstools"
+    }, {
+        "id": "3020",
+        "name": "Artificer Aldus of the Toadstools"
+    }, {
+        "id": "3209",
+        "name": "Alchemist Impy of the Toadstools"
+    }, {
+        "id": "3270",
+        "name": "Alchemist Edge of the Toadstools"
+    }, {
+        "id": "3416",
+        "name": "Alchemist Hadrien of the Toadstools"
+    }, {
+        "id": "3533",
+        "name": "Druid Crowley of the Toadstools"
+    }, {
+        "id": "3971",
+        "name": "Solomon of the Toadstools"
+    }, {
+        "id": "4011",
+        "name": "Magus Woomba of the Toadstools"
+    }, {
+        "id": "4311",
+        "name": "Mystic Pandora of the Toadstools"
+    }, {
+        "id": "4334",
+        "name": "Alchemist Crobas of the Toadstools"
+    }, {
+        "id": "4450",
+        "name": "Hedge Wizard Kobold of the Toadstools"
+    }, {
+        "id": "4551",
+        "name": "Alchemist Zubin of the Toadstools"
+    }, {
+        "id": "4860",
+        "name": "Arch-Magician  of the Toadstools"
+    }, {
+        "id": "4939",
+        "name": "Enchanter Faiz of the Toadstools"
+    }, {
+        "id": "4978",
+        "name": "Alchemist Samael of the Toadstools"
+    }, {
+        "id": "5082",
+        "name": "Sage Jeldor of the Toadstools"
+    }, {
+        "id": "5152",
+        "name": "Pyromancer Ilu of the Toadstools"
+    }, {
+        "id": "5488",
+        "name": "Alchemist Axel of the Toadstools"
+    }, {
+        "id": "5594",
+        "name": "Alchemist Fabio of the Toadstools"
+    }, {
+        "id": "5612",
+        "name": "Sage Iprix of the Toadstools"
+    }, {
+        "id": "5824",
+        "name": "Artificer Delilah of the Toadstools"
+    }, {
+        "id": "5937",
+        "name": "Archmagus Merlon of the Toadstools"
+    }, {
+        "id": "5957",
+        "name": "Sorcerer Salvatore of the Toadstools"
+    }, {
+        "id": "6130",
+        "name": "Magus Azazel of the Toadstools"
+    }, {
+        "id": "6208",
+        "name": "Hedge Wizard Ulysse of the Toadstools"
+    }, {
+        "id": "6212",
+        "name": "Spellsinger Magpie of the Toadstools"
+    }, {
+        "id": "6275",
+        "name": "Crowley of the Toadstools"
+    }, {
+        "id": "6551",
+        "name": "Pyromancer Milo of the Toadstools"
+    }, {
+        "id": "6625",
+        "name": "Shaman Rafiq of the Toadstools"
+    }, {
+        "id": "6627",
+        "name": "Archmagus Jerret of the Toadstools"
+    }, {
+        "id": "6725",
+        "name": "Ghost Eater Bathsheba of the Toadstools"
+    }, {
+        "id": "6827",
+        "name": "Necromancer Malcom of the Toadstools"
+    }, {
+        "id": "7033",
+        "name": "Alchemist Cairon of the Toadstools"
+    }, {
+        "id": "7167",
+        "name": "Arcanist Otto of the Toadstools"
+    }, {
+        "id": "7227",
+        "name": "Bard Pumlo of the Toadstools"
+    }, {
+        "id": "7256",
+        "name": "Cleric Wolfram of the Toadstools"
+    }, {
+        "id": "7516",
+        "name": "Magus Danny of the Toadstools"
+    }, {
+        "id": "7573",
+        "name": "Asphodel of the Toadstools"
+    }, {
+        "id": "7666",
+        "name": "Summoner Colorman of the Toadstools"
+    }, {
+        "id": "7893",
+        "name": "Alchemist Lin of the Toadstools"
+    }, {
+        "id": "7905",
+        "name": "Battle Mage Ratko of the Toadstools"
+    }, {
+        "id": "8128",
+        "name": "Alchemist Flynn of the Toadstools"
+    }, {
+        "id": "8162",
+        "name": "Sorcerer Kamil of the Toadstools"
+    }, {
+        "id": "8324",
+        "name": "Hedge Wizard Goober of the Toadstools"
+    }, {
+        "id": "8371",
+        "name": "Enchanter Devon of the Toadstools"
+    }, {
+        "id": "8427",
+        "name": "Illusionist Amir of the Toadstools"
+    }, {
+        "id": "8463",
+        "name": "Eden of the Toadstools"
+    }, {
+        "id": "8693",
+        "name": "Enchanter Bathsheba of the Toadstools"
+    }, {
+        "id": "8951",
+        "name": "Medium Hadrien of the Toadstools"
+    }, {
+        "id": "9290",
+        "name": "Cleric Angus of the Toadstools"
+    }, {
+        "id": "9832",
+        "name": "Archmagus Crowley of the Toadstools"
+    }, {
+        "id": "9997",
+        "name": "Conjurer Nemo of the Toadstools"
+    }],
+    "Avalon": [{
+        "id": "93",
+        "name": "Druid Diana of Avalon"
+    }, {
+        "id": "204",
+        "name": "Transmuter Isaac of Avalon"
+    }, {
+        "id": "214",
+        "name": "Sorcerer Apollo of Avalon"
+    }, {
+        "id": "240",
+        "name": "Spellsinger Celah of Avalon"
+    }, {
+        "id": "279",
+        "name": "Mystic Ophelia of Avalon"
+    }, {
+        "id": "502",
+        "name": "Shaman Sturgis of Avalon"
+    }, {
+        "id": "1006",
+        "name": "Archmagus Uvlius of Avalon"
+    }, {
+        "id": "1011",
+        "name": "Enchanter Sarah of Avalon"
+    }, {
+        "id": "1396",
+        "name": "Aeromancer Nikolas of Avalon"
+    }, {
+        "id": "1474",
+        "name": "Illusionist Cybele of Avalon"
+    }, {
+        "id": "1602",
+        "name": "Arcanist Udor of Avalon"
+    }, {
+        "id": "1610",
+        "name": "Sage Crobas of Avalon"
+    }, {
+        "id": "1734",
+        "name": "Alatar of Avalon"
+    }, {
+        "id": "1746",
+        "name": "Battle Mage Hothor of Avalon"
+    }, {
+        "id": "1936",
+        "name": "Battle Mage Angus of Avalon"
+    }, {
+        "id": "2212",
+        "name": "Sage Devon of Avalon"
+    }, {
+        "id": "2220",
+        "name": "Magus Uday of Avalon"
+    }, {
+        "id": "2249",
+        "name": "Alchemist Udor of Avalon"
+    }, {
+        "id": "2283",
+        "name": "Artificer Danny of Avalon"
+    }, {
+        "id": "2304",
+        "name": "Alchemist Gary of Avalon"
+    }, {
+        "id": "2370",
+        "name": "Geomancer Toadstool of Avalon"
+    }, {
+        "id": "2400",
+        "name": "Crowley of Avalon"
+    }, {
+        "id": "2422",
+        "name": "Alchemist Aden of Avalon"
+    }, {
+        "id": "2499",
+        "name": "Arch-Magician Pus Mother of Avalon"
+    }, {
+        "id": "2551",
+        "name": "Voodoo Priest Gaspard of Avalon"
+    }, {
+        "id": "3007",
+        "name": "Shaman Nicolas of Avalon"
+    }, {
+        "id": "3034",
+        "name": "Witch Velorina of Avalon"
+    }, {
+        "id": "3050",
+        "name": "Hedge Wizard Aiko of Avalon"
+    }, {
+        "id": "3187",
+        "name": "Archmagus Amir of Avalon"
+    }, {
+        "id": "3233",
+        "name": "Spellsinger Ursula of Avalon"
+    }, {
+        "id": "3335",
+        "name": "Cleric Lumos of Avalon"
+    }, {
+        "id": "3351",
+        "name": "Sorcerer Alizam of Avalon"
+    }, {
+        "id": "3380",
+        "name": "Archmagus Allistair of Avalon"
+    }, {
+        "id": "3519",
+        "name": "Archmagus Bolin of Avalon"
+    }, {
+        "id": "3632",
+        "name": "Archmagus Oberon of Avalon"
+    }, {
+        "id": "3998",
+        "name": "Arch-Magician Homer of Avalon"
+    }, {
+        "id": "4026",
+        "name": "Battle Mage Malthus of Avalon"
+    }, {
+        "id": "4042",
+        "name": "Hedge Wizard Moloch of Avalon"
+    }, {
+        "id": "4067",
+        "name": "Alchemist Zagan of Avalon"
+    }, {
+        "id": "4182",
+        "name": "Druid Ilyas of Avalon"
+    }, {
+        "id": "4403",
+        "name": "Enchanter Gary of Avalon"
+    }, {
+        "id": "4422",
+        "name": "Enchanter Thana of Avalon"
+    }, {
+        "id": "4705",
+        "name": "Archmagus Jerret of Avalon"
+    }, {
+        "id": "4811",
+        "name": "Summoner Hansel of Avalon"
+    }, {
+        "id": "4828",
+        "name": "Sorcerer Eizo of Avalon"
+    }, {
+        "id": "4951",
+        "name": "Arcanist Qianfan of Avalon"
+    }, {
+        "id": "5084",
+        "name": "Sorcerer Allistair of Avalon"
+    }, {
+        "id": "5208",
+        "name": "Runecaster Zagan of Avalon"
+    }, {
+        "id": "5343",
+        "name": "Mystic Borak of Avalon"
+    }, {
+        "id": "5345",
+        "name": "Alessar of Avalon"
+    }, {
+        "id": "5679",
+        "name": "Archmagus  of Avalon"
+    }, {
+        "id": "5855",
+        "name": "Aleister of Avalon"
+    }, {
+        "id": "6011",
+        "name": "Shadow Mage Zubin of Avalon"
+    }, {
+        "id": "6148",
+        "name": "Spellsinger Rumpleskin of Avalon"
+    }, {
+        "id": "6656",
+        "name": "Mystic Jeldor of Avalon"
+    }, {
+        "id": "6680",
+        "name": "Charmer Daphne of Avalon"
+    }, {
+        "id": "6778",
+        "name": "Battle Mage Angus of Avalon"
+    }, {
+        "id": "6982",
+        "name": "Druid Alessar of Avalon"
+    }, {
+        "id": "6997",
+        "name": "Battle Mage Rodolfo of Avalon"
+    }, {
+        "id": "7425",
+        "name": "Shaman Soya of Avalon"
+    }, {
+        "id": "7456",
+        "name": "Archmagus Milton of Avalon"
+    }, {
+        "id": "7531",
+        "name": "Hex Mage David of Avalon"
+    }, {
+        "id": "7748",
+        "name": "Archmagus Isaac of Avalon"
+    }, {
+        "id": "7814",
+        "name": "Spellsinger Cairon of Avalon"
+    }, {
+        "id": "8016",
+        "name": "Archmagus Udor of Avalon"
+    }, {
+        "id": "8132",
+        "name": "Archmagus Soran of Avalon"
+    }, {
+        "id": "8153",
+        "name": "Pyromancer Ali of Avalon"
+    }, {
+        "id": "8184",
+        "name": "Battle Mage Angus of Avalon"
+    }, {
+        "id": "8392",
+        "name": "Chronomancer Eizo of Avalon"
+    }, {
+        "id": "8455",
+        "name": "Shaman Epher of Avalon"
+    }, {
+        "id": "8823",
+        "name": "Magus Zaros of Avalon"
+    }, {
+        "id": "9858",
+        "name": "Artificer Pozzik of Avalon"
+    }, {
+        "id": "9863",
+        "name": "Illusionist Crowley of Avalon"
+    }, {
+        "id": "9934",
+        "name": "Hedge Wizard Soran of Avalon"
+    }, {
+        "id": "9955",
+        "name": "Voodoo Priest Jean Leon of Avalon"
+    }],
+    "Dark": [{
+        "id": "1106",
+        "name": "Hydromancer Rita of the Dark"
+    }],
+    "Oasis": [{
+        "id": "153",
+        "name": "Illusionist Aleister of the Oasis"
+    }, {
+        "id": "299",
+        "name": "Cosmic Mage Jabir of the Oasis"
+    }, {
+        "id": "346",
+        "name": "Runecaster David of the Oasis"
+    }, {
+        "id": "614",
+        "name": "Archmagus Lumos of the Oasis"
+    }, {
+        "id": "656",
+        "name": "Battle Mage Cromwell of the Oasis"
+    }, {
+        "id": "824",
+        "name": "Battle Mage Talon of the Oasis"
+    }, {
+        "id": "1044",
+        "name": "Battle Mage Durm of the Oasis"
+    }, {
+        "id": "1194",
+        "name": "Diviner Axel of the Oasis"
+    }, {
+        "id": "1276",
+        "name": "Archmagus Uvlius of the Oasis"
+    }, {
+        "id": "1388",
+        "name": "Sorcerer Ali of the Oasis"
+    }, {
+        "id": "1519",
+        "name": "Mystic Lucien of the Oasis"
+    }, {
+        "id": "1576",
+        "name": "Sage Misumi of the Oasis"
+    }, {
+        "id": "1592",
+        "name": "Katherine of the Oasis"
+    }, {
+        "id": "1669",
+        "name": "Adept Nazim of the Oasis"
+    }, {
+        "id": "1676",
+        "name": "Witch Gwendolin of the Oasis"
+    }, {
+        "id": "1718",
+        "name": "Battle Mage Gunthor of the Oasis"
+    }, {
+        "id": "2185",
+        "name": "Artificer Pezo of the Oasis"
+    }, {
+        "id": "2242",
+        "name": "Archmagus Amir of the Oasis"
+    }, {
+        "id": "2247",
+        "name": "Sorcerer Isaac of the Oasis"
+    }, {
+        "id": "2263",
+        "name": "Witch Juniper of the Oasis"
+    }, {
+        "id": "2316",
+        "name": "Arcanist Dante of the Oasis"
+    }, {
+        "id": "2360",
+        "name": "Illusionist Behemoth of the Oasis"
+    }, {
+        "id": "2490",
+        "name": "Ghost Eater Carly of the Oasis"
+    }, {
+        "id": "2652",
+        "name": "Magus Jabir of the Oasis"
+    }, {
+        "id": "2839",
+        "name": "Basil of the Oasis"
+    }, {
+        "id": "2847",
+        "name": "Conjurer Zhan of the Oasis"
+    }, {
+        "id": "2869",
+        "name": "Enchanter Devon of the Oasis"
+    }, {
+        "id": "2969",
+        "name": "Enchanter Requiem of the Oasis"
+    }, {
+        "id": "2987",
+        "name": "Shaman Azathoth of the Oasis"
+    }, {
+        "id": "3088",
+        "name": "Enchanter Lamia of the Oasis"
+    }, {
+        "id": "3500",
+        "name": "Witch Herne of the Oasis"
+    }, {
+        "id": "3670",
+        "name": "Hedge Wizard Nicolas of the Oasis"
+    }, {
+        "id": "3710",
+        "name": "Sorcerer Shukri of the Oasis"
+    }, {
+        "id": "3749",
+        "name": "Pyromancer Milton of the Oasis"
+    }, {
+        "id": "3809",
+        "name": "Shaman Wolfram of the Oasis"
+    }, {
+        "id": "4162",
+        "name": "Alchemist Blaise of the Oasis"
+    }, {
+        "id": "4177",
+        "name": "Bard Ronald of the Oasis"
+    }, {
+        "id": "4193",
+        "name": "Druid Casper of the Oasis"
+    }, {
+        "id": "4197",
+        "name": "Cryptomancer Ixar of the Oasis"
+    }, {
+        "id": "4248",
+        "name": "Battle Mage Cassius of the Oasis"
+    }, {
+        "id": "4293",
+        "name": "Archmagus Amir of the Oasis"
+    }, {
+        "id": "4351",
+        "name": "Sorcerer Kazem of the Oasis"
+    }, {
+        "id": "4372",
+        "name": "Null Mage Drusilla of the Oasis"
+    }, {
+        "id": "4379",
+        "name": "Sorcerer Alizam of the Oasis"
+    }, {
+        "id": "4633",
+        "name": "Alchemist Jean Leon of the Oasis"
+    }, {
+        "id": "4666",
+        "name": "Battle Mage Cromwell of the Oasis"
+    }, {
+        "id": "4706",
+        "name": "Scryer Angus of the Oasis"
+    }, {
+        "id": "4732",
+        "name": "Medium Junko of the Oasis"
+    }, {
+        "id": "4955",
+        "name": "Shaman Goober of the Oasis"
+    }, {
+        "id": "5135",
+        "name": "Artificer Dante of the Oasis"
+    }, {
+        "id": "5240",
+        "name": "Archmagus Soran of the Oasis"
+    }, {
+        "id": "5464",
+        "name": "Archmagus Casper of the Oasis"
+    }, {
+        "id": "5479",
+        "name": "Mystic Elmo of the Oasis"
+    }, {
+        "id": "5551",
+        "name": "Druid Angus of the Oasis"
+    }, {
+        "id": "5630",
+        "name": "Artificer Uday of the Oasis"
+    }, {
+        "id": "5634",
+        "name": "Oberon of the Oasis"
+    }, {
+        "id": "5729",
+        "name": "Sorcerer Ramiz of the Oasis"
+    }, {
+        "id": "5767",
+        "name": "Archmagus George of the Oasis"
+    }, {
+        "id": "5866",
+        "name": "Pyromancer Flamos of the Oasis"
+    }, {
+        "id": "5871",
+        "name": "Enchanter Alaric of the Oasis"
+    }, {
+        "id": "6201",
+        "name": "Magus Chooki of the Oasis"
+    }, {
+        "id": "6349",
+        "name": "Shaman Homer of the Oasis"
+    }, {
+        "id": "6407",
+        "name": "Magus Alizam of the Oasis"
+    }, {
+        "id": "6470",
+        "name": "Archmagus Ariadne of the Oasis"
+    }, {
+        "id": "6626",
+        "name": "Sage Victor of the Oasis"
+    }, {
+        "id": "6658",
+        "name": "Archmagus Argus of the Oasis"
+    }, {
+        "id": "6678",
+        "name": "Archmagus Venga of the Oasis"
+    }, {
+        "id": "6818",
+        "name": "Sorcerer Jahid of the Oasis"
+    }, {
+        "id": "6941",
+        "name": "Enchanter Dante of the Oasis"
+    }, {
+        "id": "6978",
+        "name": "Alchemist Ali of the Oasis"
+    }, {
+        "id": "7243",
+        "name": "Arch-Magician Robert of the Oasis"
+    }, {
+        "id": "7403",
+        "name": "Magus Crowley of the Oasis"
+    }, {
+        "id": "7433",
+        "name": "Archmagus Lumos of the Oasis"
+    }, {
+        "id": "7601",
+        "name": "Magus Orpheus of the Oasis"
+    }, {
+        "id": "7730",
+        "name": "Alchemist Davos of the Oasis"
+    }, {
+        "id": "7900",
+        "name": "Hedge Wizard Zaros of the Oasis"
+    }, {
+        "id": "7961",
+        "name": "Hedge Wizard Zixin of the Oasis"
+    }, {
+        "id": "8335",
+        "name": "Battle Mage Hothor of the Oasis"
+    }, {
+        "id": "8440",
+        "name": "Summoner Goober of the Oasis"
+    }, {
+        "id": "8517",
+        "name": "Battle Mage Angus of the Oasis"
+    }, {
+        "id": "8800",
+        "name": "Hex Mage Aleister of the Oasis"
+    }, {
+        "id": "8863",
+        "name": "Wild Mage Talbot of the Oasis"
+    }, {
+        "id": "8889",
+        "name": "Artificer Milton of the Oasis"
+    }, {
+        "id": "9043",
+        "name": "Necromancer Edge of the Oasis"
+    }, {
+        "id": "9057",
+        "name": "Archmagus Salvatore of the Oasis"
+    }, {
+        "id": "9212",
+        "name": "Medium Aldus of the Oasis"
+    }, {
+        "id": "9384",
+        "name": "Shaman Darby of the Oasis"
+    }, {
+        "id": "9566",
+        "name": "Illusionist Gaspard of the Oasis"
+    }, {
+        "id": "9772",
+        "name": "Lumos of the Oasis"
+    }, {
+        "id": "9796",
+        "name": "Druid Axel of the Oasis"
+    }, {
+        "id": "9853",
+        "name": "Aeromancer Lucien of the Oasis"
+    }, {
+        "id": "9874",
+        "name": "Hedge Wizard Kazud of the Oasis"
+    }, {
+        "id": "9995",
+        "name": "Augurer Ilu of the Oasis"
+    }],
+    "Shadow": [{
+        "id": "53",
+        "name": "Adept Milo from the Shadow"
+    }, {
+        "id": "201",
+        "name": "Jeldor from the Shadow"
+    }, {
+        "id": "381",
+        "name": "Archmagus Amir from the Shadow"
+    }, {
+        "id": "435",
+        "name": "Enchanter Angus from the Shadow"
+    }, {
+        "id": "1462",
+        "name": "Arch-Magician Talon from the Shadow"
+    }, {
+        "id": "1694",
+        "name": "Battle Mage Dutorn from the Shadow"
+    }, {
+        "id": "1793",
+        "name": "Battle Mage Thor from the Shadow"
+    }, {
+        "id": "1916",
+        "name": "Adept Brown Cow from the Shadow"
+    }, {
+        "id": "2002",
+        "name": "Archmagus Orpheus from the Shadow"
+    }, {
+        "id": "2168",
+        "name": "Enchanter Sondra from the Shadow"
+    }, {
+        "id": "2513",
+        "name": "Necromancer Hagatha from the Shadow"
+    }, {
+        "id": "3027",
+        "name": "Magus Ilyas from the Shadow"
+    }, {
+        "id": "3644",
+        "name": "Cleric Aleister from the Shadow"
+    }, {
+        "id": "3715",
+        "name": "Geomancer Marceau from the Shadow"
+    }, {
+        "id": "3907",
+        "name": "Void Disciple Charlord from the Shadow"
+    }, {
+        "id": "3945",
+        "name": "Archmagus Lumos from the Shadow"
+    }, {
+        "id": "4717",
+        "name": "Alchemist Cassandra from the Shadow"
+    }, {
+        "id": "5110",
+        "name": "Archmagus Shivra from the Shadow"
+    }, {
+        "id": "5185",
+        "name": "Arch-Magician Shigenjo from the Shadow"
+    }, {
+        "id": "5578",
+        "name": "Necromancer Anton of the Shadow"
+    }, {
+        "id": "5583",
+        "name": "Pyromancer Rita from the Shadow"
+    }, {
+        "id": "5769",
+        "name": "Shadow Mage Pumlo from the Shadow"
+    }, {
+        "id": "6113",
+        "name": "Adept Vossler from the Shadow"
+    }, {
+        "id": "6309",
+        "name": "Summoner Pino from the Shadow"
+    }, {
+        "id": "6458",
+        "name": "Hedge Wizard Magnus from the Shadow"
+    }, {
+        "id": "6570",
+        "name": "Archmagus Milton from the Shadow"
+    }, {
+        "id": "6869",
+        "name": "Adept Hellspawn from the Shadow"
+    }, {
+        "id": "7423",
+        "name": "Voodoo Priest Lucien from the Shadow"
+    }, {
+        "id": "7449",
+        "name": "Electromancer Apollo from the Shadow"
+    }, {
+        "id": "7559",
+        "name": "Alatar from the Shadow"
+    }, {
+        "id": "7650",
+        "name": "Druid Jig from the Shadow"
+    }, {
+        "id": "7685",
+        "name": "Sorcerer Ozohr from the Shadow"
+    }, {
+        "id": "7796",
+        "name": "Pyromancer Solomon from the Shadow"
+    }, {
+        "id": "8110",
+        "name": "Summoner Atlas from the Shadow"
+    }, {
+        "id": "8210",
+        "name": "Hex Mage Apollo from the Shadow"
+    }, {
+        "id": "8248",
+        "name": "Archmagus Isaac from the Shadow"
+    }, {
+        "id": "8557",
+        "name": "Milton from the Shadow"
+    }, {
+        "id": "8666",
+        "name": "Sorcerer Alatar from the Shadow"
+    }, {
+        "id": "8678",
+        "name": "Electromancer Alessar from the Shadow"
+    }, {
+        "id": "8902",
+        "name": "Void Disciple David from the Shadow"
+    }, {
+        "id": "8920",
+        "name": "Geomancer Aleister from the Shadow"
+    }, {
+        "id": "9141",
+        "name": "Artificer Homer from the Shadow"
+    }, {
+        "id": "9197",
+        "name": "Magus Kang from the Shadow"
+    }, {
+        "id": "9401",
+        "name": "Alchemist Wolfram from the Shadow"
+    }, {
+        "id": "9687",
+        "name": "Pyromancer Davos from the Shadow"
+    }, {
+        "id": "9711",
+        "name": "Magus Moloch from the Shadow"
+    }],
+    "Ash": [{
+        "id": "531",
+        "name": "Sage Voidoth of the Ash"
+    }, {
+        "id": "755",
+        "name": "Necromancer Zeromus of the Ash"
+    }],
+    "Hall": [{
+        "id": "35",
+        "name": "Archmagus Casper of the Hall"
+    }, {
+        "id": "155",
+        "name": "Magus Pumlo of the Hall"
+    }, {
+        "id": "224",
+        "name": "Sage Silas of the Hall"
+    }, {
+        "id": "344",
+        "name": "Archmagus Suki of the Hall"
+    }, {
+        "id": "379",
+        "name": "Archmagus Eden of the Hall"
+    }, {
+        "id": "472",
+        "name": "Oberon of the Hall"
+    }, {
+        "id": "479",
+        "name": "Archmagus Alatar of the Hall"
+    }, {
+        "id": "536",
+        "name": "Battle Mage Hansel of the Hall"
+    }, {
+        "id": "620",
+        "name": "Battle Mage Wolfram of the Hall"
+    }, {
+        "id": "727",
+        "name": "Magus George of the Hall"
+    }, {
+        "id": "738",
+        "name": "Alchemist Hestia of the Hall"
+    }, {
+        "id": "765",
+        "name": "Mystic Amir of the Hall"
+    }, {
+        "id": "788",
+        "name": "Archmagus George of the Hall"
+    }, {
+        "id": "816",
+        "name": "Magus Lumos of the Hall"
+    }, {
+        "id": "871",
+        "name": "Archmagus Iprix of the Hall"
+    }, {
+        "id": "895",
+        "name": "Sorcerer Crowley of the Hall"
+    }, {
+        "id": "923",
+        "name": "Colormancer Devo of the Hall"
+    }, {
+        "id": "925",
+        "name": "Witch Milo of the Hall"
+    }, {
+        "id": "997",
+        "name": "Cleric Marceline of the Hall"
+    }, {
+        "id": "1008",
+        "name": "Alchemist Remus of the Hall"
+    }, {
+        "id": "1020",
+        "name": "Artificer Layla of the Hall"
+    }, {
+        "id": "1027",
+        "name": "Alchemist Eizo of the Hall"
+    }, {
+        "id": "1165",
+        "name": "Shadow Mage Chooki of the Hall"
+    }, {
+        "id": "1185",
+        "name": "Arcanist Eliphas of the Hall"
+    }, {
+        "id": "1226",
+        "name": "Sorcerer Atlanta of the Hall"
+    }, {
+        "id": "1273",
+        "name": "Archmagus Zaros of the Hall"
+    }, {
+        "id": "1279",
+        "name": "Enchanter Maia of the Hall"
+    }, {
+        "id": "1300",
+        "name": "Holy Monk Akron of the Hall"
+    }, {
+        "id": "1305",
+        "name": "Charmer Leah of the Hall"
+    }, {
+        "id": "1335",
+        "name": "Magus Brown Cow of the Hall"
+    }, {
+        "id": "1372",
+        "name": "Sorcerer Angus of the Hall"
+    }, {
+        "id": "1373",
+        "name": "Archmagus Milton of the Hall"
+    }, {
+        "id": "1411",
+        "name": "Magus Amir of the Hall"
+    }, {
+        "id": "1458",
+        "name": "Hedge Wizard Victoria of the Hall"
+    }, {
+        "id": "1480",
+        "name": "Sorcerer Lumos of the Hall"
+    }, {
+        "id": "1490",
+        "name": "Sorcerer Nadeem of the Hall"
+    }, {
+        "id": "1506",
+        "name": "Charmer Artis of the Hall"
+    }, {
+        "id": "1539",
+        "name": "Adept Gunthor of the Hall"
+    }, {
+        "id": "1543",
+        "name": "Adept Iprix of the Hall"
+    }, {
+        "id": "1584",
+        "name": "Bard Lux of the Hall"
+    }, {
+        "id": "1604",
+        "name": "Arch-Magician Amanita of the Hall"
+    }, {
+        "id": "1757",
+        "name": "Battle Mage Ethan of the Hall"
+    }, {
+        "id": "1784",
+        "name": "Alchemist Izible of the Hall"
+    }, {
+        "id": "1808",
+        "name": "Hedge Wizard Celah of the Hall"
+    }, {
+        "id": "1812",
+        "name": "Arch-Magician Enigma of the Hall"
+    }, {
+        "id": "1827",
+        "name": "Hedge Wizard Circe of the Hall"
+    }, {
+        "id": "1935",
+        "name": "Enchanter Layla of the Hall"
+    }, {
+        "id": "1942",
+        "name": "Wizard Oiq of the Hall"
+    }, {
+        "id": "2025",
+        "name": "Ghost Eater Azazel of the Hall"
+    }, {
+        "id": "2053",
+        "name": "Arcanist Hagatha of the Hall"
+    }, {
+        "id": "2089",
+        "name": "Enchanter Devon of the Hall"
+    }, {
+        "id": "2103",
+        "name": "Artificer Jiggs of the Hall"
+    }, {
+        "id": "2141",
+        "name": "Archmagus Apollo of the Hall"
+    }, {
+        "id": "2245",
+        "name": "Shaman Gaspard of the Hall"
+    }, {
+        "id": "2312",
+        "name": "Null Mage Lucifer of the Hall"
+    }, {
+        "id": "2348",
+        "name": "Medium Stefan of the Hall"
+    }, {
+        "id": "2367",
+        "name": "Arch-Magician Hishoken of the Hall"
+    }, {
+        "id": "2507",
+        "name": "Archmagus Basil of the Hall"
+    }, {
+        "id": "2633",
+        "name": "Illusionist Aleister of the Hall"
+    }, {
+        "id": "2666",
+        "name": "Sorcerer Aleister of the Hall"
+    }, {
+        "id": "2818",
+        "name": "Enchanter Adrienne of the Hall"
+    }, {
+        "id": "2870",
+        "name": "Cryptomancer Amir of the Hall"
+    }, {
+        "id": "2908",
+        "name": "Lumos of the Hall"
+    }, {
+        "id": "2927",
+        "name": "Conjurer Willow of the Hall"
+    }, {
+        "id": "2970",
+        "name": "Sage Eliphas of the Hall"
+    }, {
+        "id": "2988",
+        "name": "Voodoo Priest Requiem of the Hall"
+    }, {
+        "id": "3001",
+        "name": "Aeromancer Argus of the Hall"
+    }, {
+        "id": "3073",
+        "name": "Sorcerer Milo of the Hall"
+    }, {
+        "id": "3076",
+        "name": "Illusionist Zaros of the Hall"
+    }, {
+        "id": "3080",
+        "name": "Artificer Gunthor of the Hall"
+    }, {
+        "id": "3119",
+        "name": "Archmagus Eden of the Hall"
+    }, {
+        "id": "3212",
+        "name": "Archmagus Alessar of the Hall"
+    }, {
+        "id": "3274",
+        "name": "Ghost Eater Azazel of the Hall"
+    }, {
+        "id": "3399",
+        "name": "Sorcerer Milo of the Hall"
+    }, {
+        "id": "3520",
+        "name": "Illusionist Layla of the Hall"
+    }, {
+        "id": "3532",
+        "name": "Illusionist Eden of the Hall"
+    }, {
+        "id": "3537",
+        "name": "Archmagus Milo of the Hall"
+    }, {
+        "id": "3547",
+        "name": "Augurer Lumos of the Hall"
+    }, {
+        "id": "3550",
+        "name": "Magus Jahid of the Hall"
+    }, {
+        "id": "3552",
+        "name": "Archmagus Nikolas of the Hall"
+    }, {
+        "id": "3631",
+        "name": "Charmer Mina of the Hall"
+    }, {
+        "id": "3733",
+        "name": "Bard Zelroth of the Hall"
+    }, {
+        "id": "3833",
+        "name": "Shadow Mage Angus of the Hall"
+    }, {
+        "id": "3858",
+        "name": "Magus Qasim of the Hall"
+    }, {
+        "id": "3900",
+        "name": "Archmagus  of the Hall"
+    }, {
+        "id": "3961",
+        "name": "Hedge Wizard Lilith of the Hall"
+    }, {
+        "id": "4013",
+        "name": "Sorcerer Celah of the Hall"
+    }, {
+        "id": "4017",
+        "name": "Alchemist Miyo of the Hall"
+    }, {
+        "id": "4060",
+        "name": "Diabolist Aiko of the Hall"
+    }, {
+        "id": "4086",
+        "name": "Archmagus Apollo of the Hall"
+    }, {
+        "id": "4101",
+        "name": "Battle Mage Homer of the Hall"
+    }, {
+        "id": "4111",
+        "name": "Cleric Jeldor of the Hall"
+    }, {
+        "id": "4210",
+        "name": "Magus Edge of the Hall"
+    }, {
+        "id": "4219",
+        "name": "Archmagus Lumos of the Hall"
+    }, {
+        "id": "4235",
+        "name": "Archmagus Orpheus of the Hall"
+    }, {
+        "id": "4317",
+        "name": "Archmagus Zubin of the Hall"
+    }, {
+        "id": "4366",
+        "name": "Sage Hadrien of the Hall"
+    }, {
+        "id": "4374",
+        "name": "Ghost Eater Demos of the Hall"
+    }, {
+        "id": "4397",
+        "name": "Illusionist Drusilla of the Hall"
+    }, {
+        "id": "4464",
+        "name": "Archmagus  of the Hall"
+    }, {
+        "id": "4465",
+        "name": "Necromancer Abaddon of the Hall"
+    }, {
+        "id": "4468",
+        "name": "Enchanter Victoria of the Hall"
+    }, {
+        "id": "4480",
+        "name": "Battle Mage Dante of the Hall"
+    }, {
+        "id": "4557",
+        "name": "Battle Mage Goliath of the Hall"
+    }, {
+        "id": "4587",
+        "name": "Ghost Eater Basil of the Hall"
+    }, {
+        "id": "4593",
+        "name": "Artificer Diana of the Hall"
+    }, {
+        "id": "4615",
+        "name": "Shaman Impy of the Hall"
+    }, {
+        "id": "4630",
+        "name": "Shaman Alizam of the Hall"
+    }, {
+        "id": "4664",
+        "name": "Hedge Wizard Merlon of the Hall"
+    }, {
+        "id": "4788",
+        "name": "Diabolist Azahl of the Hall"
+    }, {
+        "id": "4800",
+        "name": "Void Disciple Norix of the Hall"
+    }, {
+        "id": "4814",
+        "name": "Artificer Zaros of the Hall"
+    }, {
+        "id": "4853",
+        "name": "Archmagus Lumos of the Hall"
+    }, {
+        "id": "4893",
+        "name": "Shaman Apollo of the Hall"
+    }, {
+        "id": "4966",
+        "name": "Artificer Aamon of the Hall"
+    }, {
+        "id": "4992",
+        "name": "Medium Soya of the Hall"
+    }, {
+        "id": "5069",
+        "name": "Illusionist Durm of the Hall"
+    }, {
+        "id": "5078",
+        "name": "Artificer Bayard of the Hall"
+    }, {
+        "id": "5189",
+        "name": "Casper of the Hall"
+    }, {
+        "id": "5252",
+        "name": "Charmer Victoria of the Hall"
+    }, {
+        "id": "5311",
+        "name": "Magus Merlon of the Hall"
+    }, {
+        "id": "5417",
+        "name": "Alchemist Impy of the Hall"
+    }, {
+        "id": "5482",
+        "name": "Illusionist Hugo of the Hall"
+    }, {
+        "id": "5605",
+        "name": "Battle Mage Hansel of the Hall"
+    }, {
+        "id": "5618",
+        "name": "Illusionist Mina of the Hall"
+    }, {
+        "id": "5648",
+        "name": "Alchemist Gaspard of the Hall"
+    }, {
+        "id": "5651",
+        "name": "Archmagus Rocco of the Hall"
+    }, {
+        "id": "5776",
+        "name": "Archmagus Iprix of the Hall"
+    }, {
+        "id": "5816",
+        "name": "Charmer Cassiopeia of the Hall"
+    }, {
+        "id": "5825",
+        "name": "Wild Mage Axel of the Hall"
+    }, {
+        "id": "5868",
+        "name": "Thaumaturge Hobbs of the Hall"
+    }, {
+        "id": "5883",
+        "name": "Arcanist Atlanta of the Hall"
+    }, {
+        "id": "5884",
+        "name": "Cartomancer Patch of the Hall"
+    }, {
+        "id": "6150",
+        "name": "Sage Gunthor of the Hall"
+    }, {
+        "id": "6166",
+        "name": "Hedge Wizard Talon of the Hall"
+    }, {
+        "id": "6169",
+        "name": "Battle Mage Cromwell of the Hall"
+    }, {
+        "id": "6188",
+        "name": "Archmagus Aleister of the Hall"
+    }, {
+        "id": "6249",
+        "name": "Sage  of the Hall"
+    }, {
+        "id": "6259",
+        "name": "Druid Caligari of the Hall"
+    }, {
+        "id": "6406",
+        "name": "Alatar of the Hall"
+    }, {
+        "id": "6414",
+        "name": "Archmagus Soya of the Hall"
+    }, {
+        "id": "6420",
+        "name": "Wild Mage Solomon of the Hall"
+    }, {
+        "id": "6457",
+        "name": "Alchemist Zixin of the Hall"
+    }, {
+        "id": "6474",
+        "name": "Arcanist Ofaris of the Hall"
+    }, {
+        "id": "6587",
+        "name": "Magus Kalo of the Hall"
+    }, {
+        "id": "6623",
+        "name": "Shaman Nicolas of the Hall"
+    }, {
+        "id": "6671",
+        "name": "Adept Thoth of the Hall"
+    }, {
+        "id": "6722",
+        "name": "Battle Mage Cassius of the Hall"
+    }, {
+        "id": "6728",
+        "name": "Witch Drusilla of the Hall"
+    }, {
+        "id": "6838",
+        "name": "Augurer Allistair of the Hall"
+    }, {
+        "id": "6884",
+        "name": "Archmagus Lux of the Hall"
+    }, {
+        "id": "6936",
+        "name": "Colormancer Devo of the Hall"
+    }, {
+        "id": "6983",
+        "name": "Ghost Eater Crackerjack of the Hall"
+    }, {
+        "id": "6988",
+        "name": "Artificer Sarah of the Hall"
+    }, {
+        "id": "7031",
+        "name": "Isaac of the Hall"
+    }, {
+        "id": "7047",
+        "name": "Archmagus Solomon of the Hall"
+    }, {
+        "id": "7111",
+        "name": "Archmagus Solomon of the Hall"
+    }, {
+        "id": "7200",
+        "name": "Archmagus Merlon of the Hall"
+    }, {
+        "id": "7283",
+        "name": "Battle Mage Sturgis of the Hall"
+    }, {
+        "id": "7286",
+        "name": "Archmagus Solomon of the Hall"
+    }, {
+        "id": "7398",
+        "name": "Battle Mage Nicolas of the Hall"
+    }, {
+        "id": "7507",
+        "name": "Hedge Wizard Properpine of the Hall"
+    }, {
+        "id": "7568",
+        "name": "Fortune Teller Gil of the Hall"
+    }, {
+        "id": "7574",
+        "name": "Thaumaturge Celah of the Hall"
+    }, {
+        "id": "7604",
+        "name": "Shaman Zelroth of the Hall"
+    }, {
+        "id": "7610",
+        "name": "Sorcerer Amir of the Hall"
+    }, {
+        "id": "7614",
+        "name": "Pyromancer Zaros of the Hall"
+    }, {
+        "id": "7619",
+        "name": "Druid Daria of the Hall"
+    }, {
+        "id": "7649",
+        "name": "Arch-Magician Zaros of the Hall"
+    }, {
+        "id": "7661",
+        "name": "Alchemist Aldus of the Hall"
+    }, {
+        "id": "7734",
+        "name": "Sorcerer Aldus of the Hall"
+    }, {
+        "id": "7810",
+        "name": "Sorcerer Davos of the Hall"
+    }, {
+        "id": "7822",
+        "name": "Cleric Jabir of the Hall"
+    }, {
+        "id": "7824",
+        "name": "Illusionist Seth of the Hall"
+    }, {
+        "id": "7859",
+        "name": "Archmagus Isaac of the Hall"
+    }, {
+        "id": "7921",
+        "name": "Summoner Pandora of the Hall"
+    }, {
+        "id": "7924",
+        "name": "Witch Ophelia of the Hall"
+    }, {
+        "id": "7948",
+        "name": "Shaman Alessar of the Hall"
+    }, {
+        "id": "7956",
+        "name": "Sorcerer Eronin of the Hall"
+    }, {
+        "id": "7979",
+        "name": "Charmer Faye of the Hall"
+    }, {
+        "id": "8029",
+        "name": "Archmagus Lumos of the Hall"
+    }, {
+        "id": "8123",
+        "name": "Adept Angus of the Hall"
+    }, {
+        "id": "8131",
+        "name": "Archmagus Milo of the Hall"
+    }, {
+        "id": "8172",
+        "name": "Adept Apollo of the Hall"
+    }, {
+        "id": "8216",
+        "name": "Cleric Wolfram of the Hall"
+    }, {
+        "id": "8221",
+        "name": "George of the Hall"
+    }, {
+        "id": "8227",
+        "name": "Shaman Uday of the Hall"
+    }, {
+        "id": "8306",
+        "name": "Arcanist Ratko of the Hall"
+    }, {
+        "id": "8355",
+        "name": "Shaman Celah of the Hall"
+    }, {
+        "id": "8360",
+        "name": "Jeldor of the Hall"
+    }, {
+        "id": "8380",
+        "name": "Electromancer Hothor of the Hall"
+    }, {
+        "id": "8393",
+        "name": "Arch-Magician Celeste of the Hall"
+    }, {
+        "id": "8474",
+        "name": "Mystic Allistair of the Hall"
+    }, {
+        "id": "8611",
+        "name": "Ghost Eater Flamos of the Hall"
+    }, {
+        "id": "8713",
+        "name": "Enchanter Ariadne of the Hall"
+    }, {
+        "id": "8731",
+        "name": "Battle Mage Atlas of the Hall"
+    }, {
+        "id": "8801",
+        "name": "Enchanter Tundror of the Hall"
+    }, {
+        "id": "8814",
+        "name": "Sage Aleister of the Hall"
+    }, {
+        "id": "8860",
+        "name": "Archmagus Uvlius of the Hall"
+    }, {
+        "id": "8872",
+        "name": "Enchanter Sondra of the Hall"
+    }, {
+        "id": "8893",
+        "name": "Archmagus Jerret of the Hall"
+    }, {
+        "id": "8905",
+        "name": "Shaman Ilyas of the Hall"
+    }, {
+        "id": "8937",
+        "name": "Eden of the Hall"
+    }, {
+        "id": "8945",
+        "name": "Alchemist George of the Hall"
+    }, {
+        "id": "8993",
+        "name": "Arcanist Thana of the Hall"
+    }, {
+        "id": "9011",
+        "name": "Runecaster David of the Hall"
+    }, {
+        "id": "9062",
+        "name": "Archmagus Aldus of the Hall"
+    }, {
+        "id": "9097",
+        "name": "Artificer Katherine of the Hall"
+    }, {
+        "id": "9103",
+        "name": "Battle Mage Goliath of the Hall"
+    }, {
+        "id": "9133",
+        "name": "Voodoo Priest Baptiste of the Hall"
+    }, {
+        "id": "9252",
+        "name": "Summoner Celah of the Hall"
+    }, {
+        "id": "9299",
+        "name": "Archmagus Udor of the Hall"
+    }, {
+        "id": "9302",
+        "name": "Magus Suki of the Hall"
+    }, {
+        "id": "9332",
+        "name": "Thaumaturge David of the Hall"
+    }, {
+        "id": "9360",
+        "name": "Illusionist Chanterelle of the Hall"
+    }, {
+        "id": "9396",
+        "name": "Diviner Galatea of the Hall"
+    }, {
+        "id": "9399",
+        "name": "Sorcerer Anton of the Hall"
+    }, {
+        "id": "9408",
+        "name": "Thaumaturge Milo of the Hall"
+    }, {
+        "id": "9485",
+        "name": "Alchemist Jerret of the Hall"
+    }, {
+        "id": "9544",
+        "name": "Enchanter Lumos of the Hall"
+    }, {
+        "id": "9551",
+        "name": "Archmagus Milton of the Hall"
+    }, {
+        "id": "9575",
+        "name": "Sorcerer Idris of the Hall"
+    }, {
+        "id": "9621",
+        "name": "Illusionist Jasper of the Hall"
+    }, {
+        "id": "9622",
+        "name": "Chaos Mage Alessar of the Hall"
+    }, {
+        "id": "9673",
+        "name": "Summoner Tundror of the Hall"
+    }, {
+        "id": "9700",
+        "name": "Scryer Lamia of the Hall"
+    }, {
+        "id": "9732",
+        "name": "Holy Monk Aldo of the Hall"
+    }, {
+        "id": "9770",
+        "name": "Archmagus Aleister of the Hall"
+    }, {
+        "id": "9808",
+        "name": "Artificer Toby of the Hall"
+    }, {
+        "id": "9833",
+        "name": "Conjurer Elizabeth of the Hall"
+    }, {
+        "id": "9879",
+        "name": "Archmagus George of the Hall"
+    }, {
+        "id": "9882",
+        "name": "Arch-Magician Orbus of the Hall"
+    }, {
+        "id": "9932",
+        "name": "Magus Hadrien of the Hall"
+    }],
+    "Dreams": [{
+        "id": "47",
+        "name": "Chronomancer George of Dreams"
+    }, {
+        "id": "183",
+        "name": "Eden of Dreams"
+    }, {
+        "id": "238",
+        "name": "Alchemist Lumos of Dreams"
+    }, {
+        "id": "312",
+        "name": "Holy Monk Edge of Dreams"
+    }, {
+        "id": "410",
+        "name": "Archmagus Nikolas of Dreams"
+    }, {
+        "id": "511",
+        "name": "Illusionist Uday of Dreams"
+    }, {
+        "id": "566",
+        "name": "Artificer Homer of Dreams"
+    }, {
+        "id": "880",
+        "name": "Arch-Magician Apollo of Dreams"
+    }, {
+        "id": "947",
+        "name": "Shaman Wolfram of Dreams"
+    }, {
+        "id": "955",
+        "name": "Chronomancer Zubin of Dreams"
+    }, {
+        "id": "1097",
+        "name": "Battle Mage Hagar of Dreams"
+    }, {
+        "id": "1187",
+        "name": "Sorcerer Davos of Dreams"
+    }, {
+        "id": "1200",
+        "name": "Arch-Magician Xiaobo of Dreams"
+    }, {
+        "id": "1227",
+        "name": "Runecaster Nicolas of Dreams"
+    }, {
+        "id": "1357",
+        "name": "Artificer Samuel of Dreams"
+    }, {
+        "id": "1465",
+        "name": "Shaman Cromwell of Dreams"
+    }, {
+        "id": "2042",
+        "name": "Electromancer Hagar of Dreams"
+    }, {
+        "id": "2067",
+        "name": "Adept Ratko of Dreams"
+    }, {
+        "id": "2119",
+        "name": "Magus Zorko of Dreams"
+    }, {
+        "id": "2255",
+        "name": "Artificer Elvio of Dreams"
+    }, {
+        "id": "2359",
+        "name": "Alchemist Suki of Dreams"
+    }, {
+        "id": "2467",
+        "name": "Battle Mage Nicolas of Dreams"
+    }, {
+        "id": "2510",
+        "name": "Enchanter Alessar of Dreams"
+    }, {
+        "id": "2573",
+        "name": "Aeromancer Hadrien of Dreams"
+    }, {
+        "id": "2715",
+        "name": "Shaman Chooki of Dreams"
+    }, {
+        "id": "2721",
+        "name": "Alchemist Alatar of Dreams"
+    }, {
+        "id": "2876",
+        "name": "Archmagus Soran of Dreams"
+    }, {
+        "id": "2926",
+        "name": "Thaumaturge Bathsheba of Dreams"
+    }, {
+        "id": "2982",
+        "name": "Witch Rowena of Dreams"
+    }, {
+        "id": "3390",
+        "name": "Conjurer Huan of Dreams"
+    }, {
+        "id": "3394",
+        "name": "Battle Mage Caligula of Dreams"
+    }, {
+        "id": "3626",
+        "name": "Illusionist Pezo of Dreams"
+    }, {
+        "id": "3735",
+        "name": "Sorcerer Zubin of Dreams"
+    }, {
+        "id": "3918",
+        "name": "Augurer Meloogen of Dreams"
+    }, {
+        "id": "3969",
+        "name": "Runecaster Silas of Dreams"
+    }, {
+        "id": "3981",
+        "name": "Battle Mage Cromwell of Dreams"
+    }, {
+        "id": "4045",
+        "name": "Battle Mage Nicolas of Dreams"
+    }, {
+        "id": "4074",
+        "name": "Sky Master Jay of Dreams"
+    }, {
+        "id": "4395",
+        "name": "Hedge Wizard Iprix of Dreams"
+    }, {
+        "id": "4475",
+        "name": "Sorcerer Merlon of Dreams"
+    }, {
+        "id": "4659",
+        "name": "Archmagus Milton of Dreams"
+    }, {
+        "id": "4662",
+        "name": "Adept Kryll of Dreams"
+    }, {
+        "id": "4688",
+        "name": "Druid Venga of Dreams"
+    }, {
+        "id": "4818",
+        "name": "Arch-Magician Aldus of Dreams"
+    }, {
+        "id": "4854",
+        "name": "Ghost Eater Voidoth of Dreams"
+    }, {
+        "id": "5019",
+        "name": "Sorcerer Solomon of Dreams"
+    }, {
+        "id": "5264",
+        "name": "Enchanter Artis of Dreams"
+    }, {
+        "id": "5357",
+        "name": "Sky Master Rook of Dreams"
+    }, {
+        "id": "5366",
+        "name": "Jerret of Dreams"
+    }, {
+        "id": "5410",
+        "name": "Ozohr of Dreams"
+    }, {
+        "id": "5704",
+        "name": "Magus Alizam of Dreams"
+    }, {
+        "id": "5740",
+        "name": "Sage Requiem of Dreams"
+    }, {
+        "id": "6303",
+        "name": "Cryptomancer Seth of Dreams"
+    }, {
+        "id": "6330",
+        "name": "Soya of Dreams"
+    }, {
+        "id": "6394",
+        "name": "Spellsinger Sturgis of Dreams"
+    }, {
+        "id": "6428",
+        "name": "Battle Mage Goliath of Dreams"
+    }, {
+        "id": "6553",
+        "name": "Illusionist Thana of Dreams"
+    }, {
+        "id": "6679",
+        "name": "Sorcerer Eizo of Dreams"
+    }, {
+        "id": "7025",
+        "name": "Druid Allistair of Dreams"
+    }, {
+        "id": "7108",
+        "name": "Archmagus Jerret of Dreams"
+    }, {
+        "id": "7118",
+        "name": "Chaos Mage Sylvia of Dreams"
+    }, {
+        "id": "7128",
+        "name": "Wild Mage Quddus of Dreams"
+    }, {
+        "id": "7159",
+        "name": "Shaman Tengukensei of Dreams"
+    }, {
+        "id": "7238",
+        "name": "Druid Merlon of Dreams"
+    }, {
+        "id": "7807",
+        "name": "Charmer Calliope of Dreams"
+    }, {
+        "id": "8005",
+        "name": "Evoker Lenora of Dreams"
+    }, {
+        "id": "8080",
+        "name": "Archmagus Celah of Dreams"
+    }, {
+        "id": "8117",
+        "name": "Magus Alizam of Dreams"
+    }, {
+        "id": "8183",
+        "name": "Mystic Casper of Dreams"
+    }, {
+        "id": "8269",
+        "name": "Pyromancer Gunthor of Dreams"
+    }, {
+        "id": "8283",
+        "name": "Wild Mage Larissa of Dreams"
+    }, {
+        "id": "8351",
+        "name": "Archmagus Aldo of Dreams"
+    }, {
+        "id": "8616",
+        "name": "Enchanter Hansel of Dreams"
+    }, {
+        "id": "8703",
+        "name": "Holy Monk Aden of Dreams"
+    }, {
+        "id": "8717",
+        "name": "Witch Enigma of Dreams"
+    }, {
+        "id": "8740",
+        "name": "Archmagus Jeldor of Dreams"
+    }, {
+        "id": "8932",
+        "name": "Sorcerer Jahid of Dreams"
+    }, {
+        "id": "9019",
+        "name": "Shaman Iprix of Dreams"
+    }, {
+        "id": "9072",
+        "name": "Battle Mage Axel of Dreams"
+    }, {
+        "id": "9075",
+        "name": "Sorcerer Soya of Dreams"
+    }, {
+        "id": "9179",
+        "name": "Electromancer Horace of Dreams"
+    }, {
+        "id": "9259",
+        "name": "of Dreams"
+    }, {
+        "id": "9277",
+        "name": "Arch-Magician Gwendolin of Dreams"
+    }, {
+        "id": "9305",
+        "name": "Diviner Merlon of Dreams"
+    }, {
+        "id": "9537",
+        "name": "Arch-Magician Ofaris of Dreams"
+    }, {
+        "id": "9580",
+        "name": "Archmagus Zubin of Dreams"
+    }, {
+        "id": "9950",
+        "name": "Shaman Aamon of Dreams"
+    }, {
+        "id": "9962",
+        "name": "Alchemist Aslan of Dreams"
+    }],
+    "Atheneum": [{
+        "id": "116",
+        "name": "Runecaster Huan of the Atheneum"
+    }, {
+        "id": "138",
+        "name": "Magus Thor of the Atheneum"
+    }, {
+        "id": "216",
+        "name": "Hedge Wizard Hashim of the Atheneum"
+    }, {
+        "id": "394",
+        "name": "Sorcerer Milton of the Atheneum"
+    }, {
+        "id": "544",
+        "name": "Celah of the Atheneum"
+    }, {
+        "id": "601",
+        "name": "Sage Bane of the Atheneum"
+    }, {
+        "id": "632",
+        "name": "Archmagus  of the Atheneum"
+    }, {
+        "id": "660",
+        "name": "Chaos Mage Marceline of the Atheneum"
+    }, {
+        "id": "717",
+        "name": "Geomancer Wolfram of the Atheneum"
+    }, {
+        "id": "731",
+        "name": "Witch Lucinda of the Atheneum"
+    }, {
+        "id": "827",
+        "name": "Celah of the Atheneum"
+    }, {
+        "id": "961",
+        "name": "Summoner  of the Atheneum"
+    }, {
+        "id": "1003",
+        "name": "Adept Thor of the Atheneum"
+    }, {
+        "id": "1004",
+        "name": "Sorcerer Nikolas of the Atheneum"
+    }, {
+        "id": "1023",
+        "name": "Runecaster Nicolas of the Atheneum"
+    }, {
+        "id": "1091",
+        "name": "Summoner Hothor of the Atheneum"
+    }, {
+        "id": "1179",
+        "name": "Aleister of the Atheneum"
+    }, {
+        "id": "1220",
+        "name": "Jeldor of the Atheneum"
+    }, {
+        "id": "1306",
+        "name": "Hex Mage Zafar of the Atheneum"
+    }, {
+        "id": "1314",
+        "name": "Necromancer Aldus of the Atheneum"
+    }, {
+        "id": "1574",
+        "name": "Magus Wolfram of the Atheneum"
+    }, {
+        "id": "1881",
+        "name": "Celeste of the Atheneum"
+    }, {
+        "id": "1913",
+        "name": "Magus Gogol of the Atheneum"
+    }, {
+        "id": "1927",
+        "name": "Alchemist Daria of the Atheneum"
+    }, {
+        "id": "2040",
+        "name": "Alchemist Zubin of the Atheneum"
+    }, {
+        "id": "2111",
+        "name": "Archmagus Salvatore of the Atheneum"
+    }, {
+        "id": "2122",
+        "name": "Artificer Agapito of the Atheneum"
+    }, {
+        "id": "2148",
+        "name": "Artificer Nadeem of the Atheneum"
+    }, {
+        "id": "2392",
+        "name": "Sorcerer Zane of the Atheneum"
+    }, {
+        "id": "2423",
+        "name": "Void Disciple Malcom of the Atheneum"
+    }, {
+        "id": "2454",
+        "name": "Sorcerer Zaim of the Atheneum"
+    }, {
+        "id": "2791",
+        "name": "Summoner Pandora of the Atheneum"
+    }, {
+        "id": "2864",
+        "name": "Archmagus Ixar of the Atheneum"
+    }, {
+        "id": "2964",
+        "name": "Arch-Magician Spore Boy of the Atheneum"
+    }, {
+        "id": "3192",
+        "name": "Cosmic Mage Sturgis of the Atheneum"
+    }, {
+        "id": "3251",
+        "name": "Sorcerer Cairon of the Atheneum"
+    }, {
+        "id": "3358",
+        "name": "Cleric Onaxx of the Atheneum"
+    }, {
+        "id": "3657",
+        "name": "Beyna of the Atheneum"
+    }, {
+        "id": "3686",
+        "name": "Electromancer Lux of the Atheneum"
+    }, {
+        "id": "3697",
+        "name": "Cryptomancer Argus of the Atheneum"
+    }, {
+        "id": "3761",
+        "name": "Artificer Bojangles of the Atheneum"
+    }, {
+        "id": "4224",
+        "name": "Adept Idris of the Atheneum"
+    }, {
+        "id": "4327",
+        "name": "Cryptomancer Demos of the Atheneum"
+    }, {
+        "id": "4331",
+        "name": "Electromancer Aleister of the Atheneum"
+    }, {
+        "id": "4513",
+        "name": "Artificer Bobbin of the Atheneum"
+    }, {
+        "id": "4516",
+        "name": "Battle Mage Danny of the Atheneum"
+    }, {
+        "id": "4561",
+        "name": "Magus Qianfan of the Atheneum"
+    }, {
+        "id": "4610",
+        "name": "Sorcerer Iprix of the Atheneum"
+    }, {
+        "id": "4727",
+        "name": "Magus Dutorn of the Atheneum"
+    }, {
+        "id": "4892",
+        "name": "Battle Mage Darick of the Atheneum"
+    }, {
+        "id": "5154",
+        "name": "Cosmic Mage Ifran of the Atheneum"
+    }, {
+        "id": "5161",
+        "name": "Archmagus Finch of the Atheneum"
+    }, {
+        "id": "5587",
+        "name": "Sage Edge of the Atheneum"
+    }, {
+        "id": "5752",
+        "name": "Salvatore of the Atheneum"
+    }, {
+        "id": "5789",
+        "name": "Archmagus David of the Atheneum"
+    }, {
+        "id": "5950",
+        "name": "Alchemist Bolin of the Atheneum"
+    }, {
+        "id": "5959",
+        "name": "Witch Ursula of the Atheneum"
+    }, {
+        "id": "5966",
+        "name": "Shaman Idris of the Atheneum"
+    }, {
+        "id": "6036",
+        "name": "Alchemist Vossler of the Atheneum"
+    }, {
+        "id": "6110",
+        "name": "Illusionist Udor of the Atheneum"
+    }, {
+        "id": "6242",
+        "name": "Electromancer Ixar of the Atheneum"
+    }, {
+        "id": "6290",
+        "name": "Sage Zorko of the Atheneum"
+    }, {
+        "id": "6304",
+        "name": "Alchemist Lumos of the Atheneum"
+    }, {
+        "id": "6408",
+        "name": "Void Disciple Aiko of the Atheneum"
+    }, {
+        "id": "6418",
+        "name": "Aeromancer Orpheus of the Atheneum"
+    }, {
+        "id": "6558",
+        "name": "Enchanter Talon of the Atheneum"
+    }, {
+        "id": "6640",
+        "name": "Archmagus Ozohr of the Atheneum"
+    }, {
+        "id": "6695",
+        "name": "Enchanter Devon of the Atheneum"
+    }, {
+        "id": "6840",
+        "name": "Witch Zolona of the Atheneum"
+    }, {
+        "id": "6957",
+        "name": "Geomancer Damien of the Atheneum"
+    }, {
+        "id": "6998",
+        "name": "Sage Jahid of the Atheneum"
+    }, {
+        "id": "7057",
+        "name": "of the Atheneum"
+    }, {
+        "id": "7196",
+        "name": "Aeromancer Casper of the Atheneum"
+    }, {
+        "id": "7405",
+        "name": "Sage Wolfram of the Atheneum"
+    }, {
+        "id": "7475",
+        "name": "Alchemist Salah of the Atheneum"
+    }, {
+        "id": "7553",
+        "name": "Battle Mage Bartholomew of the Atheneum"
+    }, {
+        "id": "8098",
+        "name": "Magus Ifran of the Atheneum"
+    }, {
+        "id": "8270",
+        "name": "Spellsinger Calista of the Atheneum"
+    }, {
+        "id": "8279",
+        "name": "Mystic Elena of the Atheneum"
+    }, {
+        "id": "8449",
+        "name": "Arcanist Magnus of the Atheneum"
+    }, {
+        "id": "8496",
+        "name": "Fortune Teller Angus of the Atheneum"
+    }, {
+        "id": "8588",
+        "name": "Alchemist Merlon of the Atheneum"
+    }, {
+        "id": "9180",
+        "name": "Magus Jerret of the Atheneum"
+    }, {
+        "id": "9200",
+        "name": "Battle Mage Thor of the Atheneum"
+    }, {
+        "id": "9464",
+        "name": "Alchemist Atlanta of the Atheneum"
+    }, {
+        "id": "9809",
+        "name": "Charmer Arabella of the Atheneum"
+    }, {
+        "id": "9951",
+        "name": "Arcanist George of the Atheneum"
+    }],
+    "Xanadu": [{
+        "id": "356",
+        "name": "Hedge Wizard Dante of Xanadu"
+    }, {
+        "id": "448",
+        "name": "Witch Basil of Xanadu"
+    }, {
+        "id": "575",
+        "name": "Archmagus Basil of Xanadu"
+    }, {
+        "id": "610",
+        "name": "Arcanist Rodolfo of Xanadu"
+    }, {
+        "id": "674",
+        "name": "Necromancer Moloch of Xanadu"
+    }, {
+        "id": "761",
+        "name": "Artificer David of Xanadu"
+    }, {
+        "id": "807",
+        "name": "Battle Mage Ratko of Xanadu"
+    }, {
+        "id": "812",
+        "name": "Magus Jahid of Xanadu"
+    }, {
+        "id": "878",
+        "name": "Alchemist Moka of Xanadu"
+    }, {
+        "id": "938",
+        "name": "Conjurer Eliphas of Xanadu"
+    }, {
+        "id": "1201",
+        "name": "Druid Ozohr of Xanadu"
+    }, {
+        "id": "1210",
+        "name": "Spellsinger Jasper of Xanadu"
+    }, {
+        "id": "1225",
+        "name": "Void Disciple Zane of Xanadu"
+    }, {
+        "id": "1290",
+        "name": "Alchemist Soran of Xanadu"
+    }, {
+        "id": "1775",
+        "name": "Diabolist Bartholomew of Xanadu"
+    }, {
+        "id": "1815",
+        "name": "Archmagus Orpheus of Xanadu"
+    }, {
+        "id": "1945",
+        "name": "Mystic Silas of Xanadu"
+    }, {
+        "id": "2484",
+        "name": "Archmagus Soran of Xanadu"
+    }, {
+        "id": "2503",
+        "name": "Hedge Wizard Devon of Xanadu"
+    }, {
+        "id": "2620",
+        "name": "Artificer Apollo of Xanadu"
+    }, {
+        "id": "2851",
+        "name": "Ghost Eater Aleister of Xanadu"
+    }, {
+        "id": "2930",
+        "name": "Soran of Xanadu"
+    }, {
+        "id": "2953",
+        "name": "Druid Hu of Xanadu"
+    }, {
+        "id": "3095",
+        "name": "Battle Mage Ulysse of Xanadu"
+    }, {
+        "id": "3104",
+        "name": "Cosmic Mage George of Xanadu"
+    }, {
+        "id": "3122",
+        "name": "Magus Dr. Death of Xanadu"
+    }, {
+        "id": "3205",
+        "name": "Artificer Trollin of Xanadu"
+    }, {
+        "id": "3268",
+        "name": "Bard Hishoken of Xanadu"
+    }, {
+        "id": "3296",
+        "name": "Sage Alatar of Xanadu"
+    }, {
+        "id": "3384",
+        "name": "Adept Soran of Xanadu"
+    }, {
+        "id": "3535",
+        "name": "Necromancer Aamon of Xanadu"
+    }, {
+        "id": "3562",
+        "name": "Artificer Corky of Xanadu"
+    }, {
+        "id": "3616",
+        "name": "Ghost Eater Aleister of Xanadu"
+    }, {
+        "id": "3783",
+        "name": "Medium Allistair of Xanadu"
+    }, {
+        "id": "3862",
+        "name": "Cryptomancer David of Xanadu"
+    }, {
+        "id": "4201",
+        "name": "Arch-Magician Ramiz of Xanadu"
+    }, {
+        "id": "4205",
+        "name": "Celah of Xanadu"
+    }, {
+        "id": "4215",
+        "name": "Artificer Crowley of Xanadu"
+    }, {
+        "id": "4523",
+        "name": "Hydromancer Bogey of Xanadu"
+    }, {
+        "id": "4540",
+        "name": "Magus Jabir of Xanadu"
+    }, {
+        "id": "4568",
+        "name": "Arch-Magician Baptiste of Xanadu"
+    }, {
+        "id": "4649",
+        "name": "Sage Ulysse of Xanadu"
+    }, {
+        "id": "4689",
+        "name": "David of Xanadu"
+    }, {
+        "id": "4707",
+        "name": "Druid Rumpleskin of Xanadu"
+    }, {
+        "id": "4776",
+        "name": "Shaman Taqi of Xanadu"
+    }, {
+        "id": "4846",
+        "name": "Sorcerer Ofaris of Xanadu"
+    }, {
+        "id": "5130",
+        "name": "Diabolist Shivra of Xanadu"
+    }, {
+        "id": "5375",
+        "name": "Archmagus Milton of Xanadu"
+    }, {
+        "id": "5456",
+        "name": "Enchanter Amir of Xanadu"
+    }, {
+        "id": "5480",
+        "name": "Cryptomancer Rodolfo of Xanadu"
+    }, {
+        "id": "5533",
+        "name": "Archmagus Basil of Xanadu"
+    }, {
+        "id": "5887",
+        "name": "Witch Sylvia of Xanadu"
+    }, {
+        "id": "6087",
+        "name": "Udor of Xanadu"
+    }, {
+        "id": "6155",
+        "name": "Archmagus Pumlo of Xanadu"
+    }, {
+        "id": "6195",
+        "name": "Magus Zafar of Xanadu"
+    }, {
+        "id": "6222",
+        "name": "Sorcerer Celah of Xanadu"
+    }, {
+        "id": "6429",
+        "name": "Pyromancer Asmodeus of Xanadu"
+    }, {
+        "id": "6742",
+        "name": "Sorcerer Sahir of Xanadu"
+    }, {
+        "id": "7301",
+        "name": "Artificer Nicolas of Xanadu"
+    }, {
+        "id": "7440",
+        "name": "Shaman Crowley of Xanadu"
+    }, {
+        "id": "7465",
+        "name": "Battlemage Angus of Xanadu"
+    }, {
+        "id": "7490",
+        "name": "Archmagus Orpheus of Xanadu"
+    }, {
+        "id": "7504",
+        "name": "Mystic Silas of Xanadu"
+    }, {
+        "id": "7633",
+        "name": "Adept Jaffer of Xanadu"
+    }, {
+        "id": "7808",
+        "name": "Archmagus Milo of Xanadu"
+    }, {
+        "id": "7817",
+        "name": "Sage Casper of Xanadu"
+    }, {
+        "id": "7847",
+        "name": "Artificer Apollo of Xanadu"
+    }, {
+        "id": "8452",
+        "name": "Battle Mage Rodolfo of Xanadu"
+    }, {
+        "id": "8665",
+        "name": "Shaman Milo of Xanadu"
+    }, {
+        "id": "8736",
+        "name": "Shadow Mage Azar of Xanadu"
+    }, {
+        "id": "8983",
+        "name": "Hedge Wizard Ratko of Xanadu"
+    }, {
+        "id": "9162",
+        "name": "Chronomancer Ozohr of Xanadu"
+    }, {
+        "id": "9168",
+        "name": "Enchanter Daria of Xanadu"
+    }, {
+        "id": "9486",
+        "name": "Magus Esme of Xanadu"
+    }, {
+        "id": "9963",
+        "name": "Enchanter Cairon of Xanadu"
+    }],
+    "Thorn": [{
+        "id": "66",
+        "name": "Hedge Wizard Soya of the Thorn"
+    }, {
+        "id": "125",
+        "name": "Eden of the Thorn"
+    }, {
+        "id": "267",
+        "name": "Cryptomancer Lavinia of the Thorn"
+    }, {
+        "id": "702",
+        "name": "Geomancer Cosmo of the Thorn"
+    }, {
+        "id": "737",
+        "name": "Augurer Chromo of the Thorn"
+    }, {
+        "id": "799",
+        "name": "Arch-Magician Properpine of the Thorn"
+    }, {
+        "id": "838",
+        "name": "Artificer Salty of the Thorn"
+    }, {
+        "id": "1461",
+        "name": "Hedge Wizard Calliope of the Thorn"
+    }, {
+        "id": "1467",
+        "name": "Pyromancer Udor of the Thorn"
+    }, {
+        "id": "1686",
+        "name": "Artificer Benito of the Thorn"
+    }, {
+        "id": "1983",
+        "name": "Aldus of the Thorn"
+    }, {
+        "id": "2009",
+        "name": "Battle Mage Cromwell of the Thorn"
+    }, {
+        "id": "2135",
+        "name": "Sage Khudalf of the Thorn"
+    }, {
+        "id": "2342",
+        "name": "Magus Nassif of the Thorn"
+    }, {
+        "id": "2494",
+        "name": "Battle Mage Talon of the Thorn"
+    }, {
+        "id": "2500",
+        "name": "Enchanter Fark of the Thorn"
+    }, {
+        "id": "2710",
+        "name": "Alchemist Aleister of the Thorn"
+    }, {
+        "id": "2734",
+        "name": "Arch-Magician Finn of the Thorn"
+    }, {
+        "id": "2875",
+        "name": "Thaumaturge Akron of the Thorn"
+    }, {
+        "id": "2981",
+        "name": "Artificer Oberon of the Thorn"
+    }, {
+        "id": "3410",
+        "name": "Magus Jig of the Thorn"
+    }, {
+        "id": "3685",
+        "name": "Artificer Atlas of the Thorn"
+    }, {
+        "id": "4663",
+        "name": "Alchemist Actaeon of the Thorn"
+    }, {
+        "id": "5038",
+        "name": "Archmagus Zaros of the Thorn"
+    }, {
+        "id": "5172",
+        "name": "Magus Taqi of the Thorn"
+    }, {
+        "id": "5411",
+        "name": "Ghost Eater Devo of the Thorn"
+    }, {
+        "id": "5471",
+        "name": "Magus Merlon of the Thorn"
+    }, {
+        "id": "5517",
+        "name": "Archmagus Jeldor of the Thorn"
+    }, {
+        "id": "6217",
+        "name": "Arch-Magician Enzo of the Thorn"
+    }, {
+        "id": "6270",
+        "name": "Battlemage Zafar of the Thorn"
+    }, {
+        "id": "6347",
+        "name": "Enchanter Cybele of the Thorn"
+    }, {
+        "id": "6647",
+        "name": "Sky Master Hank of the Thorn"
+    }, {
+        "id": "6779",
+        "name": "Pyromancer Cassius of the Thorn"
+    }, {
+        "id": "6805",
+        "name": "Druid Jig of the Thorn"
+    }, {
+        "id": "7222",
+        "name": "Magus Wolfram of the Thorn"
+    }, {
+        "id": "7470",
+        "name": "Archmagus Edge of the Thorn"
+    }, {
+        "id": "8230",
+        "name": "Alchemist Jig of the Thorn"
+    }, {
+        "id": "8477",
+        "name": "Cosmic Mage Homer of the Thorn"
+    }, {
+        "id": "8651",
+        "name": "Casper of the Thorn"
+    }, {
+        "id": "9326",
+        "name": "Hedge Wizard Talon of the Thorn"
+    }, {
+        "id": "9435",
+        "name": "Sage Xiaosheng of the Thorn"
+    }, {
+        "id": "9494",
+        "name": "Archmagus Evangeline of the Thorn"
+    }, {
+        "id": "9654",
+        "name": "Soran of the Thorn"
+    }],
+    "Heath": [{
+        "id": "67",
+        "name": "Apollo of the Heath"
+    }, {
+        "id": "206",
+        "name": "Cosmic Mage Bathsheba of the Heath"
+    }, {
+        "id": "226",
+        "name": "Conjurer Zhan of the Heath"
+    }, {
+        "id": "269",
+        "name": "Necromancer Norix of the Heath"
+    }, {
+        "id": "487",
+        "name": "Shaman Daphne of the Heath"
+    }, {
+        "id": "592",
+        "name": "Geomancer Herne of the Heath"
+    }, {
+        "id": "714",
+        "name": "Scryer Isaac of the Heath"
+    }, {
+        "id": "749",
+        "name": "Magus George of the Heath"
+    }, {
+        "id": "769",
+        "name": "Faye of the Heath"
+    }, {
+        "id": "886",
+        "name": "Archmagus Aldo of the Heath"
+    }, {
+        "id": "912",
+        "name": "Charmer Circe of the Heath"
+    }, {
+        "id": "989",
+        "name": "Shaman Malcom of the Heath"
+    }, {
+        "id": "1032",
+        "name": "Evoker Kalo of the Heath"
+    }, {
+        "id": "1056",
+        "name": "Mystic Merlon of the Heath"
+    }, {
+        "id": "1181",
+        "name": "Hedge Wizard Mycho of the Heath"
+    }, {
+        "id": "1342",
+        "name": "Witch Elena of the Heath"
+    }, {
+        "id": "1504",
+        "name": "Void Disciple Abbadon of the Heath"
+    }, {
+        "id": "1594",
+        "name": "Archmagus Hadrien of the Heath"
+    }, {
+        "id": "1685",
+        "name": "Magus Galatea of the Heath"
+    }, {
+        "id": "1691",
+        "name": "Faye of the Heath"
+    }, {
+        "id": "1695",
+        "name": "Arcanist Shi of the Heath"
+    }, {
+        "id": "1766",
+        "name": "Mystic Uday of the Heath"
+    }, {
+        "id": "1779",
+        "name": "Pyromancer Alatar of the Heath"
+    }, {
+        "id": "1886",
+        "name": "Battle Mage Bartholomew of the Heath"
+    }, {
+        "id": "1929",
+        "name": "Archmagus Zane of the Heath"
+    }, {
+        "id": "1931",
+        "name": "Hedge Wizard Asphodel of the Heath"
+    }, {
+        "id": "2243",
+        "name": "Shaman Sylvia of the Heath"
+    }, {
+        "id": "2406",
+        "name": "Sage Shigenjo of the Heath"
+    }, {
+        "id": "2462",
+        "name": "Mystic Poppy of the Heath"
+    }, {
+        "id": "2562",
+        "name": "Hedge Wizard Astrid of the Heath"
+    }, {
+        "id": "2593",
+        "name": "Battle Mage Nolan of the Heath"
+    }, {
+        "id": "2596",
+        "name": "Sorcerer Goober of the Heath"
+    }, {
+        "id": "2605",
+        "name": "Jadis of the Heath"
+    }, {
+        "id": "2784",
+        "name": "Alchemist Asmodeus of the Heath"
+    }, {
+        "id": "2795",
+        "name": "Artificer Angus of the Heath"
+    }, {
+        "id": "2855",
+        "name": "Geomancer Bartholomew of the Heath"
+    }, {
+        "id": "3028",
+        "name": "Druid Qasim of the Heath"
+    }, {
+        "id": "3098",
+        "name": "Witch Sylvia of the Heath"
+    }, {
+        "id": "3179",
+        "name": "Shaman Cullen of the Heath"
+    }, {
+        "id": "3396",
+        "name": "Hex Mage Tundror of the Heath"
+    }, {
+        "id": "3401",
+        "name": "Battle Mage Durm of the Heath"
+    }, {
+        "id": "3433",
+        "name": "Magus Wolfram of the Heath"
+    }, {
+        "id": "3442",
+        "name": "Hydromancer Gaspard of the Heath"
+    }, {
+        "id": "3508",
+        "name": "Magus Alizam of the Heath"
+    }, {
+        "id": "3606",
+        "name": "Victoria of the Heath"
+    }, {
+        "id": "3695",
+        "name": "Conjurer Yookoo of the Heath"
+    }, {
+        "id": "3764",
+        "name": "Enchanter Galatea of the Heath"
+    }, {
+        "id": "3921",
+        "name": "Battle Mage Robert of the Heath"
+    }, {
+        "id": "3950",
+        "name": "Shaman Luther of the Heath"
+    }, {
+        "id": "3980",
+        "name": "Spellsinger Galatea of the Heath"
+    }, {
+        "id": "4105",
+        "name": "Battle Mage Samuel of the Heath"
+    }, {
+        "id": "4112",
+        "name": "Arcanist Tengu of the Heath"
+    }, {
+        "id": "4144",
+        "name": "Alchemist Aleister of the Heath"
+    }, {
+        "id": "4156",
+        "name": "Conjurer Devon of the Heath"
+    }, {
+        "id": "4284",
+        "name": "Hedge Wizard Aslan of the Heath"
+    }, {
+        "id": "4290",
+        "name": "Witch Gwendolin of the Heath"
+    }, {
+        "id": "4352",
+        "name": "Enchanter Daria of the Heath"
+    }, {
+        "id": "4386",
+        "name": "Battle Mage Magnus of the Heath"
+    }, {
+        "id": "4445",
+        "name": "Pyromancer Daria of the Heath"
+    }, {
+        "id": "4473",
+        "name": "Pyromancer Calypso of the Heath"
+    }, {
+        "id": "4482",
+        "name": "Illusionist Ixar of the Heath"
+    }, {
+        "id": "4505",
+        "name": "Archmagus Allistair of the Heath"
+    }, {
+        "id": "4714",
+        "name": "Shaman Brown Cow of the Heath"
+    }, {
+        "id": "4751",
+        "name": "Hedge Wizard Milton of the Heath"
+    }, {
+        "id": "4763",
+        "name": "Conjurer Calliope of the Heath"
+    }, {
+        "id": "4775",
+        "name": "Archmagus Aldus of the Heath"
+    }, {
+        "id": "4882",
+        "name": "Witch Ophelia of the Heath"
+    }, {
+        "id": "4942",
+        "name": "Ghost Eater Calliope of the Heath"
+    }, {
+        "id": "4970",
+        "name": "Illusionist Calliope of the Heath"
+    }, {
+        "id": "4987",
+        "name": "Shaman Cassandra of the Heath"
+    }, {
+        "id": "5041",
+        "name": "Arch-Magician Merlon of the Heath"
+    }, {
+        "id": "5068",
+        "name": "Ghost Eater Zhan of the Heath"
+    }, {
+        "id": "5094",
+        "name": "Mystic Hagatha of the Heath"
+    }, {
+        "id": "5105",
+        "name": "Arch-Magician Sonja of the Heath"
+    }, {
+        "id": "5318",
+        "name": "Magus Milton of the Heath"
+    }, {
+        "id": "5487",
+        "name": "Witch Shivra of the Heath"
+    }, {
+        "id": "5590",
+        "name": "Alchemist Lavinia of the Heath"
+    }, {
+        "id": "5639",
+        "name": "Sorcerer Aleister of the Heath"
+    }, {
+        "id": "5707",
+        "name": "Diviner Luther of the Heath"
+    }, {
+        "id": "5716",
+        "name": "Artificer Robin of the Heath"
+    }, {
+        "id": "5734",
+        "name": "Cosmic Mage Daria of the Heath"
+    }, {
+        "id": "5771",
+        "name": "Pyromancer Salty of the Heath"
+    }, {
+        "id": "5774",
+        "name": "Layla of the Heath"
+    }, {
+        "id": "5858",
+        "name": "Hex Mage Celah of the Heath"
+    }, {
+        "id": "5878",
+        "name": "Archmagus Crobas of the Heath"
+    }, {
+        "id": "5928",
+        "name": "Druid Azahl of the Heath"
+    }, {
+        "id": "6091",
+        "name": "Druid Layla of the Heath"
+    }, {
+        "id": "6163",
+        "name": "Augurer Arabella of the Heath"
+    }, {
+        "id": "6310",
+        "name": "Arcanist Huizhong of the Heath"
+    }, {
+        "id": "6316",
+        "name": "Diviner Khudalf of the Heath"
+    }, {
+        "id": "6520",
+        "name": "Thaumaturge Jerret of the Heath"
+    }, {
+        "id": "6536",
+        "name": "Archmagus Embrose of the Heath"
+    }, {
+        "id": "6594",
+        "name": "Alchemist Fire Eater of the Heath"
+    }, {
+        "id": "6642",
+        "name": "Arch-Magician Thana of the Heath"
+    }, {
+        "id": "6645",
+        "name": "Archmagus Fark of the Heath"
+    }, {
+        "id": "6705",
+        "name": "Cleric Hagar of the Heath"
+    }, {
+        "id": "6735",
+        "name": "Chronomancer Finn of the Heath"
+    }, {
+        "id": "6766",
+        "name": "Artificer Caligula of the Heath"
+    }, {
+        "id": "6859",
+        "name": "Hedge Wizard Alizam of the Heath"
+    }, {
+        "id": "6904",
+        "name": "Alchemist Goomer of the Heath"
+    }, {
+        "id": "6922",
+        "name": "Cartomancer Aiko of the Heath"
+    }, {
+        "id": "7134",
+        "name": "Charmer Cassiopeia of the Heath"
+    }, {
+        "id": "7216",
+        "name": "Cleric George of the Heath"
+    }, {
+        "id": "7304",
+        "name": "Aeromancer Lin of the Heath"
+    }, {
+        "id": "7396",
+        "name": "Sorcerer Soya of the Heath"
+    }, {
+        "id": "7420",
+        "name": "Void Disciple Seth of the Heath"
+    }, {
+        "id": "7434",
+        "name": "Arch-Magician Ramiz of the Heath"
+    }, {
+        "id": "7437",
+        "name": "Arch-Magician Aleister of the Heath"
+    }, {
+        "id": "7514",
+        "name": "Cosmic Mage Diana of the Heath"
+    }, {
+        "id": "7518",
+        "name": "Diviner Finn of the Heath"
+    }, {
+        "id": "7645",
+        "name": "Arch-Magician Cybele of the Heath"
+    }, {
+        "id": "7646",
+        "name": "Charmer Daria of the Heath"
+    }, {
+        "id": "7660",
+        "name": "Enchanter Daria of the Heath"
+    }, {
+        "id": "7690",
+        "name": "Diabolist Pix of the Heath"
+    }, {
+        "id": "7879",
+        "name": "Wild Mage Eric of the Heath"
+    }, {
+        "id": "7910",
+        "name": "Battle Mage Cassius of the Heath"
+    }, {
+        "id": "7936",
+        "name": "Arch-Magician Nikolas of the Heath"
+    }, {
+        "id": "7942",
+        "name": "Shadow Mage Artis of the Heath"
+    }, {
+        "id": "8001",
+        "name": "Evoker Ofaris of the Heath"
+    }, {
+        "id": "8006",
+        "name": "Chaos Mage Milo of the Heath"
+    }, {
+        "id": "8061",
+        "name": "Chronomancer Pumlo of the Heath"
+    }, {
+        "id": "8157",
+        "name": "Arcanist Leah of the Heath"
+    }, {
+        "id": "8251",
+        "name": "Enchanter Faye of the Heath"
+    }, {
+        "id": "8344",
+        "name": "Enchanter Larissa of the Heath"
+    }, {
+        "id": "8499",
+        "name": "Enchanter Jadis of the Heath"
+    }, {
+        "id": "8586",
+        "name": "Artificer Onaxx of the Heath"
+    }, {
+        "id": "8599",
+        "name": "Battle Mage Thor of the Heath"
+    }, {
+        "id": "8602",
+        "name": "Magus Zorko of the Heath"
+    }, {
+        "id": "8659",
+        "name": "Shadow Mage Sabina of the Heath"
+    }, {
+        "id": "8834",
+        "name": "Hedge Wizard Eliphas of the Heath"
+    }, {
+        "id": "8952",
+        "name": "Shaman Magnus of the Heath"
+    }, {
+        "id": "8967",
+        "name": "Summoner Soya of the Heath"
+    }, {
+        "id": "8989",
+        "name": "Holy Monk Aldo of the Heath"
+    }, {
+        "id": "9002",
+        "name": "Archmagus Lumos of the Heath"
+    }, {
+        "id": "9023",
+        "name": "Druid Astrid of the Heath"
+    }, {
+        "id": "9028",
+        "name": "Battle Mage Nicolas of the Heath"
+    }, {
+        "id": "9034",
+        "name": "Enchanter Bathsheba of the Heath"
+    }, {
+        "id": "9060",
+        "name": "Battle Mage Godfrey of the Heath"
+    }, {
+        "id": "9130",
+        "name": "Shaman Ekmira of the Heath"
+    }, {
+        "id": "9134",
+        "name": "Archmagus Hadrien of the Heath"
+    }, {
+        "id": "9160",
+        "name": "Battle Mage Cromwell of the Heath"
+    }, {
+        "id": "9247",
+        "name": "Battle Mage Durm of the Heath"
+    }, {
+        "id": "9275",
+        "name": "Arch-Magician Ratko of the Heath"
+    }, {
+        "id": "9296",
+        "name": "Sorcerer Soran of the Heath"
+    }, {
+        "id": "9366",
+        "name": "Artificer Sondra of the Heath"
+    }, {
+        "id": "9460",
+        "name": "Hex Mage Sabina of the Heath"
+    }, {
+        "id": "9465",
+        "name": "Wild Mage Axel of the Heath"
+    }, {
+        "id": "9498",
+        "name": "Conjurer Eden of the Heath"
+    }, {
+        "id": "9510",
+        "name": "Archmagus Alatar of the Heath"
+    }, {
+        "id": "9524",
+        "name": "Titania of the Heath"
+    }, {
+        "id": "9623",
+        "name": "Witch Lavinia of the Heath"
+    }, {
+        "id": "9773",
+        "name": "Arcanist Homer of the Heath"
+    }, {
+        "id": "9783",
+        "name": "Archmagus Layla of the Heath"
+    }, {
+        "id": "9799",
+        "name": "Shaman Misumi of the Heath"
+    }, {
+        "id": "9920",
+        "name": "Hydromancer Yanlin of the Heath"
+    }, {
+        "id": "9945",
+        "name": "Alchemist Uvlius of the Heath"
+    }, {
+        "id": "9954",
+        "name": "Druid Mycho of the Heath"
+    }],
+    "Great Blue": [{
+        "id": "794",
+        "name": "Pyromancer Miyo of the Great Blue"
+    }, {
+        "id": "1672",
+        "name": "Alchemist David of the Great Blue"
+    }, {
+        "id": "1901",
+        "name": "Soran of the Great Blue"
+    }, {
+        "id": "2114",
+        "name": "Voodoo Priest Jaffer of the Great Blue"
+    }, {
+        "id": "2292",
+        "name": "Arch-Magician Otto of the Great Blue"
+    }, {
+        "id": "2928",
+        "name": "Evil Arcanist Faustus of the Great Blue"
+    }, {
+        "id": "4288",
+        "name": "Geomancer Aleister of the Great Blue"
+    }, {
+        "id": "4995",
+        "name": "Sorcerer Uday of the Great Blue"
+    }, {
+        "id": "7389",
+        "name": "Hydromancer Victoria of the Great Blue"
+    }, {
+        "id": "7441",
+        "name": "Hydromancer Danny of the Great Blue"
+    }, {
+        "id": "7811",
+        "name": "Bard Impy of the Great Blue"
+    }, {
+        "id": "8939",
+        "name": "Archmagus Aldo of the Great Blue"
+    }],
+    "Elysium": [{
+        "id": "62",
+        "name": "Hue of Elysium"
+    }, {
+        "id": "65",
+        "name": "Battle Mage Angus of Elysium"
+    }, {
+        "id": "105",
+        "name": "Shaman Ivy of Elysium"
+    }, {
+        "id": "134",
+        "name": "Necromancer Zeromus of Elysium"
+    }, {
+        "id": "140",
+        "name": "Shaman Angus of Elysium"
+    }, {
+        "id": "239",
+        "name": "Wild Mage Xiaobo of Elysium"
+    }, {
+        "id": "403",
+        "name": "Charmer Devon of Elysium"
+    }, {
+        "id": "490",
+        "name": "Sorcerer Zelroth of Elysium"
+    }, {
+        "id": "875",
+        "name": "Arch-Magician Epher of Elysium"
+    }, {
+        "id": "935",
+        "name": "Adept Nolan of Elysium"
+    }, {
+        "id": "1012",
+        "name": "Adept Solomon of Elysium"
+    }, {
+        "id": "1021",
+        "name": "Voodoo Priest Victor of Elysium"
+    }, {
+        "id": "1327",
+        "name": "Sorcerer Ofaris of Elysium"
+    }, {
+        "id": "1381",
+        "name": "Archmagus Milo of Elysium"
+    }, {
+        "id": "1423",
+        "name": "Archmagus Aldus of Elysium"
+    }, {
+        "id": "1621",
+        "name": "Archmagus Milton of Elysium"
+    }, {
+        "id": "1645",
+        "name": "Archmagus  of Elysium"
+    }, {
+        "id": "1745",
+        "name": "Arcanist Rainman of Elysium"
+    }, {
+        "id": "1828",
+        "name": "Enchanter Calliope of Elysium"
+    }, {
+        "id": "2033",
+        "name": "Diabolist Alizam of Elysium"
+    }, {
+        "id": "2082",
+        "name": "Sorcerer Nassif of Elysium"
+    }, {
+        "id": "2347",
+        "name": "Archmagus Solomon of Elysium"
+    }, {
+        "id": "2452",
+        "name": "Sorcerer Hadrien of Elysium"
+    }, {
+        "id": "2634",
+        "name": "Bard Zaros of Elysium"
+    }, {
+        "id": "2731",
+        "name": "Bard Borak of Elysium"
+    }, {
+        "id": "2878",
+        "name": "Magus Aden of Elysium"
+    }, {
+        "id": "3021",
+        "name": "Sage Cybele of Elysium"
+    }, {
+        "id": "3134",
+        "name": "Ghost Eater Soya of Elysium"
+    }, {
+        "id": "3181",
+        "name": "Adept Elizabeth of Elysium"
+    }, {
+        "id": "3355",
+        "name": "Sage Zane of Elysium"
+    }, {
+        "id": "3374",
+        "name": "Battle Mage Luther of Elysium"
+    }, {
+        "id": "3497",
+        "name": "Artificer Luther of Elysium"
+    }, {
+        "id": "3742",
+        "name": "Archmagus Iprix of Elysium"
+    }, {
+        "id": "3766",
+        "name": "Magus Cthulu of Elysium"
+    }, {
+        "id": "3772",
+        "name": "Artificer Rook of Elysium"
+    }, {
+        "id": "3836",
+        "name": "Witch Zolona of Elysium"
+    }, {
+        "id": "4191",
+        "name": "Chronomancer Soya of Elysium"
+    }, {
+        "id": "4344",
+        "name": "Battle Mage Otto of Elysium"
+    }, {
+        "id": "4402",
+        "name": "Aleister of Elysium"
+    }, {
+        "id": "4479",
+        "name": "Archmagus Soran of Elysium"
+    }, {
+        "id": "4558",
+        "name": "Druid Lux of Elysium"
+    }, {
+        "id": "4843",
+        "name": "Sorcerer Uday of Elysium"
+    }, {
+        "id": "4888",
+        "name": "Arch-Magician Finn of Elysium"
+    }, {
+        "id": "5039",
+        "name": "Enchanter Cassiopeia of Elysium"
+    }, {
+        "id": "5086",
+        "name": "Alchemist Quddus of Elysium"
+    }, {
+        "id": "5194",
+        "name": "Archmagus Rita of Elysium"
+    }, {
+        "id": "5267",
+        "name": "Charmer Beyna of Elysium"
+    }, {
+        "id": "5393",
+        "name": "Diviner Huan of Elysium"
+    }, {
+        "id": "5470",
+        "name": "Void Disciple Orbus of Elysium"
+    }, {
+        "id": "5474",
+        "name": "Alchemist Nicolas of Elysium"
+    }, {
+        "id": "5526",
+        "name": "Arcanist Patch of Elysium"
+    }, {
+        "id": "5565",
+        "name": "Magus Milton of Elysium"
+    }, {
+        "id": "5772",
+        "name": "Sage Udor of Elysium"
+    }, {
+        "id": "5897",
+        "name": "Circe of Elysium"
+    }, {
+        "id": "6230",
+        "name": "Archmagus Orpheus of Elysium"
+    }, {
+        "id": "6337",
+        "name": "Arch-Magician Eden of Elysium"
+    }, {
+        "id": "6386",
+        "name": "Cosmic Mage Zelroth of Elysium"
+    }, {
+        "id": "6601",
+        "name": "Evoker Zelroth of Elysium"
+    }, {
+        "id": "6606",
+        "name": "Summoner Gogol of Elysium"
+    }, {
+        "id": "6660",
+        "name": "Battle Mage Ratko of Elysium"
+    }, {
+        "id": "6661",
+        "name": "Archmagus Davos of Elysium"
+    }, {
+        "id": "6723",
+        "name": "Sorcerer Ofaris of Elysium"
+    }, {
+        "id": "6737",
+        "name": "Adept Ambrosia of Elysium"
+    }, {
+        "id": "6950",
+        "name": "Sorcerer Ixar of Elysium"
+    }, {
+        "id": "7212",
+        "name": "Hedge Wizard Samael of Elysium"
+    }, {
+        "id": "7427",
+        "name": "Evoker Nicolas of Elysium"
+    }, {
+        "id": "7537",
+        "name": "Adept Aleister of Elysium"
+    }, {
+        "id": "7606",
+        "name": "Enchanter Drusilla of Elysium"
+    }, {
+        "id": "7863",
+        "name": "Conjurer Zane of Elysium"
+    }, {
+        "id": "7938",
+        "name": "Magus Ramiz of Elysium"
+    }, {
+        "id": "8111",
+        "name": "Alchemist Konoha of Elysium"
+    }, {
+        "id": "8177",
+        "name": "Void Disciple Azazel of Elysium"
+    }, {
+        "id": "8385",
+        "name": "Magus Ixar of Elysium"
+    }, {
+        "id": "8394",
+        "name": "Witch Florah of Elysium"
+    }, {
+        "id": "8705",
+        "name": "Archmagus Hadrien of Elysium"
+    }, {
+        "id": "9047",
+        "name": "Runecaster Nadeem of Elysium"
+    }, {
+        "id": "9244",
+        "name": "Thaumaturge Aleister of Elysium"
+    }, {
+        "id": "9371",
+        "name": "Archmagus Eden of Elysium"
+    }, {
+        "id": "9389",
+        "name": "Archmagus Aden of Elysium"
+    }, {
+        "id": "9947",
+        "name": "Hex Mage Bayard of Elysium"
+    }],
+    "Boneyard": [{
+        "id": "3775",
+        "name": "Pyromancer Pezo of the Boneyard"
+    }],
+    "Wild": [{
+        "id": "4",
+        "name": "Hedge Wizard Chandler of the Wild"
+    }, {
+        "id": "58",
+        "name": "Magus Hestia of the Wild"
+    }, {
+        "id": "135",
+        "name": "Battle Mage Nicolas of the Wild"
+    }, {
+        "id": "171",
+        "name": "Conjurer Galatea of the Wild"
+    }, {
+        "id": "174",
+        "name": "Archmagus Aslan of the Wild"
+    }, {
+        "id": "270",
+        "name": "Sage Ixar of the Wild"
+    }, {
+        "id": "281",
+        "name": "Battle Mage Magnus of the Wild"
+    }, {
+        "id": "420",
+        "name": "Sorcerer Jahid of the Wild"
+    }, {
+        "id": "560",
+        "name": "Witch Rita of the Wild"
+    }, {
+        "id": "748",
+        "name": "Hedge Wizard Basil of the Wild"
+    }, {
+        "id": "796",
+        "name": "Charmer Daphne of the Wild"
+    }, {
+        "id": "951",
+        "name": "Archmagus Eden of the Wild"
+    }, {
+        "id": "1047",
+        "name": "Aleister of the Wild"
+    }, {
+        "id": "1095",
+        "name": "Hadrien of the Wild"
+    }, {
+        "id": "1137",
+        "name": "Archmagus Hothor of the Wild"
+    }, {
+        "id": "1203",
+        "name": "Witch Evangeline of the Wild"
+    }, {
+        "id": "1348",
+        "name": "Artificer Twinkletoes of the Wild"
+    }, {
+        "id": "1430",
+        "name": "Druid Apollo of the Wild"
+    }, {
+        "id": "1450",
+        "name": "Conjurer Atlas of the Wild"
+    }, {
+        "id": "1475",
+        "name": "Hedge Wizard Aleister of the Wild"
+    }, {
+        "id": "1607",
+        "name": "Alchemist Remus of the Wild"
+    }, {
+        "id": "1897",
+        "name": "Arcanist Larissa of the Wild"
+    }, {
+        "id": "1914",
+        "name": "Druid Bartholomew of the Wild"
+    }, {
+        "id": "2134",
+        "name": "Magus Allistair of the Wild"
+    }, {
+        "id": "2272",
+        "name": "Diabolist Zhan of the Wild"
+    }, {
+        "id": "2274",
+        "name": "Artificer Flynn of the Wild"
+    }, {
+        "id": "2357",
+        "name": "Magus Lilith of the Wild"
+    }, {
+        "id": "2405",
+        "name": "Enchanter Arabella of the Wild"
+    }, {
+        "id": "2411",
+        "name": "Witch Liliana of the Wild"
+    }, {
+        "id": "2526",
+        "name": "Illusionist  of the Wild"
+    }, {
+        "id": "2559",
+        "name": "Shaman Apollo of the Wild"
+    }, {
+        "id": "2606",
+        "name": "Archmagus Apollo of the Wild"
+    }, {
+        "id": "2619",
+        "name": "Summoner Tabitha of the Wild"
+    }, {
+        "id": "2654",
+        "name": "Fortune Teller Goliath of the Wild"
+    }, {
+        "id": "2726",
+        "name": "Azahl of the Wild"
+    }, {
+        "id": "2962",
+        "name": "Daria of the Wild"
+    }, {
+        "id": "3029",
+        "name": "Archmagus Milo of the Wild"
+    }, {
+        "id": "3059",
+        "name": "Battle Mage Tundror of the Wild"
+    }, {
+        "id": "3150",
+        "name": "Enchanter Devon of the Wild"
+    }, {
+        "id": "3169",
+        "name": "Charmer Diana of the Wild"
+    }, {
+        "id": "3415",
+        "name": "Battle Mage Blaise of the Wild"
+    }, {
+        "id": "3567",
+        "name": "Thana of the Wild"
+    }, {
+        "id": "3694",
+        "name": "Arabella of the Wild"
+    }, {
+        "id": "3726",
+        "name": "Summoner Willow of the Wild"
+    }, {
+        "id": "3843",
+        "name": "Alchemist George of the Wild"
+    }, {
+        "id": "3857",
+        "name": "Archmagus Zelroth of the Wild"
+    }, {
+        "id": "3860",
+        "name": "Archmagus Iprix of the Wild"
+    }, {
+        "id": "3960",
+        "name": "of the Wild"
+    }, {
+        "id": "3988",
+        "name": "Magus Faye of the Wild"
+    }, {
+        "id": "3991",
+        "name": "Magus Danny of the Wild"
+    }, {
+        "id": "4057",
+        "name": "Sage Brutus of the Wild"
+    }, {
+        "id": "4096",
+        "name": "Magus Uvlius of the Wild"
+    }, {
+        "id": "4136",
+        "name": "Charmer Faye of the Wild"
+    }, {
+        "id": "4227",
+        "name": "Sorcerer Aleister of the Wild"
+    }, {
+        "id": "4254",
+        "name": "Artificer Udor of the Wild"
+    }, {
+        "id": "4440",
+        "name": "Artis of the Wild"
+    }, {
+        "id": "4554",
+        "name": "Necromancer Diabolos of the Wild"
+    }, {
+        "id": "4725",
+        "name": "Archmagus Ozohr of the Wild"
+    }, {
+        "id": "4824",
+        "name": "Artificer Mycho of the Wild"
+    }, {
+        "id": "4943",
+        "name": "Mystic Faye of the Wild"
+    }, {
+        "id": "5026",
+        "name": "Arch-Magician Gary of the Wild"
+    }, {
+        "id": "5072",
+        "name": "Artificer Poppy of the Wild"
+    }, {
+        "id": "5132",
+        "name": "Cleric Moloch of the Wild"
+    }, {
+        "id": "5187",
+        "name": "Conjurer Jadis of the Wild"
+    }, {
+        "id": "5218",
+        "name": "Archmagus Ixar of the Wild"
+    }, {
+        "id": "5225",
+        "name": "Artificer Uvlius of the Wild"
+    }, {
+        "id": "5339",
+        "name": "Battle Mage Ethan of the Wild"
+    }, {
+        "id": "5403",
+        "name": "Witch Rowena of the Wild"
+    }, {
+        "id": "5476",
+        "name": "Sorcerer Davos of the Wild"
+    }, {
+        "id": "5535",
+        "name": "Artificer Fumiko of the Wild"
+    }, {
+        "id": "5675",
+        "name": "Chaos Mage Robert of the Wild"
+    }, {
+        "id": "5832",
+        "name": "Bard Zagan of the Wild"
+    }, {
+        "id": "5986",
+        "name": "Archmagus Merlon of the Wild"
+    }, {
+        "id": "6006",
+        "name": "Battle Mage Hagar of the Wild"
+    }, {
+        "id": "6064",
+        "name": "Enchanter Larissa of the Wild"
+    }, {
+        "id": "6196",
+        "name": "Archmagus Sondra of the Wild"
+    }, {
+        "id": "6198",
+        "name": "Sage Cassandra of the Wild"
+    }, {
+        "id": "6283",
+        "name": "Alchemist Delilah of the Wild"
+    }, {
+        "id": "6288",
+        "name": "Charmer Bathsheba of the Wild"
+    }, {
+        "id": "6377",
+        "name": "Witch Rowena of the Wild"
+    }, {
+        "id": "6477",
+        "name": "Arcanist Helix of the Wild"
+    }, {
+        "id": "6511",
+        "name": "Larissa of the Wild"
+    }, {
+        "id": "6624",
+        "name": "Sorcerer Jahid of the Wild"
+    }, {
+        "id": "6901",
+        "name": "Magus Ifran of the Wild"
+    }, {
+        "id": "6905",
+        "name": "Sorcerer Soya of the Wild"
+    }, {
+        "id": "6928",
+        "name": "Hedge Wizard Calliope of the Wild"
+    }, {
+        "id": "6949",
+        "name": "Crowley of the Wild"
+    }, {
+        "id": "7083",
+        "name": "Druid Hothor of the Wild"
+    }, {
+        "id": "7231",
+        "name": "Ghost Eater Atlanta of the Wild"
+    }, {
+        "id": "7257",
+        "name": "Geomancer Rowena of the Wild"
+    }, {
+        "id": "7379",
+        "name": "Sorcerer Jahid of the Wild"
+    }, {
+        "id": "7668",
+        "name": "Charmer Thana of the Wild"
+    }, {
+        "id": "7840",
+        "name": "Hedge Wizard Gary of the Wild"
+    }, {
+        "id": "7869",
+        "name": "Battle Mage Ethan of the Wild"
+    }, {
+        "id": "8004",
+        "name": "Runecaster Zaros of the Wild"
+    }, {
+        "id": "8035",
+        "name": "Sorcerer Faiz of the Wild"
+    }, {
+        "id": "8071",
+        "name": "Chaos Mage Amir of the Wild"
+    }, {
+        "id": "8119",
+        "name": "Enchanter Calliope of the Wild"
+    }, {
+        "id": "8208",
+        "name": "Alchemist Celeste of the Wild"
+    }, {
+        "id": "8243",
+        "name": "Necromancer Voidoth of the Wild"
+    }, {
+        "id": "8287",
+        "name": "Udor of the Wild"
+    }, {
+        "id": "8332",
+        "name": "Archmagus Gunthor of the Wild"
+    }, {
+        "id": "8408",
+        "name": "Archmagus Alatar of the Wild"
+    }, {
+        "id": "8475",
+        "name": "Mystic Casper of the Wild"
+    }, {
+        "id": "8476",
+        "name": "Alchemist Shivra of the Wild"
+    }, {
+        "id": "8629",
+        "name": "Cleric Izible of the Wild"
+    }, {
+        "id": "8685",
+        "name": "Arch-Magician Althea of the Wild"
+    }, {
+        "id": "8875",
+        "name": "Artificer Aleister of the Wild"
+    }, {
+        "id": "8896",
+        "name": "Battle Mage Angus of the Wild"
+    }, {
+        "id": "8899",
+        "name": "Archmagus Aldus of the Wild"
+    }, {
+        "id": "8947",
+        "name": "Charmer Sondra of the Wild"
+    }, {
+        "id": "8953",
+        "name": "Battle Mage Ethan of the Wild"
+    }, {
+        "id": "9100",
+        "name": "Druid Merlon of the Wild"
+    }, {
+        "id": "9109",
+        "name": "Sorcerer Qasim of the Wild"
+    }, {
+        "id": "9218",
+        "name": "Scryer Dante of the Wild"
+    }, {
+        "id": "9256",
+        "name": "Ghost Eater Gary of the Wild"
+    }, {
+        "id": "9270",
+        "name": "Witch Rowena of the Wild"
+    }, {
+        "id": "9368",
+        "name": "Arcanist  of the Wild"
+    }, {
+        "id": "9477",
+        "name": "Colormancer Roy G. Biv of the Wild"
+    }, {
+        "id": "9489",
+        "name": "Alchemist Althea of the Wild"
+    }, {
+        "id": "9777",
+        "name": "Archmagus Alessar of the Wild"
+    }, {
+        "id": "9844",
+        "name": "Pyromancer Cassandra of the Wild"
+    }],
+    "HyperLight": [{
+        "id": "9070",
+        "name": "Hedge Wizard Chooki of the HyperLight"
+    }],
+    "Cuckoo Land": [{
+        "id": "406",
+        "name": "Sorcerer Ilyas of Cuckoo Land"
+    }, {
+        "id": "618",
+        "name": "Witch Lucinda of Cuckoo Land"
+    }, {
+        "id": "636",
+        "name": "Ghost Eater Calypso of Cuckoo Land"
+    }, {
+        "id": "1078",
+        "name": "Archmagus Axel of Cuckoo Land"
+    }, {
+        "id": "1759",
+        "name": "Charmer Beyna of Cuckoo Land"
+    }, {
+        "id": "1777",
+        "name": "Ghost Eater Voidoth of Cuckoo Land"
+    }, {
+        "id": "1910",
+        "name": "Hedge Wizard Peter of Cuckoo Land"
+    }, {
+        "id": "2021",
+        "name": "Archmagus Sharx of Cuckoo Land"
+    }, {
+        "id": "2098",
+        "name": "Clairvoyant Soran of Cuckoo Land"
+    }, {
+        "id": "2531",
+        "name": "Battle Mage Homer of Cuckoo Land"
+    }, {
+        "id": "2585",
+        "name": "Magus Oiq of Cuckoo Land"
+    }, {
+        "id": "2767",
+        "name": "Shaman Aleister of Cuckoo Land"
+    }, {
+        "id": "2794",
+        "name": "Battle Mage Ratko of Cuckoo Land"
+    }, {
+        "id": "3219",
+        "name": "Battlemage Hagar of Cuckoo Land"
+    }, {
+        "id": "3719",
+        "name": "Diviner Meloogen of Cuckoo Land"
+    }, {
+        "id": "3959",
+        "name": "Geomancer  of Cuckoo Land"
+    }, {
+        "id": "5136",
+        "name": "Sorcerer Remus of Cuckoo Land"
+    }, {
+        "id": "5746",
+        "name": "Magus David of Cuckoo Land"
+    }, {
+        "id": "6620",
+        "name": "Hadrien of Cuckoo Land"
+    }, {
+        "id": "6856",
+        "name": "Illusionist Eggplant of Cuckoo Land"
+    }, {
+        "id": "7669",
+        "name": "Arch-Magician Milo of Cuckoo Land"
+    }, {
+        "id": "8120",
+        "name": "Archmagus Eizo of Cuckoo Land"
+    }, {
+        "id": "9572",
+        "name": "Geomancer Pino of Cuckoo Land"
+    }],
+    "Loch": [{
+        "id": "691",
+        "name": "Shadow Mage Darick of the Loch"
+    }, {
+        "id": "1031",
+        "name": "Hedge Wizard Goliath of the Loch"
+    }, {
+        "id": "1628",
+        "name": "Battle Mage Blaise of the Loch"
+    }, {
+        "id": "2147",
+        "name": "Sage Demos of the Loch"
+    }, {
+        "id": "2293",
+        "name": "Iprix of the Loch"
+    }, {
+        "id": "2521",
+        "name": "Battle Mage Rodolfo of the Loch"
+    }, {
+        "id": "3993",
+        "name": "Geomancer Liliana of the Loch"
+    }, {
+        "id": "4704",
+        "name": "Sorcerer Wazir of the Loch"
+    }, {
+        "id": "5237",
+        "name": "Hydromancer Fugh of the Loch"
+    }, {
+        "id": "5539",
+        "name": "Chaos Mage Azahl of the Loch"
+    }, {
+        "id": "6346",
+        "name": "Arcanist Amir of the Loch"
+    }, {
+        "id": "6692",
+        "name": "Enchanter Bogey of the Loch"
+    }, {
+        "id": "7378",
+        "name": "Charmer Cybele of the Loch"
+    }, {
+        "id": "8434",
+        "name": "Hydromancer Lux of the Loch"
+    }, {
+        "id": "9603",
+        "name": "Hydromancer Koop of the Loch"
+    }, {
+        "id": "9794",
+        "name": "Enchanter Cairon of the Loch"
+    }],
+    "Quantum Downs": [{
+        "id": "148",
+        "name": "Void Disciple Aamon of the Quantum Downs"
+    }, {
+        "id": "286",
+        "name": "Archmagus Amir of the Quantum Downs"
+    }, {
+        "id": "539",
+        "name": "Thaumaturge Goliath of the Quantum Downs"
+    }, {
+        "id": "1118",
+        "name": "Spellsinger Soya of the Quantum Downs"
+    }, {
+        "id": "1366",
+        "name": "Druid Aldus of the Quantum Downs"
+    }, {
+        "id": "1507",
+        "name": "Alchemist Celah of the Quantum Downs"
+    }, {
+        "id": "1984",
+        "name": "Archmagus Amir of the Quantum Downs"
+    }, {
+        "id": "2001",
+        "name": "Cassiopeia of the Quantum Downs"
+    }, {
+        "id": "2108",
+        "name": "Cryptomancer Rixxa of the Quantum Downs"
+    }, {
+        "id": "2215",
+        "name": "Chaos Mage Solomon of the Quantum Downs"
+    }, {
+        "id": "2305",
+        "name": "Enchanter Larissa of the Quantum Downs"
+    }, {
+        "id": "2343",
+        "name": "Hex Mage Zagan of the Quantum Downs"
+    }, {
+        "id": "2543",
+        "name": "Archmagus Celah of the Quantum Downs"
+    }, {
+        "id": "2742",
+        "name": "Cosmic Mage Aleister of the Quantum Downs"
+    }, {
+        "id": "2778",
+        "name": "Arch-Magician George of the Quantum Downs"
+    }, {
+        "id": "2829",
+        "name": "Sky Master Morfran of the Quantum Downs"
+    }, {
+        "id": "3109",
+        "name": "Magus Aden of the Quantum Downs"
+    }, {
+        "id": "3160",
+        "name": "Sorcerer Solomon of the Quantum Downs"
+    }, {
+        "id": "3357",
+        "name": "Sorcerer Ixar of the Quantum Downs"
+    }, {
+        "id": "3437",
+        "name": "Willow of the Quantum Downs"
+    }, {
+        "id": "3560",
+        "name": "Witch Ophelia of the Quantum Downs"
+    }, {
+        "id": "3702",
+        "name": "Magus Faiz of the Quantum Downs"
+    }, {
+        "id": "3787",
+        "name": "Magus Jerret of the Quantum Downs"
+    }, {
+        "id": "4089",
+        "name": "Pyromancer Lumos of the Quantum Downs"
+    }, {
+        "id": "4185",
+        "name": "Alchemist Sonja of the Quantum Downs"
+    }, {
+        "id": "4401",
+        "name": "Arch-Magician Aleister of the Quantum Downs"
+    }, {
+        "id": "4859",
+        "name": "Shadow Mage Iprix of the Quantum Downs"
+    }, {
+        "id": "4876",
+        "name": "Magus Faye of the Quantum Downs"
+    }, {
+        "id": "4887",
+        "name": "Alchemist Ofaris of the Quantum Downs"
+    }, {
+        "id": "5058",
+        "name": "Adept Apollo of the Quantum Downs"
+    }, {
+        "id": "5107",
+        "name": "Alchemist Shanyuan of the Quantum Downs"
+    }, {
+        "id": "5443",
+        "name": "Aeromancer Xue of the Quantum Downs"
+    }, {
+        "id": "5616",
+        "name": "Battle Mage Blaise of the Quantum Downs"
+    }, {
+        "id": "5643",
+        "name": "Adept Merlon of the Quantum Downs"
+    }, {
+        "id": "5685",
+        "name": "Arcanist Blaise of the Quantum Downs"
+    }, {
+        "id": "5691",
+        "name": "Hadrien of the Quantum Downs"
+    }, {
+        "id": "5721",
+        "name": "Alchemist Gary of the Quantum Downs"
+    }, {
+        "id": "5797",
+        "name": "Illusionist Suki of the Quantum Downs"
+    }, {
+        "id": "5900",
+        "name": "Pyromancer Jameel of the Quantum Downs"
+    }, {
+        "id": "5962",
+        "name": "Wild Mage Ixar of the Quantum Downs"
+    }, {
+        "id": "6001",
+        "name": "Magus Devon of the Quantum Downs"
+    }, {
+        "id": "6162",
+        "name": "Witch Lilith of the Quantum Downs"
+    }, {
+        "id": "6368",
+        "name": "Spellsinger Layla of the Quantum Downs"
+    }, {
+        "id": "6369",
+        "name": "Chronomancer Iprix of the Quantum Downs"
+    }, {
+        "id": "6832",
+        "name": "Arch-Magician Silas of the Quantum Downs"
+    }, {
+        "id": "7085",
+        "name": "Salvatore of the Quantum Downs"
+    }, {
+        "id": "7148",
+        "name": "Arcanist Crowley of the Quantum Downs"
+    }, {
+        "id": "7356",
+        "name": "Arch-Magician Oiq of the Quantum Downs"
+    }, {
+        "id": "7498",
+        "name": "Sorcerer Lumos of the Quantum Downs"
+    }, {
+        "id": "7564",
+        "name": "Holy Magus Ilu of the Quantum Downs"
+    }, {
+        "id": "7743",
+        "name": "Archmagus Lumos of the Quantum Downs"
+    }, {
+        "id": "7750",
+        "name": "Necromancer Liu of the Quantum Downs"
+    }, {
+        "id": "7813",
+        "name": "Hedge Wizard Solomon of the Quantum Downs"
+    }, {
+        "id": "8109",
+        "name": "Hedge Wizard Nicolas of the Quantum Downs"
+    }, {
+        "id": "8112",
+        "name": "Magus Suki of the Quantum Downs"
+    }, {
+        "id": "8149",
+        "name": "Enchanter Tengukensei of the Quantum Downs"
+    }, {
+        "id": "8151",
+        "name": "Ghost Eater Ixar of the Quantum Downs"
+    }, {
+        "id": "8190",
+        "name": "Holy Monk Mace of the Quantum Downs"
+    }, {
+        "id": "8401",
+        "name": "Archmagus Lumos of the Quantum Downs"
+    }, {
+        "id": "8484",
+        "name": "Druid Crowley of the Quantum Downs"
+    }, {
+        "id": "8582",
+        "name": "Magus Aldo of the Quantum Downs"
+    }, {
+        "id": "8758",
+        "name": "Archmagus Aleister of the Quantum Downs"
+    }, {
+        "id": "8802",
+        "name": "Adept Jezebel of the Quantum Downs"
+    }, {
+        "id": "8850",
+        "name": "Pyromancer Dutorn of the Quantum Downs"
+    }, {
+        "id": "8867",
+        "name": "Archmagus Crowley of the Quantum Downs"
+    }, {
+        "id": "9031",
+        "name": "Hedge Wizard Bolin of the Quantum Downs"
+    }, {
+        "id": "9309",
+        "name": "Atlanta of the Quantum Downs"
+    }, {
+        "id": "9330",
+        "name": "Merlon of the Quantum Downs"
+    }, {
+        "id": "9512",
+        "name": "Shaman Ramiz of the Quantum Downs"
+    }, {
+        "id": "9516",
+        "name": "Spellsinger Wazir of the Quantum Downs"
+    }, {
+        "id": "9667",
+        "name": "Shaman Danny of the Quantum Downs"
+    }, {
+        "id": "9759",
+        "name": "Druid Calliope of the Quantum Downs"
+    }],
+    "Morning Star": [{
+        "id": "293",
+        "name": "Battle Mage Dutorn of the Morning Star"
+    }, {
+        "id": "789",
+        "name": "Battlemage Kurama of the Morning Star"
+    }, {
+        "id": "1010",
+        "name": "Archmagus Soya of the Morning Star"
+    }, {
+        "id": "1050",
+        "name": "Archmagus Eden of the Morning Star"
+    }, {
+        "id": "1248",
+        "name": "Summoner Apollo of the Morning Star"
+    }, {
+        "id": "1593",
+        "name": "Archmagus Ratko of the Morning Star"
+    }, {
+        "id": "1707",
+        "name": "Battle Mage Brutus of the Morning Star"
+    }, {
+        "id": "1716",
+        "name": "Chaos Mage Tabitha of the Morning Star"
+    }, {
+        "id": "1739",
+        "name": "Artificer Beyna of the Morning Star"
+    }, {
+        "id": "1778",
+        "name": "Archmagus Soya of the Morning Star"
+    }, {
+        "id": "1800",
+        "name": "Pyromancer Alessar of the Morning Star"
+    }, {
+        "id": "2132",
+        "name": "Archmagus Aden of the Morning Star"
+    }, {
+        "id": "2907",
+        "name": "Shaman Jerret of the Morning Star"
+    }, {
+        "id": "3815",
+        "name": "Druid Ozohr of the Morning Star"
+    }, {
+        "id": "3865",
+        "name": "Sorcerer Iprix of the Morning Star"
+    }, {
+        "id": "3885",
+        "name": "Magus Gunthor of the Morning Star"
+    }, {
+        "id": "3926",
+        "name": "Conjurer Ratko of the Morning Star"
+    }, {
+        "id": "4099",
+        "name": "Shadow Mage Flamos of the Morning Star"
+    }, {
+        "id": "4270",
+        "name": "Sorcerer Basil of the Morning Star"
+    }, {
+        "id": "4413",
+        "name": "Artificer Soran of the Morning Star"
+    }, {
+        "id": "4472",
+        "name": "Udor of the Morning Star"
+    }, {
+        "id": "4520",
+        "name": "Chronomancer Oiq of the Morning Star"
+    }, {
+        "id": "4541",
+        "name": "Illusionist Corvin of the Morning Star"
+    }, {
+        "id": "4579",
+        "name": "Archmagus Basil of the Morning Star"
+    }, {
+        "id": "4933",
+        "name": "Battle Mage Goliath of the Morning Star"
+    }, {
+        "id": "4957",
+        "name": "Witch Hanataka of the Morning Star"
+    }, {
+        "id": "5147",
+        "name": "Enchanter Atlanta of the Morning Star"
+    }, {
+        "id": "5163",
+        "name": "Archmagus Calliope of the Morning Star"
+    }, {
+        "id": "5258",
+        "name": "Archmagus Orpheus of the Morning Star"
+    }, {
+        "id": "5329",
+        "name": "Alchemist Poppy of the Morning Star"
+    }, {
+        "id": "5381",
+        "name": "Sorcerer Nassif of the Morning Star"
+    }, {
+        "id": "5808",
+        "name": "Medium Taqi of the Morning Star"
+    }, {
+        "id": "5952",
+        "name": "Battlemage Angus of the Morning Star"
+    }, {
+        "id": "6077",
+        "name": "Sorcerer Milton of the Morning Star"
+    }, {
+        "id": "6491",
+        "name": "Sorcerer Aldus of the Morning Star"
+    }, {
+        "id": "6605",
+        "name": "Void Disciple Thoth of the Morning Star"
+    }, {
+        "id": "7080",
+        "name": "Battle Mage Rodolfo of the Morning Star"
+    }, {
+        "id": "7139",
+        "name": "Summoner Silas of the Morning Star"
+    }, {
+        "id": "7422",
+        "name": "Archmagus Zaros of the Morning Star"
+    }, {
+        "id": "7489",
+        "name": "Shadow Mage Alex of the Morning Star"
+    }, {
+        "id": "7597",
+        "name": "Scorch of the Morning Star"
+    }, {
+        "id": "7917",
+        "name": "Archmagus Blaise of the Morning Star"
+    }, {
+        "id": "8236",
+        "name": "Thaumaturge Wolfram of the Morning Star"
+    }, {
+        "id": "8310",
+        "name": "Battle Mage Eric of the Morning Star"
+    }, {
+        "id": "8509",
+        "name": "Witch Drusilla of the Morning Star"
+    }, {
+        "id": "8695",
+        "name": "Arcanist Vossler of the Morning Star"
+    }, {
+        "id": "8877",
+        "name": "Battle Mage Brutus of the Morning Star"
+    }, {
+        "id": "9233",
+        "name": "Shadow Mage Edge of the Morning Star"
+    }, {
+        "id": "9235",
+        "name": "Hedge Wizard Basil of the Morning Star"
+    }, {
+        "id": "9570",
+        "name": "Arch-Magician Ixar of the Morning Star"
+    }, {
+        "id": "9582",
+        "name": "Witch Elena of the Morning Star"
+    }, {
+        "id": "9895",
+        "name": "Necromancer Drusilla of the Morning Star"
+    }, {
+        "id": "9965",
+        "name": "Pyromancer Karasu of the Morning Star"
+    }],
+    "Bibliotheca": [{
+        "id": "353",
+        "name": "Battle Mage Bayard of the Bibliotheca"
+    }, {
+        "id": "432",
+        "name": "Sorcerer Alessar of the Bibliotheca"
+    }, {
+        "id": "454",
+        "name": "Archmagus Merlon of the Bibliotheca"
+    }, {
+        "id": "477",
+        "name": "Battle Mage Durm of the Bibliotheca"
+    }, {
+        "id": "504",
+        "name": "Magus Lumos of the Bibliotheca"
+    }, {
+        "id": "639",
+        "name": "Pyromancer Titania of the Bibliotheca"
+    }, {
+        "id": "677",
+        "name": "Illusionist Iprix of the Bibliotheca"
+    }, {
+        "id": "751",
+        "name": "Sky Master Magpie of the Bibliotheca"
+    }, {
+        "id": "853",
+        "name": "Sorcerer Quddus of the Bibliotheca"
+    }, {
+        "id": "1159",
+        "name": "Witch Rita of the Bibliotheca"
+    }, {
+        "id": "1648",
+        "name": "Battle Mage Magnus of the Bibliotheca"
+    }, {
+        "id": "1680",
+        "name": "Arch-Magician Aleister of the Bibliotheca"
+    }, {
+        "id": "1795",
+        "name": "Shaman Cromwell of the Bibliotheca"
+    }, {
+        "id": "1873",
+        "name": "Conjurer Merlon of the Bibliotheca"
+    }, {
+        "id": "1876",
+        "name": "Runecaster Izible of the Bibliotheca"
+    }, {
+        "id": "2364",
+        "name": "Bard Iprix of the Bibliotheca"
+    }, {
+        "id": "2383",
+        "name": "Archmagus Lux of the Bibliotheca"
+    }, {
+        "id": "2641",
+        "name": "Conjurer Bobbin of the Bibliotheca"
+    }, {
+        "id": "2894",
+        "name": "Sorcerer David of the Bibliotheca"
+    }, {
+        "id": "3053",
+        "name": "Sorcerer Lumos of the Bibliotheca"
+    }, {
+        "id": "3063",
+        "name": "Runecaster Udor of the Bibliotheca"
+    }, {
+        "id": "3117",
+        "name": "Alchemist Gary of the Bibliotheca"
+    }, {
+        "id": "3228",
+        "name": "Archmagus Solomon of the Bibliotheca"
+    }, {
+        "id": "3592",
+        "name": "Pyromancer Iris of the Bibliotheca"
+    }, {
+        "id": "3656",
+        "name": "Sage Milo of the Bibliotheca"
+    }, {
+        "id": "3720",
+        "name": "Sage Morrow of the Bibliotheca"
+    }, {
+        "id": "3794",
+        "name": "Enchanter Ramiz of the Bibliotheca"
+    }, {
+        "id": "4198",
+        "name": "Druid Brutus of the Bibliotheca"
+    }, {
+        "id": "4911",
+        "name": "Sage Rocco of the Bibliotheca"
+    }, {
+        "id": "5083",
+        "name": "Archmagus Azahl of the Bibliotheca"
+    }, {
+        "id": "5305",
+        "name": "Sorcerer Alizam of the Bibliotheca"
+    }, {
+        "id": "6128",
+        "name": "Sorcerer Orpheus of the Bibliotheca"
+    }, {
+        "id": "6786",
+        "name": "Druid Idris of the Bibliotheca"
+    }, {
+        "id": "7127",
+        "name": "Alchemist Bumble of the Bibliotheca"
+    }, {
+        "id": "7240",
+        "name": "Summoner Tengu of the Bibliotheca"
+    }, {
+        "id": "7402",
+        "name": "Battle Mage Magnus of the Bibliotheca"
+    }, {
+        "id": "7404",
+        "name": "Arch-Magician Gunthor of the Bibliotheca"
+    }, {
+        "id": "8218",
+        "name": "Druid Salty of the Bibliotheca"
+    }, {
+        "id": "8379",
+        "name": "Archmagus Ofaris of the Bibliotheca"
+    }, {
+        "id": "8480",
+        "name": "Alchemist Alessar of the Bibliotheca"
+    }, {
+        "id": "8618",
+        "name": "Mystic Crowley of the Bibliotheca"
+    }, {
+        "id": "8878",
+        "name": "Artificer Actaeon of the Bibliotheca"
+    }, {
+        "id": "9018",
+        "name": "Salvatore of the Bibliotheca"
+    }, {
+        "id": "9317",
+        "name": "Adept Trollin of the Bibliotheca"
+    }, {
+        "id": "9381",
+        "name": "Holy Monk Drokore of the Bibliotheca"
+    }, {
+        "id": "9467",
+        "name": "Battle Mage Talon of the Bibliotheca"
+    }, {
+        "id": "9587",
+        "name": "Adept Pan of the Bibliotheca"
+    }, {
+        "id": "9981",
+        "name": "Shaman Ekmira of the Bibliotheca"
+    }],
+    "Heavens": [{
+        "id": "0",
+        "name": "Holy Arcanist Illuminus of the Heavens"
+    }],
+    "Swell": [{
+        "id": "357",
+        "name": "Conjurer Nixie of the Swell"
+    }, {
+        "id": "360",
+        "name": "Hedge Wizard Jerret of the Swell"
+    }, {
+        "id": "676",
+        "name": "Pyromancer Flamos of the Swell"
+    }, {
+        "id": "767",
+        "name": "Hydromancer  of the Swell"
+    }, {
+        "id": "1135",
+        "name": "Wild Mage Kobold of the Swell"
+    }, {
+        "id": "1267",
+        "name": "Magus Ilyas of the Swell"
+    }, {
+        "id": "2692",
+        "name": "Oracle Astrid of the Swell"
+    }, {
+        "id": "2809",
+        "name": "Battle Mage Hagar of the Swell"
+    }, {
+        "id": "2854",
+        "name": "Archmagus Milton of the Swell"
+    }, {
+        "id": "3664",
+        "name": "Artificer Numpty of the Swell"
+    }, {
+        "id": "4555",
+        "name": "Wild Mage Cassandra of the Swell"
+    }, {
+        "id": "5337",
+        "name": "Aeromancer Silas of the Swell"
+    }, {
+        "id": "6105",
+        "name": "Archmagus Merlon of the Swell"
+    }, {
+        "id": "6565",
+        "name": "Archmagus Jerret of the Swell"
+    }, {
+        "id": "6593",
+        "name": "Magus Iprix of the Swell"
+    }, {
+        "id": "6675",
+        "name": "Battle Mage Nicolas of the Swell"
+    }, {
+        "id": "6898",
+        "name": "Chronomancer Ixar of the Swell"
+    }, {
+        "id": "7110",
+        "name": "Battlemage Voidoth of the Swell"
+    }, {
+        "id": "7114",
+        "name": "Mystic Juniper of the Swell"
+    }, {
+        "id": "7142",
+        "name": "Solomon of the Swell"
+    }, {
+        "id": "7496",
+        "name": "Battle Mage Atlas of the Swell"
+    }, {
+        "id": "7766",
+        "name": "Sorcerer Zafar of the Swell"
+    }, {
+        "id": "8107",
+        "name": "Void Disciple Seth of the Swell"
+    }, {
+        "id": "8345",
+        "name": "Archmagus Crobas of the Swell"
+    }, {
+        "id": "9762",
+        "name": "Sky Master Corvin of the Swell"
+    }]
+}


### PR DESCRIPTION
Very much a work in progress with questionable typescript, but this adds a rudimentary view of each wizard at a given location on the map:

<img width="1277" alt="Screen Shot 2021-07-29 at 12 03 51 AM" src="https://user-images.githubusercontent.com/1606986/127455464-8029ab67-43ae-40c9-93b7-097416502aa8.png">

TO-DO:

- Add cooler map marker icon (or remove altogether/make transparent and just allow users to click directly on the location?)
- Improve UI/layout for displaying wizards
- Combine data structures by including latitude and longitude values directly in the location JSON
- Fix TypeScript no-nos like using `any` everywhere
- Include wizard images directly in repo or at least lazy-load from IPFS (IPFS can't load so many wizard images at once, they're too powerful)