### PR TITLE
Remove the index from the main listing page

### DIFF
--- a/pages/posts/index.tsx
+++ b/pages/posts/index.tsx
@@ -59,7 +59,7 @@ export default function Index({ posts }: { posts: Post[] }) {
             >
               <StyledAnchor>
                 <h2>
-                  {post.data.index}. {post.data.title}
+                  {post.data.title}
                 </h2>
                 {post.data.description && (
                   <Description>{post.data.description}</Description>


### PR DESCRIPTION
Based on the feedback in the previous PR #121 , this PR is removing the index from the main listing page