### PR TITLE
Fix for non-MetaMask wallet signing issues

### DIFF
--- a/components/AddLore/addLoreHelpers.tsx
+++ b/components/AddLore/addLoreHelpers.tsx
@@ -6,7 +6,6 @@ import parseDataUrl from "parse-data-url";
 import client from "../../lib/graphql";
 import { gql } from "@apollo/client";
 import { NORMALIZED_WIZARD_CONTRACT_ADDRESS } from "../Lore/loreSubgraphUtils";
-import { getLoreUrl } from "../Lore/loreUtils";
 import { NETWORK } from "../../constants";
 import replaceAsync from "string-replace-async";
 import axios from "axios";
@@ -176,7 +175,9 @@ export const onSubmitAddLoreForm = async ({
   try {
     // Note: we can't use signer.signMessage as it doesn't work consistently across wallets: https://github.com/ethers-io/ethers.js/issues/1840
     signature = await provider.send("personal_sign", [
-      ethers.utils.toUtf8Bytes(currentWizard.tokenId),
+      ethers.utils.hexlify(
+        ethers.utils.toUtf8Bytes(currentWizard.tokenId.toString())
+      ),
       (await signer.getAddress()).toLowerCase(),
     ]);
   } catch (err: any) {

--- a/components/AddLore/addLoreHelpers.tsx
+++ b/components/AddLore/addLoreHelpers.tsx
@@ -175,7 +175,7 @@ export const onSubmitAddLoreForm = async ({
   try {
     // signature = await signer.signMessage(parseInt(currentWizard.tokenId));
     // Note: we can't use signer.signMessage as it doesn't work consistently across wallets: https://github.com/ethers-io/ethers.js/issues/1840
-    await provider.send("personal_sign", [
+    signature = await provider.send("personal_sign", [
       parseInt(currentWizard.tokenId),
       (await signer.getAddress()).toLowerCase(),
     ]);

--- a/components/AddLore/addLoreHelpers.tsx
+++ b/components/AddLore/addLoreHelpers.tsx
@@ -173,7 +173,7 @@ export const onSubmitAddLoreForm = async ({
   let signature: string;
 
   try {
-    signature = await signer.signMessage(currentWizard.tokenId);
+    signature = await signer.signMessage(parseInt(currentWizard.tokenId));
   } catch (err: any) {
     console.log("err: ", err);
     toast.error(`Sorry, there was a problem when signing: ${err.message}`, {
@@ -221,15 +221,18 @@ export const onSubmitAddLoreForm = async ({
   } catch (err: any) {
     console.log("err: ", err);
     toast.dismiss();
-    toast.error(`Sorry, there was a problem when signing: ${err.message}`, {
-      position: "top-right",
-      autoClose: false,
-      hideProgressBar: false,
-      closeOnClick: true,
-      pauseOnHover: true,
-      draggable: false,
-      progress: undefined,
-    });
+    toast.error(
+      `Sorry, there was a problem when uploading images to IPFS: ${err.message}`,
+      {
+        position: "top-right",
+        autoClose: false,
+        hideProgressBar: false,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: false,
+        progress: undefined,
+      }
+    );
     setSubmitting(false);
     return false;
   }

--- a/components/AddLore/addLoreHelpers.tsx
+++ b/components/AddLore/addLoreHelpers.tsx
@@ -173,7 +173,12 @@ export const onSubmitAddLoreForm = async ({
   let signature: string;
 
   try {
-    signature = await signer.signMessage(parseInt(currentWizard.tokenId));
+    // signature = await signer.signMessage(parseInt(currentWizard.tokenId));
+    // Note: we can't use signer.signMessage as it doesn't work consistently across wallets: https://github.com/ethers-io/ethers.js/issues/1840
+    await provider.send("personal_sign", [
+      parseInt(currentWizard.tokenId),
+      (await signer.getAddress()).toLowerCase(),
+    ]);
   } catch (err: any) {
     console.log("err: ", err);
     toast.error(`Sorry, there was a problem when signing: ${err.message}`, {

--- a/components/AddLore/addLoreHelpers.tsx
+++ b/components/AddLore/addLoreHelpers.tsx
@@ -11,6 +11,7 @@ import { NETWORK } from "../../constants";
 import replaceAsync from "string-replace-async";
 import axios from "axios";
 import { Flex } from "rebass";
+import { ethers } from "ethers";
 
 export const pinFileToIPFS = async (
   base64string: string,
@@ -173,10 +174,9 @@ export const onSubmitAddLoreForm = async ({
   let signature: string;
 
   try {
-    // signature = await signer.signMessage(parseInt(currentWizard.tokenId));
     // Note: we can't use signer.signMessage as it doesn't work consistently across wallets: https://github.com/ethers-io/ethers.js/issues/1840
     signature = await provider.send("personal_sign", [
-      parseInt(currentWizard.tokenId),
+      ethers.utils.toUtf8Bytes(currentWizard.tokenId),
       (await signer.getAddress()).toLowerCase(),
     ]);
   } catch (err: any) {

--- a/pages/api/lore.ts
+++ b/pages/api/lore.ts
@@ -36,7 +36,9 @@ export default async function handler(
   );
 
   const wizardContract = getWizardsContract({ provider: getProvider(true) });
-  const wizardOwner = await wizardContract.ownerOf(req.body.wizard_id);
+  const wizardOwner = await wizardContract.ownerOf(
+    parseInt(req.body.wizard_id)
+  );
 
   if (wizardOwner !== signingAddress) {
     console.error(

--- a/pages/api/lore.ts
+++ b/pages/api/lore.ts
@@ -3,9 +3,6 @@ import pinataSDK from "@pinata/sdk";
 import { utils } from "ethers";
 import { getProvider } from "../../hooks/useProvider";
 import { getWizardsContract } from "../../contracts/ForgottenRunesWizardsCultContract";
-import replaceAsync from "string-replace-async";
-import fs from "fs";
-import * as os from "os";
 
 const pinata = pinataSDK(
   process.env.PINATA_ID || "",
@@ -21,13 +18,17 @@ export default async function handler(
   }
 
   if (!req.body?.signature || !req.body?.wizard_id) {
+    console.error(
+      `No signature ${req.body?.signature} or wizard_id ${req.body?.wizard_id}`
+    );
     return res.status(400).json({
       error:
         "You must supply both a signature and a wizard id that was signed...",
     });
   }
 
-  // console.log("signature", req.body.signature);
+  console.log("Signature:", req.body.signature);
+  console.log("Wizard ID:", req.body.wizard_id);
 
   const signingAddress = await utils.verifyMessage(
     req.body.wizard_id,
@@ -38,7 +39,8 @@ export default async function handler(
   const wizardOwner = await wizardContract.ownerOf(req.body.wizard_id);
 
   if (wizardOwner !== signingAddress) {
-    return res.status(400).json({
+    console.log("Wizard is not owner");
+    return res.status(403).json({
       error: `Address ${signingAddress} does not own wizard ${req.body.wizard_id}, ${wizardOwner} does instead.`,
     });
   }

--- a/pages/api/lore.ts
+++ b/pages/api/lore.ts
@@ -40,7 +40,7 @@ export default async function handler(
     parseInt(req.body.wizard_id)
   );
 
-  if (wizardOwner !== signingAddress) {
+  if (wizardOwner.toLowerCase() !== signingAddress.toLowerCase()) {
     console.error(
       `Wizard signature address ${signingAddress} is not owner ${wizardOwner}`
     );

--- a/pages/api/lore.ts
+++ b/pages/api/lore.ts
@@ -1,8 +1,9 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import pinataSDK from "@pinata/sdk";
-import { utils } from "ethers";
+import { ethers, utils } from "ethers";
 import { getProvider } from "../../hooks/useProvider";
 import { getWizardsContract } from "../../contracts/ForgottenRunesWizardsCultContract";
+import { recoverAddress } from "@ethersproject/transactions/src.ts/index";
 
 const pinata = pinataSDK(
   process.env.PINATA_ID || "",
@@ -31,14 +32,12 @@ export default async function handler(
   console.log("Wizard ID:", req.body.wizard_id);
 
   const signingAddress = await utils.verifyMessage(
-    req.body.wizard_id,
+    req.body.wizard_id.toString(),
     req.body.signature
   );
 
   const wizardContract = getWizardsContract({ provider: getProvider(true) });
-  const wizardOwner = await wizardContract.ownerOf(
-    parseInt(req.body.wizard_id)
-  );
+  const wizardOwner = await wizardContract.ownerOf(req.body.wizard_id);
 
   if (wizardOwner.toLowerCase() !== signingAddress.toLowerCase()) {
     console.error(

--- a/pages/api/lore.ts
+++ b/pages/api/lore.ts
@@ -1,9 +1,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import pinataSDK from "@pinata/sdk";
-import { ethers, utils } from "ethers";
+import { utils } from "ethers";
 import { getProvider } from "../../hooks/useProvider";
 import { getWizardsContract } from "../../contracts/ForgottenRunesWizardsCultContract";
-import { recoverAddress } from "@ethersproject/transactions/src.ts/index";
 
 const pinata = pinataSDK(
   process.env.PINATA_ID || "",

--- a/pages/api/lore.ts
+++ b/pages/api/lore.ts
@@ -39,7 +39,9 @@ export default async function handler(
   const wizardOwner = await wizardContract.ownerOf(req.body.wizard_id);
 
   if (wizardOwner !== signingAddress) {
-    console.log("Wizard is not owner");
+    console.error(
+      `Wizard signature address ${signingAddress} is not owner ${wizardOwner}`
+    );
     return res.status(403).json({
       error: `Address ${signingAddress} does not own wizard ${req.body.wizard_id}, ${wizardOwner} does instead.`,
     });


### PR DESCRIPTION
Some providers (like Coinbase Wallet) end up using a different method when signing in etherjs (`eth_sign` vs. `personal_sign`)

This ensures we always consistently use `personal_sign` no matter the provider.

I tested on MetaMask and CB Wallet and they both work.