### PR TITLE
Using first image from lore (if any) for og image

### DIFF
--- a/components/Lore/markdownUtils.tsx
+++ b/components/Lore/markdownUtils.tsx
@@ -31,8 +31,18 @@ export async function hydratePageDataFromMetadata(
 ): Promise<IndividualLorePageData> {
   const metadata = await fetchLoreMetadata(loreMetadataURI);
 
+  // We use first image for og metadata, and yes regex not the coolest method but it works :)
+  let firstImage = metadata?.description?.match(
+    /!\[(?:.*?)\]\((ipfs.*?)\)/im
+  )?.[1];
+
+  if (firstImage) {
+    firstImage = firstImage.replace(/^ipfs:\/\//, `${IPFS_SERVER}/`);
+  }
+
   // result.data
   return {
+    firstImage: firstImage ?? null,
     isEmpty: false,
     bgColor: metadata?.background_color ?? "#000000",
     title: metadata?.name ?? "Untitled",

--- a/components/Lore/types.tsx
+++ b/components/Lore/types.tsx
@@ -27,6 +27,7 @@ export type Lore = {
 export type LorePage = {};
 
 export type IndividualLorePageData = {
+  firstImage: string | null;
   bgColor?: string;
   isEmpty: boolean;
   title?: string;

--- a/components/OgImage.tsx
+++ b/components/OgImage.tsx
@@ -3,30 +3,41 @@ import { isNumber } from "lodash";
 
 import Head from "next/head";
 
-const ogImageBaseURL = `https://og.forgottenrunes.com/`;
+const ogImageBaseURL =
+  process.env.NEXT_PUBLIC_OG_IMAGE_BASE ?? `https://og.forgottenrunes.com/`;
 
 type Props = {
   wizard?: string | number;
   fontSize?: string;
   title: string;
-  images?: string;
+  images?: string | null;
+  bgColor?: string;
 };
 
 // https://og.forgottenrunes.com/6001.png?wizard=6001&fontSize=128px
-export default function OgImage({ title, fontSize, wizard, images }: Props) {
+export default function OgImage({
+  title,
+  fontSize,
+  wizard,
+  images,
+  bgColor,
+}: Props) {
   const filename = encodeURIComponent(title);
   let params: any = {};
   if (fontSize) {
     params.fontSize = fontSize;
   }
-  if (isNumber(wizard)) {
+  if (isNumber(wizard) && !images) {
     params.wizard = wizard;
   }
   if (images) {
     params.images = images;
   }
+  if (bgColor) {
+    params.bgColor = bgColor;
+  }
   const queryString = Object.keys(params)
-    .map((key) => key + "=" + params[key])
+    .map((key) => key + "=" + encodeURIComponent(params[key]))
     .join("&");
   const ogImageUrl = [ogImageBaseURL, filename, ".png", "?", queryString].join(
     ""

--- a/pages/lore/[loreTokenSlug]/[tokenId]/[page].tsx
+++ b/pages/lore/[loreTokenSlug]/[tokenId]/[page].tsx
@@ -48,13 +48,23 @@ const LorePage = ({
   let title = "The Book of Lore";
 
   if (loreTokenSlug === "wizards") {
-    title = `The Lore of ${wizData[tokenId.toString()].name} #${tokenId})`;
+    title = `The Lore of ${wizData[tokenId.toString()].name} (#${tokenId})`;
   }
 
   const og = loreTokenSlug === "wizards" && (
     <OgImage
-      title={`The Lore of ${wizData[tokenId.toString()].name} #${tokenId})`}
+      title={`The Lore of ${wizData[tokenId.toString()].name} (#${tokenId})`}
       wizard={tokenId}
+      images={
+        lorePageData.leftPage?.firstImage ?? lorePageData.rightPage?.firstImage
+      }
+      bgColor={
+        lorePageData.leftPage?.firstImage
+          ? lorePageData.leftPage?.bgColor
+          : lorePageData.rightPage?.firstImage
+          ? lorePageData.rightPage?.bgColor
+          : undefined
+      }
     />
   );
 
@@ -222,6 +232,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     leftPage = {
       isEmpty: true,
       bgColor: `#${wizData[tokenId.toString()].background_color}`,
+      firstImage: null,
     };
   }
   leftPage.pageNumber = leftPageNum;
@@ -237,6 +248,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
     rightPage = {
       isEmpty: true,
       bgColor: "#000000",
+      firstImage: null,
     };
   }
 

--- a/pages/lore/add.tsx
+++ b/pages/lore/add.tsx
@@ -16,7 +16,6 @@ import BookFrame from "../../components/Lore/BookFrame";
 import { BookOfLorePage } from "../../components/Lore/IndividualLorePage";
 import StyledToastContainer from "../../components/StyledToastContainer";
 import productionWizardData from "../../data/nfts-prod.json";
-import { useDebounce } from "../../hooks";
 import { useMst } from "../../store";
 import {
   getPendingLoreTxHashRedirection,


### PR DESCRIPTION
Also passing the user chosen lore background for that page.

This works in conjunction with this PR: https://github.com/forgottenrunes/og-image/pull/2

Some examples:

![Screenshot 2021-09-28 at 11 12 12](https://user-images.githubusercontent.com/2362887/135070452-7202ad0c-0a13-49e0-adfd-5e7b65d692c3.png)

![Screenshot 2021-09-28 at 11 15 31](https://user-images.githubusercontent.com/2362887/135070489-f3b3bc9e-4392-4561-887a-2f7959341b3b.png)

![Screenshot 2021-09-28 at 11 36 03](https://user-images.githubusercontent.com/2362887/135072309-b75c979f-a89e-4152-9c3c-8008d5f586a5.png)

