### PR TITLE
Link to map and gallery pages through router for preserving locale in the path

### DIFF
--- a/components/SiteNav.tsx
+++ b/components/SiteNav.tsx
@@ -162,10 +162,14 @@ export default function SiteNav({}: Props) {
           <a href="/lore">Lore</a>
         </li> */}
         <li className="item">
-          <a href="/map">Map</a>
+          <Link as={"/map"} href={"/map"} passHref={true}>
+            <a>Map</a>
+          </Link>
         </li>
         <li className="item">
-          <a href="/gallery">Gallery</a>
+          <Link as={"/gallery"} href={"/gallery"} passHref={true}>
+            <a>Gallery</a>
+          </Link>
         </li>
         {/* <li className="item">
           <a href="/blog">Blog</a>


### PR DESCRIPTION
Locale (e.g. `ja`) in the path is lost when 'Map' or 'Gallery" pages are accessed through the header.
In order to preserve the locale, this PR changes the link of the pages to use the router of Next.js.

