### PR TITLE
Fix for bad new line rendering and narrative -> wizard transition

### DIFF
--- a/components/Lore/IndividualLorePage.tsx
+++ b/components/Lore/IndividualLorePage.tsx
@@ -142,7 +142,8 @@ export default function IndividualLorePage({
             return uriTransformer(src);
           }}
         >
-          {story}
+          {/* Markdown needs two spaces before a \n for line break but our editor doesn't do this if you c/p content into it... */}
+          {story.replace(/[^\s]+\n/gi, "  \n")}
         </ReactMarkdown>
       )}
     </TextPage>

--- a/components/Lore/IndividualLorePage.tsx
+++ b/components/Lore/IndividualLorePage.tsx
@@ -143,7 +143,7 @@ export default function IndividualLorePage({
           }}
         >
           {/* Markdown needs two spaces before a \n for line break but our editor doesn't do this if you c/p content into it... */}
-          {story.replace(/[^\s]+\n/gi, "  \n")}
+          {story.replace(/([^\s]+)\n/gi, "$1  \n")}
         </ReactMarkdown>
       )}
     </TextPage>

--- a/components/Lore/loreSubgraphUtils.tsx
+++ b/components/Lore/loreSubgraphUtils.tsx
@@ -162,18 +162,8 @@ export async function getCurrentWizardData(
 }
 
 export async function getFirstAvailableWizardLoreUrl() {
-  const { data } = await client.query({
-    query: gql`
-        query WizardLore {
-            lores( first:1, orderBy: id, orderDirection: asc, where: {tokenContract: "${NORMALIZED_WIZARD_CONTRACT_ADDRESS}", struck: false, nsfw: false}) {
-                tokenId
-            }
-        }
-    `,
-    fetchPolicy: "no-cache",
-  });
-
-  return getLoreUrl("wizards", data?.lores?.[0]?.tokenId ?? 0, 0);
+  // We used to fetch this from subgraph but now we know wizard 0 always has lore so no need :)
+  return getLoreUrl("wizards", 0, 0);
 }
 
 export async function getPreAndNextPageRoutes(


### PR DESCRIPTION
* Narrative now direct links to wizard 0 as we know they have lore :) (no need for network requests)
* We replace bad new lines with proper new lines (happens if you c/p some content into Draft sigh)

_Note: we should probs do markdown hydration on the server in `getStatic` at some point, one for v2_