### PR TITLE
Fix the site crash issue by skipping router

### DIFF
--- a/components/SiteNav.tsx
+++ b/components/SiteNav.tsx
@@ -143,9 +143,7 @@ export default function SiteNav({}: Props) {
           <ResponsivePixelImg src="/static/img/forgotten-runes-logo.png" />
         </li>
         <li className="item">
-          <Link as={"/"} href={"/"} passHref={true}>
-            <a href="/">The Secret Tower</a>
-          </Link>
+          <a href="/">The Secret Tower</a>
         </li>
         <li className="item">
           <Link as={"/wtf"} href={"/wtf"} passHref={true}>


### PR DESCRIPTION
This PR is for fixing the issue #28 which is crashing the website. 

The root cause of the crash was the overwrite of the canvas element when "The secret tower" page is loaded multiple times without the full page refresh.
In order to avoid the error, we should skip the router of Next.js when redirecting the users to "The secret tower" page.
BTW, since the locale detection happens when the document root is accessed, this fix doesn't break the internationalization.

This is a bit hackie workaround, but it works. If you have a better idea in your mind, please feel free to reject this PR.