### PR TITLE
Prefetching new lore page after it was added

### DIFF
--- a/components/AddLore/addLoreHelpers.tsx
+++ b/components/AddLore/addLoreHelpers.tsx
@@ -410,7 +410,9 @@ export const getPendingLoreTxHashRedirection = async ({
 
     return {
       redirect: {
-        destination: getLoreUrl("wizards", parseInt(wizardId), pageNum),
+        destination: `/lore/add?lorePageToPrefetch=${
+          pageNum % 2 === 0 ? pageNum : pageNum + 1
+        }&wizardId=${wizardId}&client=true`,
       },
     };
   }


### PR DESCRIPTION
Due to how static generation and caching works with nextjs it is possible that you end up on a page that still says there is no lore after you have added it (since nextjs serves the currently cached page before statically regenerating a new version).

This attempts to fix that by using `router.prefetch` once we know what the page number will be (tx is available on the subgraph) and then waiting 5 seconds before redirecting there.